### PR TITLE
fix(api/status): 250x faster /api/status — fix autofs storm + skip queries on DOWN interfaces

### DIFF
--- a/crates/api/src/status.rs
+++ b/crates/api/src/status.rs
@@ -149,9 +149,10 @@ pub async fn get_status(
         }
     }
 
-    // WiFi info
+    // WiFi info — skip shell queries when interface is down (saves 5-10s
+    // on ethernet-only systems where wlan0 exists but is unconfigured)
     let wifi_dev = find_net_device("wl*");
-    if !wifi_dev.is_empty() {
+    if !wifi_dev.is_empty() && iface_is_up(&wifi_dev) {
         if let Ok(out) = sentryusb_shell::run("iwgetid", &["-r", &wifi_dev]).await {
             s.wifi_ssid = out.trim().to_string();
         }
@@ -182,12 +183,12 @@ pub async fn get_status(
         s.wifi_tx_bps = tx;
     }
 
-    // Ethernet info
+    // Ethernet info — same operstate guard
     let mut eth_dev = find_net_device("eth*");
     if eth_dev.is_empty() {
         eth_dev = find_net_device("en*");
     }
-    if !eth_dev.is_empty() {
+    if !eth_dev.is_empty() && iface_is_up(&eth_dev) {
         if let Ok(out) = sentryusb_shell::run("ip", &["-4", "addr", "show", &eth_dev]).await {
             for line in out.lines() {
                 let trimmed = line.trim();
@@ -483,6 +484,21 @@ fn find_net_device(pattern: &str) -> String {
         }
     }
     String::new()
+}
+
+/// Returns true when the kernel reports the interface in `operstate == "up"`.
+///
+/// We use this to gate the shell queries below: `iwgetid`/`iwconfig`/`ip` can
+/// each block for several seconds when an interface is present-but-DOWN
+/// (e.g. `wlan0` exists but no NetworkManager / no Skip-WiFi configured),
+/// adding up to 5-15s on `GET /api/status`. Companion apps that probe this
+/// endpoint with a short HTTP timeout then fall back to BLE-only mode even
+/// though the Pi is reachable over ethernet.
+fn iface_is_up(dev: &str) -> bool {
+    let path = format!("/sys/class/net/{}/operstate", dev);
+    std::fs::read_to_string(&path)
+        .map(|s| s.trim() == "up")
+        .unwrap_or(false)
 }
 
 fn disk_usage(path: &str) -> i64 {

--- a/crates/api/src/status.rs
+++ b/crates/api/src/status.rs
@@ -399,37 +399,46 @@ pub async fn get_wifi_config(
 // Helpers
 // ---------------------------------------------------------------------------
 
+/// List snapshot backing files at the top of `/backingfiles/snapshots/`.
+///
+/// The previous implementation called a generic recursive `walkdir` and
+/// filtered for paths ending in `snap.bin`. That descended through every
+/// snapshot's `mnt -> /tmp/snapshots/snap-NNN` symlink, which is backed by
+/// an autofs mount (timeout=300s) that re-mounts the per-snapshot vfat loop
+/// device on first access. Each fresh /api/status call after the autofs
+/// timeout therefore triggered up to 130 vfat mounts *and* walked the
+/// entire dashcam tree inside each one — observed 15,000+ openat syscalls
+/// per request and 5-15s TTFB.
+///
+/// Snapshots always have `snap.bin` directly at the top level
+/// (`/backingfiles/snapshots/snap-NNNNNN/snap.bin`). We only need to scan
+/// that one directory level — no recursion, no symlink follow.
 fn find_snapshots() -> Vec<String> {
     let mut snaps = Vec::new();
     let base = std::path::Path::new("/backingfiles/snapshots/");
-    if base.exists() {
-        if let Ok(entries) = walkdir(base) {
-            for path in entries {
-                if path.ends_with("snap.bin") {
-                    snaps.push(path);
-                }
+    let Ok(entries) = std::fs::read_dir(base) else {
+        return snaps;
+    };
+    for entry in entries.flatten() {
+        // Only consider entries that are themselves directories on the
+        // host filesystem. `file_type()` uses the dirent's d_type and
+        // does NOT follow symlinks, so the `mnt` autofs symlink inside
+        // each snapshot is never resolved here.
+        let Ok(ft) = entry.file_type() else { continue };
+        if !ft.is_dir() {
+            continue;
+        }
+        let snap_bin = entry.path().join("snap.bin");
+        // Use symlink_metadata to avoid traversing into anything weird;
+        // snap.bin is always a regular file on the parent XFS.
+        if std::fs::symlink_metadata(&snap_bin).is_ok() {
+            if let Some(s) = snap_bin.to_str() {
+                snaps.push(s.to_string());
             }
         }
     }
     snaps.sort();
     snaps
-}
-
-fn walkdir(dir: &std::path::Path) -> std::io::Result<Vec<String>> {
-    let mut result = Vec::new();
-    if !dir.is_dir() {
-        return Ok(result);
-    }
-    for entry in std::fs::read_dir(dir)? {
-        let entry = entry?;
-        let path = entry.path();
-        if path.is_dir() {
-            result.extend(walkdir(&path)?);
-        } else if let Some(s) = path.to_str() {
-            result.push(s.to_string());
-        }
-    }
-    Ok(result)
 }
 
 fn read_fan_speed() -> String {


### PR DESCRIPTION
## Problem

`GET /api/status` consistently takes **5-15s TTFB** on a Rock Pi 4C+ with 130 snapshots on an otherwise idle system. This causes companion apps (SentryConnect, etc.) to time out their HTTP probes and fall back to BLE-only mode. The web UI also shows a perpetual "Reconnecting to Sentry USB..." banner even though data eventually loads.

Other endpoints on the same server are fast (`/api/health` ~3ms, `/api/version` ~4ms, `/api/drives` ~23ms) — so it's specific to `get_status`.

## Root cause(s)

Two independent bugs, found via `strace`/`tracing`:

### 1. `find_snapshots()` autofs storm — the big one

`find_snapshots()` in `crates/api/src/status.rs` called a recursive `walkdir` helper on `/backingfiles/snapshots/`. Each `snap-NNN/` directory contains a `mnt` symlink to `/tmp/snapshots/snap-NNN/`, which is backed by an **autofs mount-on-access** (timeout 300s) that lazily mounts the snapshot's vfat loop device on first touch. `walkdir` followed every one of those symlinks, triggering autofs to mount **130 vfat images**, then enumerated the entire dashcam tree inside each one (`SentryClips/<dates>/`, `SavedClips`, `RecentClips`, `EncryptedClips`, etc.) by calling `is_dir()` (a `stat` that follows symlinks) on every entry.

`strace` of a single `/api/status` call: **15,171 openat syscalls** across 104+ snapshot mounts × ~168 entries each. The 5–15s bimodal distribution corresponds to cold vs. partially-warm autofs state.

### 2. WiFi/Ethernet shell queries on DOWN interfaces

`iwgetid`, `iwconfig`, `ip`, `ethtool` ran unconditionally whenever the interface existed in `/sys/class/net/`, regardless of its operstate. On systems where a WiFi interface exists but is down (DietPi minimal w/o NetworkManager, Pi OS Lite with Skip WiFi, intentionally disabled WiFi, etc.) these calls can each block multiple seconds before returning empty.

## Fix

**Commit 1** — `iface_is_up()` helper gates the WiFi/Ethernet shell blocks on `/sys/class/net/<dev>/operstate == "up"`. No behavior change for systems with the interface up.

**Commit 2** — `find_snapshots()` rewritten to a single `read_dir` + `file_type().is_dir()` (uses the dirent's `d_type`, **does not follow symlinks**, so the autofs symlink is invisible) + one `symlink_metadata` per candidate `snap.bin`. Result: ~130 syscalls instead of 15,000+. The now-unused `walkdir` helper is removed.

Snapshots always have `snap.bin` directly at `snap-NNN/snap.bin`, so single-level scan is the correct depth — recursion was never needed for this lookup, just inherited from a generic helper.

## Verification

**Hardware:** Rock Pi 4C+ (RK3399 / 4GB), Armbian 6.18.29, DietPi minimal, T5 SSD via USB 3.0, `/backingfiles` XFS w/ 130 snapshot mounts.

10 sequential `curl http://pi/api/status` calls (no concurrent clients):

| | Min | Max | Mean |
|---|---:|---:|---:|
| **Before** (upstream v2.6.6) | 5.67s | 18.19s | 9.6s |
| **After** (this PR) | 0.036s | 0.040s | **0.038s** |

**~250x faster, ~450x lower variance.** Response payload byte-identical: `num_snapshots: 130`, `snapshot_oldest`/`snapshot_newest` epoch timestamps populated correctly, all other fields unchanged.

## Affected users

- Anyone with snapshots (the autofs bug — gets worse the more snapshots accumulate)
- Anyone running ethernet-only (the operstate bug — minimal-distro / Skip-WiFi users)
- Both bugs compound; combined fix is what restores fast response.

## What I ruled out along the way

- **Mutex contention on `NetSampler`** — 5/6 tokio workers were in `futex_do_wait` while 1 ran the slow handler; that's normal tokio parking when one task is doing blocking syscalls, not contention. After the fix, all workers idle correctly.
- **Auth middleware** — `/api/status` is in the always-exempt list, and loopback bypasses auth anyway.
- **Background tasks** (cloud_uploader 600s tick, processor 10ms loop) — touched nothing in the status path.
- **`sentryusb_gadget::is_active()`** — pure sysfs reads, microseconds.
- **`stat --file-system`, `ip`, `ethtool` shells** — each ~10ms when called directly; not the bottleneck.

## Files changed

- `crates/api/src/status.rs` — 1 file, ~50 net lines

No new dependencies. No protocol/API changes. Backwards compatible.

Happy to test follow-up patches if anything turns up in review.