### PR TITLE
run/nfs_archive: replace broken copy-music.sh stub with canonical impl

### DIFF
--- a/run/nfs_archive/copy-music.sh
+++ b/run/nfs_archive/copy-music.sh
@@ -1,6 +1,96 @@
 #!/bin/bash -eu
 
-ensure_music_file_is_mounted
-/root/bin/copy-music.sh
-trim_free_space "$MUSIC_MOUNT"
-unmount_music_file
+SRC="/mnt/musicarchive"
+DST="/mnt/music"
+LOG="/tmp/rsyncmusiclog.txt"
+
+# check that DST is the mounted disk image, not the mountpoint directory
+if ! findmnt --mountpoint $DST > /dev/null
+then
+  log "$DST not mounted, skipping music sync"
+  exit
+fi
+
+function connectionmonitor {
+  while true
+  do
+    for _ in {1..10}
+    do
+      if timeout 3 /root/bin/archive-is-reachable.sh "$ARCHIVE_SERVER"
+      then
+        # sleep and then continue outer loop
+        sleep 5
+        continue 2
+      fi
+      sleep 1
+    done
+    log "connection dead, killing copy-music"
+    # Give rsync a chance to clean up before killing it hard.
+    killall rsync || true
+    sleep 2
+    killall -9 rsync || true
+    kill -9 "$1" || true
+    return
+  done
+}
+
+function do_music_sync {
+  log "Syncing music from archive..."
+
+  # return immediately if the archive mount can't be accessed
+  if ! timeout 5 stat "$SRC" > /dev/null
+  then
+    log "Error: $SRC is not accessible"
+    return
+  fi
+
+  # check that SRC is the mounted NFS archive and not the empty mountpoint
+  # directory, since the latter would cause all music to be deleted from DST
+  if ! findmnt --mountpoint $SRC > /dev/null
+  then
+    log "Error: $SRC not mounted"
+    return
+  fi
+
+  connectionmonitor $$ &
+
+  if ! rsync -rum --no-human-readable --exclude=.fseventsd/*** --exclude=*.DS_Store --exclude=.metadata_never_index \
+                --exclude="System Volume Information/***" \
+                --delete --modify-window=2 --info=stats2 "$SRC/" "$DST" &> "$LOG"
+  then
+    log "rsync failed with error $?"
+  fi
+
+  # Stop the connection monitor.
+  kill %1 || true
+
+  # remove empty directories
+  find $DST -depth -type d -empty -delete || true
+
+  # parse log for relevant info
+  declare -i NUM_FILES_COPIED
+  NUM_FILES_COPIED=$(($(sed -n -e 's/\(^Number of regular files transferred: \)\([[:digit:]]\+\).*/\2/p' "$LOG")))
+  declare -i NUM_FILES_DELETED
+  NUM_FILES_DELETED=$(($(sed -n -e 's/\(^Number of deleted files: [[:digit:]]\+ (reg: \)\([[:digit:]]\+\)*.*/\2/p' "$LOG")))
+  declare -i TOTAL_FILES
+  TOTAL_FILES=$(sed -n -e 's/\(^Number of files: [[:digit:]]\+ (reg: \)\([[:digit:]]\+\)*.*/\2/p' "$LOG")
+  declare -i NUM_FILES_ERROR
+  NUM_FILES_ERROR=$(($(grep -c "failed to open" $LOG || true)))
+
+  declare -i NUM_FILES_SKIPPED=$((TOTAL_FILES-NUM_FILES_COPIED))
+  NUM_FILES_COPIED=$((NUM_FILES_COPIED-NUM_FILES_ERROR))
+
+  local message="Copied $NUM_FILES_COPIED music file(s), deleted $NUM_FILES_DELETED, skipped $NUM_FILES_SKIPPED previously-copied files, and encountered $NUM_FILES_ERROR errors."
+
+  if [ $NUM_FILES_COPIED -ne 0 ] || [ $NUM_FILES_DELETED -ne 0 ] || [ $NUM_FILES_ERROR -ne 0 ]
+  then
+    /root/bin/send-push-message "$NOTIFICATION_TITLE:" "$message" "" music_sync
+  else
+    log "$message"
+  fi
+}
+
+if ! do_music_sync
+then
+  log "Error while syncing music"
+fi


### PR DESCRIPTION
## Summary

`run/nfs_archive/copy-music.sh` ships as a **5-line stub** that dies immediately under `bash -eu`:

```bash
#!/bin/bash -eu
ensure_music_file_is_mounted   # undefined in this subprocess
/root/bin/copy-music.sh        # recurses into itself
trim_free_space "$MUSIC_MOUNT" # undefined
unmount_music_file             # undefined
```

The three function names (`ensure_music_file_is_mounted`, `trim_free_space`, `unmount_music_file`) are defined **inside archiveloop**, around lines 412/440 of `run/run/archiveloop`. So this script is actually the *body* of archiveloop's `copy_music_files()` wrapper function (line ~933) that got accidentally checked in as the standalone script file. When archiveloop calls `/root/bin/copy-music.sh` as a subprocess, none of those functions are visible — it dies on line 3 with `command not found`, archiveloop logs `ERROR: copy_music_files failed (exit 127)`, and **music sync silently never runs on any NFS install**.

The sibling `run/cifs_archive/copy-music.sh` and `run/rsync_archive/copy-music.sh` both ship the correct 96-line implementation: mount checks, connection monitor (kills rsync if NFS server goes away), rsync with **exFAT-safe `-rum` flags** instead of `-a` (no chown failures on the FAT-family destination), stats parsing, and push notification on completion.

This PR replaces the NFS stub with a **byte-equivalent of the CIFS sibling** — the only change is one comment swap (`the mounted cifs archive` → `the mounted NFS archive`). All SRC/DST paths are already filesystem-agnostic; the script just rsyncs from one mounted directory to another, and `connect-archive.sh` (NFS-aware via fstab) handles the mount of `/mnt/musicarchive` before this script is called.

## Local validation on Pi 4 / Sentry-USB-Rusty v2.6.6

Deployed this exact file as `/root/bin/copy-music.sh` on a fresh install, triggered the archive cycle via `force_sync.sh`, watched `/mutable/archiveloop.log` live:

```
19:19:34  Ensured music drive is mounted.
19:19:34  Syncing music from archive...          ← canonical script start
19:19:57  Copied 0 music file(s), deleted 0,
          skipped 6966 previously-copied files,
          and encountered 0 errors.              ← canonical script end
19:19:57  Trimming free space in /mnt/music...   ← archiveloop wrapper
19:19:58  Unmounted /mnt/music.                  ← archiveloop wrapper
19:19:58  Finished copying music.                ← archiveloop success log
```

- **23 seconds total**, exit 0
- archiveloop's `if copy_music_files` condition passes cleanly (no error log)
- Real source: a Unifi UNAS Pro NFS share with 6,966 (post-exclude) music files / 34 GB
- Before this fix, the same setup logged `ensure_music_file_is_mounted: command not found` and the music sync step silently no-op'd every cycle

## Test plan

- [x] Standalone invocation: source `/root/sentryusb.conf`, define minimal `log()` shim, run `/root/bin/copy-music.sh` → exits 0, rsync stats line emitted
- [x] Live archiveloop integration: triggered `force_sync.sh`, observed `Syncing music from archive...` → `Copied N... encountered 0 errors.` → `Finished copying music.` in `/mutable/archiveloop.log`
- [x] exFAT compatibility: 0 chown failures (confirms `-rum` flag choice over `-a`)
- [x] No spurious deletes: rsync source excludes (`.DS_Store`, `.fseventsd`, `System Volume Information`, `.metadata_never_index`) correctly **kept** at destination instead of wiped (no `--delete-excluded`)

## Known follow-up (not in scope of this PR)

The CIFS sibling has a subtle log-only bug that this byte-port inherits:

```bash
if ! rsync ... ; then
  log "rsync failed with error $?"   # $? is the inverted condition (always 0)
fi
```

The `rsync_archive` sibling already fixes this with `set +e; rsync ...; RSYNC_EXIT=$?; set -e`. Worth a separate PR to align all three archive variants. Out of scope here because (a) this PR's job is to replace the broken stub with a known-working sibling, and (b) the rsync_archive improvement is independent of the NFS-vs-CIFS distinction.