### PR TITLE
fix(ble): sentryusb-ble.py waits for BlueZ adapter to appear before bailing

### DIFF
--- a/server/ble/sentryusb-ble.py
+++ b/server/ble/sentryusb-ble.py
@@ -22,6 +22,7 @@ import os
 import sys
 import signal
 import logging
+import time
 import urllib.request
 import urllib.error
 import threading
@@ -1093,6 +1094,38 @@ def find_adapter(bus):
             return path
     return None
 
+
+def wait_for_adapter(bus, timeout_s=15, poll_interval_s=0.2):
+    """Wait for BlueZ to expose an LE adapter, polling up to `timeout_s`.
+
+    The systemd unit waits for the org.bluez D-Bus name to be claimed before
+    starting this script, but BlueZ exposes the adapter object asynchronously
+    after claiming the bus name. On a slow boot, busy SD card, or service
+    restart (after archiveloop's awake_stop, OOM kill, RuntimeMaxSec, etc.),
+    a single GetManagedObjects() call can race ahead of adapter enumeration
+    and find nothing. The script then exits 1, systemd retries up to
+    StartLimitBurst times, and if all retries hit the race the service stays
+    inactive until reboot.
+
+    First-principle fix: wait for the dependency we actually need (the LE
+    adapter object), not just the bus name. Polling once every 200ms for ~5
+    iterations is effectively free and simpler than D-Bus InterfacesAdded
+    signal subscription (which has its own race when the adapter already
+    exists at subscribe time).
+    """
+    deadline = time.time() + timeout_s
+    last_log = 0.0
+    while time.time() < deadline:
+        path = find_adapter(bus)
+        if path:
+            return path
+        if time.time() - last_log >= 1.0:
+            remaining = int(deadline - time.time())
+            log.info(f'Waiting for BlueZ adapter... ({remaining}s remaining)')
+            last_log = time.time()
+        time.sleep(poll_interval_s)
+    return None
+
 def register_ad_cb():
     log.info('Advertisement registered')
 
@@ -1268,9 +1301,12 @@ def main():
     # Detect which port the Go API server is on (80 production, 8788 dev)
     API_BASE = detect_api_base()
 
-    adapter_path = find_adapter(bus)
+    # Wait up to 15s for BlueZ to expose the LE adapter — see wait_for_adapter()
+    # docstring for race-condition rationale. Single-shot find_adapter() loses
+    # the race on slow boots, busy SD cards, or service restarts after archiveloop.
+    adapter_path = wait_for_adapter(bus, timeout_s=15)
     if not adapter_path:
-        log.error('No Bluetooth LE adapter found')
+        log.error('No Bluetooth LE adapter found after 15s — BlueZ may be misconfigured')
         sys.exit(1)
 
     log.info(f'Using adapter: {adapter_path}')

--- a/server/ble/sentryusb-ble.service
+++ b/server/ble/sentryusb-ble.service
@@ -5,6 +5,14 @@ After=bluetooth.target bluetooth.service dbus.service
 Requires=bluetooth.target dbus.service
 BindsTo=bluetooth.service
 ConditionPathExists=/usr/bin/python3
+# Defense in depth against the BLE adapter boot race: systemd defaults to
+# StartLimitBurst=5 within StartLimitIntervalSec=10s, which can be exhausted
+# if all 5 attempts hit the race within 30 seconds. Bumping to 20 attempts in
+# 120s gives systemd enough budget to recover before giving up. The Python
+# wait_for_adapter() handles 99% of cases on the first attempt; this is
+# insurance for unrelated future failure modes (BlueZ crash, OOM, etc.).
+StartLimitBurst=20
+StartLimitIntervalSec=120
 
 [Service]
 Type=simple


### PR DESCRIPTION
Mirrors merged upstream [Sentry-USB#47](https://github.com/Scottmg1/Sentry-USB/pull/47). Same fix, same files (`server/ble/sentryusb-ble.py` + `.service`), reproduced live and validated on Rusty v2.6.6.

## The race

The unit's `busctl status org.bluez` ExecStartPre only waits for BlueZ to claim its bus name. BlueZ exposes `/org/bluez/hci0` asynchronously **after** that claim. A single `find_adapter()` → `GetManagedObjects()` call can race ahead of adapter enumeration on:

- Slow boots (eMMC contention, NTP sync, mDNS storms)
- Service restarts after archiveloop's awake_stop, OOM kill, RuntimeMaxSec, etc.

When it loses the race, the script logs `No Bluetooth LE adapter found` and exits 1. Restart=always retries, but on the same boot the race tends to repeat — exhausting StartLimitBurst (default 5/10s) and leaving the BLE peripheral unavailable until the next reboot.

## The fix

Wait for the dependency we actually need (the LE adapter object), not just the bus name. Bounded poll: 15s timeout, 200ms interval. Simpler than `InterfacesAdded` signal subscription (which has its own race when the adapter already exists at subscribe time).

Plus a defence-in-depth bump: `StartLimitBurst=20` within `StartLimitIntervalSec=120` so systemd has budget for unrelated future failure modes (BlueZ crash, OOM, etc.) where the default 5/10s would tap out.

## Validated live (Rock Pi 4C+ / DietPi + Rusty v2.6.6, 2026-05-18)

Applied to a running install + clean reboot. Pre-patch behaviour: 1–2 StartLimitBurst retries needed before sentryusb-ble landed cleanly; BLE peripheral unavailable for first ~30s.

Post-patch:

\`\`\`
05:37:28 systemd: Starting sentryusb-ble.service...
05:37:29 sentryusb-ble: Using adapter: /org/bluez/hci0   ← found on first poll
05:37:29 sentryusb-ble: GATT application registered
05:37:29 sentryusb-ble: Advertisement registered
05:37:34 sentryusb-ble: Peer authenticated: /org/bluez/hci0/dev_5C_92_47_1A_11_B3
05:37:34 sentryusb-ble: API proxy: GET /status (id=1)
\`\`\`

6 seconds from service start to authenticated central, no retries. Android BLE central (Pixel 10 Pro XL) reconnected without re-pair, status reads flowing.

## Test plan

- [x] Patch applies cleanly to `main`
- [x] sentryusb-ble starts on first attempt after Pi reboot
- [x] BLE central can connect + authenticate within seconds of Pi boot
- [x] No regression in normal-boot path (15s budget is generous, first poll typically succeeds within 200ms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)