### PR TITLE
fix(ble): wait for BlueZ DBus before btmgmt advertising on

### DIFF
--- a/server/ble/sentryusb-ble.service
+++ b/server/ble/sentryusb-ble.service
@@ -25,6 +25,13 @@ Type=simple
 ExecStartPre=-/bin/bash -c 'f=/tmp/ble_keep_awake_active; [ -e "$f" ] && [ $(( $(date +%s) - $(stat -c %Y "$f" 2>/dev/null || echo 0) )) -gt 86400 ] && rm -f "$f"; exit 0'
 ExecStartPre=/usr/sbin/rfkill unblock bluetooth
 ExecStartPre=-/usr/bin/hciconfig hci0 up
+# Wait for BlueZ DBus before invoking btmgmt below. btmgmt acquires the
+# kernel BT management socket via BlueZ, and at boot time runs the risk
+# of starting before bluetoothd has claimed the socket. When that happens
+# btmgmt blocks indefinitely instead of returning an error, eating the
+# full 90s systemd start-pre timeout. Doing the org.bluez ready-check
+# *first* makes btmgmt non-blocking on every restart path.
+ExecStartPre=/bin/bash -c 'for i in $(seq 1 30); do busctl status org.bluez >/dev/null 2>&1 && break; echo "Waiting for org.bluez... ($i/30)"; sleep 1; done'
 # Re-enable controller-level LE advertising. The btmgmt flag persists in
 # kernel state and ends up OFF after certain restart paths (service crash,
 # manual restart, bond-dir reset). With it OFF, BlueZ's RegisterAdvertisement
@@ -33,9 +40,9 @@ ExecStartPre=-/usr/bin/hciconfig hci0 up
 # existing users, but any NEW device trying to discover the Pi (first-time
 # setup, re-pair after bond wipe, additional family-member phone, future
 # iOS client) will silently fail with "Pi not found nearby." The leading
-# '-' makes systemd treat a missing btmgmt as non-fatal.
-ExecStartPre=-/usr/bin/btmgmt advertising on
-ExecStartPre=/bin/bash -c 'for i in $(seq 1 30); do busctl status org.bluez >/dev/null 2>&1 && break; echo "Waiting for org.bluez... ($i/30)"; sleep 1; done'
+# '-' makes systemd treat a missing btmgmt as non-fatal, and `timeout 5`
+# is belt-and-suspenders against any future BlueZ-readiness race.
+ExecStartPre=-/usr/bin/timeout 5 /usr/bin/btmgmt advertising on
 ExecStart=/usr/bin/python3 /root/bin/sentryusb-ble.py
 Restart=always
 RestartSec=5


### PR DESCRIPTION
Follow-up to #10. The `btmgmt advertising on` step it added runs as `ExecStartPre` before the `org.bluez` ready-check, which on a cold boot loses the race against `bluetoothd` starting up.

## Symptom

When btmgmt runs before BlueZ has claimed the kernel mgmt socket, btmgmt blocks indefinitely waiting for the socket instead of returning an error. Systemd's default 90s start-pre timeout then kills it. The service ends up FAILED until `Restart=always` kicks in 5s later — and on the retry BlueZ is up, so btmgmt completes fast and the service finally starts.

**Net effect on v2.7.6: ~95s extra delay before BLE is reachable on every Pi reboot.**

## Observed

Cold boot of a Rock Pi 4C+ on DietPi/eMMC after the v2.7.6 OTA:

```
$ systemctl status sentryusb-ble
● sentryusb-ble.service - SentryUSB BLE Peripheral
   Active: activating (start-pre) since ... 1min 38s ago
   Cntrl PID: 1411 (btmgmt)
        └─1411 /usr/bin/btmgmt advertising on
...
start-pre operation timed out. Terminating.
Failed with result 'timeout'.
```

The same `btmgmt advertising on` completes in <1s once BlueZ is up (verified via `timeout 5 btmgmt advertising on`).

## Fix

1. Move the btmgmt line **below** the `busctl status org.bluez` ready-check so it only runs once BlueZ has the mgmt socket.
2. Wrap btmgmt in `timeout 5` as belt-and-suspenders against any future BlueZ-readiness race — keeps service-start bounded even if the wait above ever misses an edge case.

Functionally equivalent to #10 for the steady-state goal (controller LE advertising re-enabled on every service start) but with the ordering bug removed.

## Test plan

- [x] On a Pi already affected by the v2.7.6 boot hang, applied the fix via `/etc/systemd/system/sentryusb-ble.service.d/` drop-in with the new order. BLE service goes `active` in <5s of restart. Verified `btmgmt advertising on` still flips the controller-level advertising flag (via subsequent BlueZ `Advertisement registered` log line).
- [ ] Cold reboot test on Pi 5 / RK3399 / RPi 4 to confirm the race doesn't recur with the new order.