### PR TITLE
fix(ble): re-enable controller-level LE advertising on service start

### DIFF
--- a/server/ble/sentryusb-ble.service
+++ b/server/ble/sentryusb-ble.service
@@ -25,6 +25,16 @@ Type=simple
 ExecStartPre=-/bin/bash -c 'f=/tmp/ble_keep_awake_active; [ -e "$f" ] && [ $(( $(date +%s) - $(stat -c %Y "$f" 2>/dev/null || echo 0) )) -gt 86400 ] && rm -f "$f"; exit 0'
 ExecStartPre=/usr/sbin/rfkill unblock bluetooth
 ExecStartPre=-/usr/bin/hciconfig hci0 up
+# Re-enable controller-level LE advertising. The btmgmt flag persists in
+# kernel state and ends up OFF after certain restart paths (service crash,
+# manual restart, bond-dir reset). With it OFF, BlueZ's RegisterAdvertisement
+# below has no effect — the radio stops broadcasting. Already-bonded phones
+# can still reconnect via the bonded address, so the bug is invisible to
+# existing users, but any NEW device trying to discover the Pi (first-time
+# setup, re-pair after bond wipe, additional family-member phone, future
+# iOS client) will silently fail with "Pi not found nearby." The leading
+# '-' makes systemd treat a missing btmgmt as non-fatal.
+ExecStartPre=-/usr/bin/btmgmt advertising on
 ExecStartPre=/bin/bash -c 'for i in $(seq 1 30); do busctl status org.bluez >/dev/null 2>&1 && break; echo "Waiting for org.bluez... ($i/30)"; sleep 1; done'
 ExecStart=/usr/bin/python3 /root/bin/sentryusb-ble.py
 Restart=always


### PR DESCRIPTION
## Summary

Add `ExecStartPre=-/usr/bin/btmgmt advertising on` to `server/ble/sentryusb-ble.service` so the LE advertising controller flag is on every time the service starts. Without this, certain restart paths leave the flag OFF — BlueZ's `RegisterAdvertisement` call in `sentryusb-ble.py` then has no effect and the radio silently stops broadcasting.

## Why it matters

The bug is invisible to existing users: an already-bonded phone reconnects via the bonded address regardless of advertising state. But discovery breaks, which surfaces as:

- Android setup wizard shows "Pi not found nearby" for first-time setup
- Re-pair after bond wipe / factory reset / new phone silently fails
- iOS client (when it ships) will hit the same wall

Manual workaround today is to SSH in and run `btmgmt advertising on` after every service restart. Baking it into the unit's existing `ExecStartPre` chain makes the controller state match what userspace (`RegisterAdvertisement`) expects.

## Change

```diff
 ExecStartPre=/usr/sbin/rfkill unblock bluetooth
 ExecStartPre=-/usr/bin/hciconfig hci0 up
+ExecStartPre=-/usr/bin/btmgmt advertising on
 ExecStartPre=/bin/bash -c 'for i in $(seq 1 30); do busctl status org.bluez ...'
```

The leading `-` makes systemd treat a missing `btmgmt` binary as non-fatal, matching the pattern already used for `hciconfig` on line 27 and the `ble_keep_awake_active` cleanup on line 25.

## Test plan

- [x] On a Radxa ROCK 4C+ running v2.7.5, manual reproduction confirmed: `systemctl restart sentryusb-ble` drops the controller advertising flag; existing bonded phones still reconnect, but a freshly-unpaired phone's scan returns nothing.
- [ ] Apply this patch + `systemctl daemon-reload + restart sentryusb-ble` — verify `btmgmt advertising` reports `Instance ... advertising` after the restart and a freshly-unpaired phone sees the Pi in its BLE scan.
- [ ] Verify no regression for already-bonded phone reconnect (should be unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)