### PR TITLE
setup/archive: write fstab entry for MUSIC_SHARE_NAME on NFS installs

### DIFF
--- a/crates/setup/src/archive.rs
+++ b/crates/setup/src/archive.rs
@@ -535,6 +535,27 @@ async fn configure_nfs_mount(env: &SetupEnv, emitter: &SetupEmitter) -> Result<(
     );
     replace_fstab_entry("nfs", "/mnt/archive", &line)?;
     emitter.progress("Added NFS mount to /etc/fstab");
+
+    // Optional music share. archiveloop's `connect-archive.sh` mounts
+    // `/mnt/musicarchive` from this fstab entry, and `copy-music.sh`
+    // then rsyncs from there into the loop-mounted music_disk.bin.
+    // `ro` because we only ever read this share — matches the bash
+    // `verify-and-configure-archive.sh` that handles the conf-file
+    // flow, where the music line is also written read-only.
+    // Without this block, conf-file installs that set MUSIC_SHARE_NAME
+    // end up with archiveloop retrying the mount 10× per cycle and
+    // giving up ("mount: /mnt/musicarchive: can't find in /etc/fstab"),
+    // so music sync silently never runs.
+    let music_share = env.get("MUSIC_SHARE_NAME", "");
+    if !music_share.is_empty() {
+        std::fs::create_dir_all("/mnt/musicarchive").context("mkdir /mnt/musicarchive")?;
+        let music_line = format!(
+            "{}:{} /mnt/musicarchive nfs ro,noauto,nolock,proto=tcp,vers=3 0 0",
+            server, music_share
+        );
+        replace_fstab_entry("nfs", "/mnt/musicarchive", &music_line)?;
+        emitter.progress("Added NFS music mount to /etc/fstab");
+    }
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

`configure_nfs_mount` in `crates/setup/src/archive.rs` only handles the **cam** share (`SHARE_NAME`). It never inspects `MUSIC_SHARE_NAME`, so no fstab entry is ever emitted for `/mnt/musicarchive`. When archiveloop's `connect-archive.sh` later runs `ensure_mountpoint_is_mounted /mnt/musicarchive`, it retries 10× per cycle and gives up with `mount: /mnt/musicarchive: can't find in /etc/fstab`. Music sync (`/root/bin/copy-music.sh`) is gated on that mount succeeding, so it **silently never runs** on any NFS install that sets `MUSIC_SHARE_NAME` (i.e., basically anyone syncing music from a NAS).

The bash `run/nfs_archive/verify-and-configure-archive.sh` that ships for the conf-file flow already has the right branch:

```bash
if [ -n "${MUSIC_SHARE_NAME:+x}" ]; then
  mkdir -p "$music_archive_path"
  echo "$ARCHIVE_SERVER:$MUSIC_SHARE_NAME $music_archive_path nfs ro,noauto,nolock,proto=tcp,vers=3 0 0" >> /etc/fstab
fi
```

But the Rust setup runner doesn't call that script — it writes fstab itself in `configure_nfs_mount`, and only handles `SHARE_NAME`. This PR mirrors the bash branch right after the cam fstab write: same `vers=3,proto=tcp,nolock` options (with `ro` instead of `rw` because we only ever read the music share), same mountpoint convention (`/mnt/musicarchive`), same `replace_fstab_entry("nfs", ...)` helper that handles the cam line. The block is gated on `MUSIC_SHARE_NAME` being non-empty, so installs that don't sync music are unaffected.

## Diff

```diff
     replace_fstab_entry("nfs", "/mnt/archive", &line)?;
     emitter.progress("Added NFS mount to /etc/fstab");
+
+    // Optional music share. archiveloop's `connect-archive.sh` mounts
+    // `/mnt/musicarchive` from this fstab entry, and `copy-music.sh`
+    // then rsyncs from there into the loop-mounted music_disk.bin.
+    // `ro` because we only ever read this share ...
+    let music_share = env.get("MUSIC_SHARE_NAME", "");
+    if !music_share.is_empty() {
+        std::fs::create_dir_all("/mnt/musicarchive").context("mkdir /mnt/musicarchive")?;
+        let music_line = format!(
+            "{}:{} /mnt/musicarchive nfs ro,noauto,nolock,proto=tcp,vers=3 0 0",
+            server, music_share
+        );
+        replace_fstab_entry("nfs", "/mnt/musicarchive", &music_line)?;
+        emitter.progress("Added NFS music mount to /etc/fstab");
+    }
     Ok(())
 }
```

## Verification on Pi 4 / Sentry-USB-Rusty v2.6.6

**Reproduced the bug live** in `/mutable/archiveloop.log`:

```
mount: /mnt/musicarchive: can't find in /etc/fstab.
Failed to mount /mnt/musicarchive.
Sleeping before retry ...
[... 10 retries ...]
Attempts exhausted.
ERROR: connect-archive.sh failed (exit 0), skipping archive step.
```

Then added the *exact* fstab line this PR emits, manually, to validate the runtime behavior:

```
192.168.103.250:/volume/.../TeslaMusic/.data /mnt/musicarchive nfs ro,noauto,nolock,proto=tcp,vers=3 0 0
```

Triggered `force_sync.sh` and observed clean music sync via archiveloop end-to-end (also documented in #3):

```
Ensured music drive is mounted.
Syncing music from archive...
Copied 0 music file(s), deleted 0, skipped 6966 previously-copied files,
  and encountered 0 errors.
Trimming free space in /mnt/music, which has 34 extents
Unmounted /mnt/music.
Finished copying music.
```

The fstab line this PR emits is the exact line that makes the runtime work. **Pairs with #3** (broken `copy-music.sh` stub) to fully unblock NFS music sync — without both, the music feature is a no-op on every NFS install regardless of conf settings.

## Test plan

- [x] Bug reproduces without the patch (archiveloop log captures `can't find in /etc/fstab` × 10)
- [x] Adding the equivalent fstab line manually unblocks music sync end-to-end (live archiveloop validation in #3)
- [x] `MUSIC_SHARE_NAME` empty case → block is a no-op (gated on `!is_empty()`)
- [ ] Cross-compile + full setup-from-wizard run on a fresh image, confirming the fstab line lands automatically without the manual step (would require rebuilding the binary; out of scope for this PR but worth doing pre-release)

## Notes on what's intentionally not in this PR

- **CIFS music mount.** `configure_cifs_mount` similarly only handles `SHARE_NAME`. Symmetric fix possible but out of scope here — Tesla USB users overwhelmingly do NFS for music, and the CIFS case has no validated workaround in this session to base the fix on. Worth a follow-up.
- **Music-only NFS install.** The early `return Ok(())` when `share.is_empty()` still triggers if a user somehow sets only `MUSIC_SHARE_NAME`. That's the existing behavior (unchanged). Refactoring the early-return to allow music-only would be a behavior change, not a bug fix.