### PR TITLE
fix(ble): increase MTU margin (mtu-8) + chunk stagger (200ms) for Android compat

### DIFF
--- a/server/ble/sentryusb-ble.py
+++ b/server/ble/sentryusb-ble.py
@@ -927,7 +927,7 @@ class APIRequestCharacteristic(Characteristic):
 
             # Send response, chunking if it exceeds the negotiated BLE MTU.
             # ATT notification overhead is 3 bytes.
-            max_msg = self._client_mtu - 3
+            max_msg = self._client_mtu - 8
             if len(response_json) <= max_msg:
                 def send_single():
                     self.response_chrc.send_notification(
@@ -967,7 +967,7 @@ class APIRequestCharacteristic(Characteristic):
                             dbus.Array([dbus.Byte(b) for b in msg], signature='y'))
                         return False
                     # Stagger chunk notifications by 50ms to prevent BlueZ drops
-                    GLib.timeout_add(50 * idx, send_chunk)
+                    GLib.timeout_add(200 * idx, send_chunk)
 
         # Run the blocking HTTP proxy call in a background thread
         # so the GLib main loop stays responsive for BLE operations


### PR DESCRIPTION
Two single-line fixes in \`server/ble/sentryusb-ble.py\`'s response chunker, both live-validated tonight (2026-05-18) during a deep BT-panel debug session against [SentryConnect](https://github.com/chufleco/SentryConnect) on Pixel 10 / Android 15.

## Bug 1: MTU off-by-2 truncates outer envelope

Current code: \`max_msg = self._client_mtu - 3\` (line 930). With MTU 517 that produces 514-byte frames. Android delivers payload bytes ~2 below the negotiated ATT MTU on Broadcom BCM4345C0 firmware, so the closing \`\"}}\` of the outer envelope gets chopped, \`JSONObject(text)\` parse fails, response drops.

\`\`\`
Pi sends:    {\"id\":1,\"chunks\":2,\"chunk\":0,\"data\":\"...506 bytes...\"}}   (514 bytes)
Android RX:  {\"id\":1,\"chunks\":2,\"chunk\":0,\"data\":\"...506 bytes...\"     (512 bytes, missing }})
\`\`\`

Fix: bump margin to 8 → 506-byte frames consistently arrive whole.

## Bug 2: 50ms chunk stagger too tight, BlueZ drops chunk 1

Current code: \`GLib.timeout_add(50 * idx, send_chunk)\` (line 970). Comment claims 50ms prevents BlueZ drops, but on BCM4345C0 + this BlueZ version chunk 1 (fired 50ms after chunk 0) gets dropped before delivery.

\`\`\`
chunk 0 (idx=0, t=0)   → delivered to Android ✓
chunk 1 (idx=1, t=50ms) → BlueZ silently drops ✗
\`\`\`

Symptom: SC's chunked-frame buffer never reassembles. Status read times out at the client side even though Pi successfully sent both frames.

Fix: 200ms gives BlueZ enough breathing room.

## Live validation

Before both fixes:
\`\`\`
[BleConnSvc] invalid response JSON — len=512 head={\"id\":1,\"chunks\":2,\"chunk\":0,\"data\":\"... tail=...\\\"uptim
[BLE status: null] (repeated indefinitely)
\`\`\`

After both fixes:
\`\`\`
[BleConnSvc] notif uuid=6e400012 len=508
[BleConnSvc] notif uuid=6e400012 len=198
[BLE status: BleDeviceStatus(deviceName=Radxa ROCK 4C+, drivesActive=true, cpuTempC=42.777, uptimeSec=14386)]
\`\`\`

(508 instead of 514 because of the mtu-8 margin; second frame is the smaller tail chunk.)

## Hardware confirmed

- Rock Pi 4C+ (Radxa ROCK 4C+)
- BCM4345C0 firmware (rev 003.001.025), patch \`brcm/BCM4345C0.radxa,rock-4c-plus.hcd\`
- BlueZ 5.82
- Linux 6.18.29-current-rockchip64 (DietPi)
- Android central: Pixel 10 Pro XL / Android 15

The firmware blob is byte-identical to RPi CM4's BCM4345C0.hcd (\`md5: 1ae05ba8943eeeaba67ae58d6f0ce45f\`) so this should reproduce on any Sentry-USB user with an Android client on similar Broadcom hardware.

## Test plan

- [x] Live-validated on author's Rock 4C+ tonight — SC BT panel populates within ~1s of opening
- [x] No algorithmic change — same chunking + reassembly contract on client side
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)