### PR TITLE
api/setup: force NFSv3+TCP on archive-test probe

### DIFF
--- a/crates/api/src/setup.rs
+++ b/crates/api/src/setup.rs
@@ -393,7 +393,7 @@ pub async fn test_archive(
             let _ = std::fs::create_dir_all(tmp_dir);
             let src = format!("{}:{}", server, export);
             let res = sentryusb_shell::run_with_timeout(
-                timeout, "mount", &["-t", "nfs", &src, tmp_dir, "-o", "nolock,soft,timeo=50"],
+                timeout, "mount", &["-t", "nfs", &src, tmp_dir, "-o", "nolock,soft,timeo=50,proto=tcp,vers=3"],
             ).await;
             if res.is_ok() {
                 let _ = sentryusb_shell::run_with_timeout(


### PR DESCRIPTION
## Summary

The wizard's **Test Archive** button mounts the configured NFS share via `crates/api/src/setup.rs::test_archive` to validate connectivity before completing setup. The current options are `nolock,soft,timeo=50` — no `vers=` and no `proto=`, leaving version/protocol up to the kernel NFS client's auto-negotiation. The runtime mount (the fstab line written by the setup runner) uses `rw,noauto,nolock,proto=tcp,vers=3`. **What the wizard tests is not what production mounts.**

This PR appends `proto=tcp,vers=3` so the probe and the runtime mount use the same NFS version and transport.

```diff
- "mount", &["-t", "nfs", &src, tmp_dir, "-o", "nolock,soft,timeo=50"]
+ "mount", &["-t", "nfs", &src, tmp_dir, "-o", "nolock,soft,timeo=50,proto=tcp,vers=3"]
```

`soft,timeo=50` are kept — this is a probe, not the runtime mount, and we want fast-fail behavior.

## Why this matters even though current Linux defaults usually pick v3

I verified against a Unifi UNAS Pro running current firmware that **both option sets succeed** today, because Linux 6.12 / nfs-utils 2.x happens to negotiate `vers=3,proto=tcp` even without explicit options. So the probe is "lucky" rather than correct.

Reasons to make it explicit anyway:

1. **Probe ≡ runtime parity.** The whole point of the probe is to predict whether the runtime mount will succeed. The two should use the same options.
2. **Defensive against client drift.** Linux NFS client defaults have changed across kernel versions (NFSv4 was the default for years; v3 came back as preferred on some distros). Don't bet on it.
3. **Cross-NAS compatibility.** TeslaUSB's `nfs-support` branch has the same options for the same reason — Scott's own comment in `run/nfs_archive/verify-and-configure-archive.sh` says *"Forced vers=3 for wider NAS compatibility (Unifi, Synology, etc)."*
4. **Originally a real failure.** The bug was first observed with a different kernel/firmware combination where the probe failed against a UNAS Pro that the runtime mount handled fine.

## Test plan

- [x] Mount with NEW options against UNAS Pro NFS export — succeeds, mount shows `vers=3,mountvers=3,mountproto=tcp`
- [x] Mount with OLD options against same export — also succeeds today (auto-negotiates v3), confirming current behavior is preserved
- [x] Confirmed probe options now identical to fstab runtime mount written by the setup runner