### PR TITLE
fix(notifications): honor SENTRY_NOTIFICATION_URL on send + record test events in history

### DIFF
--- a/crates/api/src/notifications.rs
+++ b/crates/api/src/notifications.rs
@@ -503,16 +503,55 @@ pub async fn send_test_notification(State(_s): State<AppState>) -> (StatusCode, 
         &format!("Test notification from {} — push notifications are working!", hostname),
     ).await;
 
-    match result {
+    let (status_code, body, send_ok, error_msg) = match result {
         Ok(()) => {
             info!("[notifications] Test notification sent successfully");
-            (StatusCode::OK, Json(serde_json::json!({"status": "ok"})))
+            (
+                StatusCode::OK,
+                serde_json::json!({"status": "ok"}),
+                true,
+                String::new(),
+            )
         }
         Err(e) => {
-            warn!("[notifications] Test notification failed: {}", e);
-            crate::json_error(StatusCode::BAD_GATEWAY, &e.to_string())
+            let msg = e.to_string();
+            warn!("[notifications] Test notification failed: {}", msg);
+            (
+                StatusCode::BAD_GATEWAY,
+                serde_json::json!({"status": "error", "error": msg.clone()}),
+                false,
+                msg,
+            )
         }
+    };
+
+    // Record in notification history so the web UI / Notification Center
+    // can show test results alongside real archive/temperature events.
+    // Matches the real /api/notifications/send path which calls
+    // record_event() after each send. Without this, users testing the
+    // pairing flow see "sent successfully" in the API response but the
+    // History tab stays empty — which incorrectly looks like the push
+    // never happened.
+    let mut results_map: std::collections::HashMap<String, String> =
+        std::collections::HashMap::new();
+    results_map.insert(
+        "sentry_connect".to_string(),
+        if send_ok { "ok".to_string() } else { format!("error: {}", error_msg) },
+    );
+    let event = crate::notification_center::NotificationEvent {
+        id: String::new(),
+        timestamp: 0,
+        event_type: "test".to_string(),
+        title: "SentryUSB Test".to_string(),
+        message: format!("Test notification from {} — push notifications are working!", hostname),
+        providers: vec!["sentry_connect".to_string()],
+        results: results_map,
+    };
+    if let Err(e) = crate::notification_center::record_event(event) {
+        warn!("[notifications] Failed to record test notification in history: {}", e);
     }
+
+    (status_code, Json(body))
 }
 
 // -----------------------------------------------------------------------------

--- a/crates/notify/src/sentry_connect.rs
+++ b/crates/notify/src/sentry_connect.rs
@@ -32,9 +32,37 @@ pub struct SendContext<'a> {
     pub device_name: Option<&'a str>,
 }
 
+/// Notification relay base URL. Resolved in this order:
+///
+/// 1. `SENTRY_NOTIFICATION_URL` env var — covers dev overrides and any
+///    systemd `EnvironmentFile=` setup.
+/// 2. `SENTRY_NOTIFICATION_URL` in `/root/sentryusb.conf` — systemd starts
+///    the binary without sourcing the config (no shell wrapper), so the
+///    env var is NOT set on a default install. Without this fallback the
+///    user's `SENTRY_NOTIFICATION_URL` is silently ignored on the send
+///    path and every push hits `notifications.sentry-six.com` regardless
+///    of what the conf says — which silently breaks third-party relays
+///    (e.g. the Android SentryConnect app's Firebase Cloud Functions).
+///    Mirrors `notification_base_url()` in `api/src/notifications.rs`
+///    and Go's `configOrDefault` (`server/api/apiconfig.go`).
+/// 3. Hardcoded default `https://notifications.sentry-six.com`.
 fn default_push_server() -> String {
-    std::env::var("SENTRY_NOTIFICATION_URL")
-        .unwrap_or_else(|_| "https://notifications.sentry-six.com".to_string())
+    if let Ok(v) = std::env::var("SENTRY_NOTIFICATION_URL") {
+        let trimmed = v.trim().trim_end_matches('/');
+        if !trimmed.is_empty() {
+            return trimmed.to_string();
+        }
+    }
+    let config_path = sentryusb_config::find_config_path();
+    if let Ok((active, _)) = sentryusb_config::parse_file(config_path) {
+        if let Some(v) = active.get("SENTRY_NOTIFICATION_URL") {
+            let trimmed = v.trim().trim_end_matches('/');
+            if !trimmed.is_empty() {
+                return trimmed.to_string();
+            }
+        }
+    }
+    "https://notifications.sentry-six.com".to_string()
 }
 
 pub async fn send(
@@ -144,11 +172,15 @@ mod tests {
     fn push_server_default_is_production_url() {
         // Cross-test env mutation is unsafe on the 2024 edition + risks
         // flakiness when other tests also touch the env; just verify the
-        // fallback branch when the variable is whatever it is in test
-        // context. The assertion holds whenever the env isn't explicitly
-        // set to a non-empty override, which is the only state CI cares
-        // about anyway.
-        if std::env::var("SENTRY_NOTIFICATION_URL").is_err() {
+        // fallback branch when neither the env var nor the on-disk config
+        // overrides it. This is the only state CI cares about anyway —
+        // a host with /root/sentryusb.conf carrying SENTRY_NOTIFICATION_URL
+        // is a deployed Pi, not a build runner.
+        let env_unset = std::env::var("SENTRY_NOTIFICATION_URL").is_err();
+        let conf_unset = sentryusb_config::parse_file(sentryusb_config::find_config_path())
+            .map(|(active, _)| !active.contains_key("SENTRY_NOTIFICATION_URL"))
+            .unwrap_or(true);
+        if env_unset && conf_unset {
             assert_eq!(default_push_server(), "https://notifications.sentry-six.com");
         }
     }


### PR DESCRIPTION
**This PR includes two related notification-path fixes.** Same area of code, both found while debugging Android SentryConnect on Rusty v2.6.6.

---

# Fix 1 — Honor `SENTRY_NOTIFICATION_URL` on the send path

## Problem

`crates/notify/src/sentry_connect.rs::default_push_server()` only checks the `SENTRY_NOTIFICATION_URL` **environment variable**. systemd's default `sentryusb.service` runs the binary directly — no shell wrapper, no `EnvironmentFile=` — so the env var is NOT set on a default install.

Net effect: the user's `SENTRY_NOTIFICATION_URL` override in `/root/sentryusb.conf` is silently ignored on the actual push send path, and every notification hits the hardcoded `notifications.sentry-six.com` default regardless of what the conf says.

This is asymmetric with `notification_base_url()` in `api/src/notifications.rs`, which already reads **both env AND config file** for the pairing-code / device-registration path. Confusing failure mode:

- Pairing-code generation works (talks to the configured relay) ✓
- Test/real notifications silently fail (talk to sentry-six.com) ❌
- Pi log says "Test notification sent successfully" — misleading

## Concrete impact

Hit this debugging the Android **SentryConnect** app on a Rock Pi 4C+ / DietPi / Rusty v2.6.6 install. The Android app's notification relay is its own Firebase Cloud Functions at `sentryconnect.web.app` — distinct from the iOS relay at `notifications.sentry-six.com`.

Standard config:

```
# /root/sentryusb.conf
export SENTRY_NOTIFICATION_URL=https://sentryconnect.web.app
```

`tcpdump` during a test notification:

**Before:** `Out IP <pi>.443 > 192.95.32.209.443` ← notifications.sentry-six.com (wrong)
**After:** `Out IP <pi>.443 > 199.36.158.100.443` ← sentryconnect.web.app (correct)

## Fix

Make `default_push_server()` walk the same resolution chain as `notification_base_url()`:

1. Env var (existing behavior)
2. `SENTRY_NOTIFICATION_URL` in `/root/sentryusb.conf` (**new fallback**)
3. Hardcoded default `https://notifications.sentry-six.com`

The `notify` crate already depends on `sentryusb-config`, so no new dependencies.

---

# Fix 2 — Record test notifications in history

## Problem

`send_test_notification` (POST `/api/notifications/test`) sends to the Sentry Connect relay but never calls `notification_center::record_event`, unlike the real `send_runtime` path which records every dispatch.

Net effect: user pairs SC, hits "Test", the push lands on phone, but the Notification Center / `/api/notifications/history` stays empty. Contradicts the "sent successfully" log line; makes the test feel half-broken even when the push worked.

## Fix

Emit a `NotificationEvent { event_type: "test", ... }` after the send call regardless of success/failure (results map records ok or error). Same pattern as the real send path, with `"test"` as the event_type and `sentry_connect` as the sole provider (matches the test handler's mobile-push-only scope).

## Combined verification (Rock Pi 4C+ / Rusty v2.6.6, both fixes deployed)

**Send path:**
```
$ curl -s -X POST http://pi/api/notifications/test
{"status":"ok"}
tcpdump confirms: Out IP > 199.36.158.100.443  ← sentryconnect.web.app
Push delivered to phone via Firebase Cloud Functions → FCM. ✓
```

**History:**
```
$ curl -s http://pi/api/notifications/history
{"events":[{"id":"dilfkgp24upo","ts":1779069681,"type":"test",
"title":"SentryUSB Test","message":"Test notification from sentryusb...",
"providers":["sentry_connect"],"results":{"sentry_connect":"ok"}}],"total":1}
```
File created at `/mutable/sentryusb-notifications.json`, web UI Notification Center shows the test alongside real events. ✓

## Files changed

- `crates/notify/src/sentry_connect.rs` — config-file fallback (commit d3695d3)
- `crates/api/src/notifications.rs` — record_event call in send_test_notification (commit e15f4b7)

No new dependencies. No protocol/API changes. Backwards compatible.

Happy to split into separate PRs if preferred.