### PR TITLE
fix(setup): replace cttseraser FUSE with kernel bind mount for TeslaCam serving

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -25,7 +25,7 @@ cp -r web/dist crates/sentryusb/static
 
 Two binaries ship with the project:
 - `sentryusb` — main daemon (HTTP + WebSocket + setup orchestrator)
-- `cttseraser` — FUSE helper that rewrites `ctts` atoms in Tesla dashcam MP4s
+- `cttseraser` — opt-in FUSE binary that rewrites `ctts` atoms in Tesla MP4s (no longer in the default serving path; bind mount used instead)
 
 ### Cross-compile for the Pi
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Output: `deploy/sentryusb-*.img.gz`, flash with Raspberry Pi Imager.
 - `crates/shell` — shell command helpers
 - `crates/usb_gadget` — configfs gadget control
 - `crates/ws` — WebSocket hub
-- `crates/cttseraser` — FUSE helper for CTTS frame atom stripping
+- `crates/cttseraser` — opt-in CTTS atom stripper (bind mount is the default; this is scaffolding for advanced users with very old browser stacks)
 - `server/ble/` — Python BLE GATT peripheral (iOS app pairing)
 - `run/`, `setup/pi/`, `tools/`, `tests/` — shell helpers & pi-gen stage scripts
 - `pi-gen-sources/` — Raspberry Pi OS image build configuration

--- a/build-image.sh
+++ b/build-image.sh
@@ -167,7 +167,7 @@ cp "$BINARY_PATH" "$WORK_DIR/stage_sentryusb/00-sentryusb-tweaks/files/sentryusb
 chmod +x "$WORK_DIR/stage_sentryusb/00-sentryusb-tweaks/files/sentryusb-binary"
 
 if [ -n "${CTTS_BINARY:-}" ] && [ -f "$CTTS_BINARY" ]; then
-    info "Injecting cttseraser FUSE binary..."
+    info "Injecting cttseraser binary (opt-in ctts stripper)..."
     cp "$CTTS_BINARY" "$WORK_DIR/stage_sentryusb/00-sentryusb-tweaks/files/cttseraser"
     chmod +x "$WORK_DIR/stage_sentryusb/00-sentryusb-tweaks/files/cttseraser"
 fi

--- a/crates/api/src/healthcheck.rs
+++ b/crates/api/src/healthcheck.rs
@@ -139,10 +139,11 @@ pub async fn health_check(State(_s): State<AppState>) -> (StatusCode, Json<serde
             st.push(item(label, status, Some("missing".to_string())));
         }
     }
-    // TeslaCam directory on /mutable — the bind-mount target for
-    // `mount.ctts`. Without it, the FUSE wrapper can't expose the cam
-    // content to Samba/web downloads, and the dashboard would otherwise
-    // show "all green" while TeslaCam is silently empty.
+    // TeslaCam directory on /mutable — the source of the bind mount
+    // at /var/www/html/TeslaCam. Without it, the Axum ServeDir route
+    // can't expose the cam content to Samba/web downloads, and the
+    // dashboard would otherwise show "all green" while TeslaCam is
+    // silently empty.
     if std::path::Path::new("/mutable/TeslaCam").is_dir() {
         st.push(item("TeslaCam directory", "pass", None));
     } else {

--- a/crates/sentryusb/src/main.rs
+++ b/crates/sentryusb/src/main.rs
@@ -255,10 +255,10 @@ async fn main() {
     // Build the API router
     let mut app = sentryusb_api::build_router(app_state.clone());
 
-    // Serve TeslaCam video files through the cttseraser FUSE mount, which
-    // strips the `ctts` atom from Tesla MP4s so Chromium-based browsers can
-    // play them. The setup crate (`sentryusb_setup::cttseraser_mount`) mounts
-    // it over the snapshot symlink tree at `/mutable/TeslaCam`.
+    // Serve TeslaCam video files via the bind mount of /mutable/TeslaCam
+    // at /var/www/html/TeslaCam. Modern browsers (Chrome 80+, Firefox 70+,
+    // Safari iOS 13+, ExoPlayer) parse Tesla's `ctts` atom natively, so
+    // no FUSE wrapper is needed.
     app = app.nest_service(
         "/TeslaCam",
         tower_http::services::ServeDir::new("/var/www/html/TeslaCam"),

--- a/crates/setup/src/cttseraser_mount.rs
+++ b/crates/setup/src/cttseraser_mount.rs
@@ -1,18 +1,16 @@
-//! TeslaCam FUSE mount wiring — port of `configure-web.sh`.
+//! TeslaCam web mount wiring — port of `configure-web.sh`.
 //!
-//! The Go/bash project compiled `cttseraser.cpp` here; the Rust port ships
-//! a native `cttseraser` binary built separately (installed by install-pi.sh
-//! or the pi-gen image at /usr/local/bin/cttseraser). This phase wires
-//! the binary into the system:
-//!   * writes `/sbin/mount.ctts` so fstab's `mount.ctts#` syntax resolves
-//!   * enables `user_allow_other` in /etc/fuse.conf
-//!   * creates the /mutable/TeslaCam source + /var/www/html/TeslaCam target
-//!   * adds the fstab entry that actually mounts it
-//!   * installs the `auto.www` autofs map when music/lightshow/boombox disk
-//!     images exist
+//! Wires the bind mount of /mutable/TeslaCam at /var/www/html/TeslaCam,
+//! which is where the Axum server's ServeDir route reads from. Prior
+//! versions of this phase configured a cttseraser FUSE mount to strip
+//! the `ctts` atom from MP4 files for browsers that couldn't parse it;
+//! modern browsers (Chrome 80+, Firefox 70+, Safari iOS 13+, ExoPlayer)
+//! handle the atom natively, so the FUSE layer is replaced with a
+//! kernel-level bind mount for correctness, throughput, and reliability.
 //!
-//! Without this phase the cttseraser binary is installed but **never mounted**,
-//! so Chrome's recordings bypass the ctts fixup entirely.
+//! The cttseraser binary and `/sbin/mount.ctts` helper are still installed
+//! by the build scripts as opt-in scaffolding; this module simply does not
+//! reference them by default.
 
 use std::path::Path;
 use std::time::Duration;
@@ -21,38 +19,39 @@ use anyhow::{Context, Result};
 
 use crate::SetupEmitter;
 
-/// Path at which install-pi.sh / pi-gen drops the Rust cttseraser binary.
-/// `/usr/local/bin/cttseraser` is a symlink to `/opt/sentryusb/cttseraser`.
-const CTTSERASER_BIN: &str = "/usr/local/bin/cttseraser";
+/// Canonical fstab entry that bind-mounts the TeslaCam source tree at the
+/// path the Axum ServeDir route reads from.
+const FSTAB_BIND_LINE: &str =
+    "/mutable/TeslaCam /var/www/html/TeslaCam none bind,nofail,x-systemd.requires=/mutable 0 0";
 
 pub async fn configure_web_mount(emitter: &SetupEmitter) -> Result<bool> {
-    // Idempotency check — if the fstab entry, mount helper, and fuse conf
-    // are all already in place, we have nothing to do.
+    // Idempotency check — if the canonical bind entry is already present
+    // and no legacy cttseraser entry remains, nothing to do.
     let fstab = std::fs::read_to_string("/etc/fstab").unwrap_or_default();
-    let fstab_has_mount = fstab.lines().any(|l| !l.starts_with('#') && l.contains("mount.ctts#"));
-    let mount_helper_ok = std::fs::read_to_string("/sbin/mount.ctts")
-        .map(|c| c.contains(CTTSERASER_BIN) || c.contains("cttseraser"))
-        .unwrap_or(false);
-    let fuse_ok = std::fs::read_to_string("/etc/fuse.conf")
-        .map(|c| c.lines().any(|l| l.trim() == "user_allow_other"))
-        .unwrap_or(false);
+    let fstab_has_bind = fstab.lines().any(|l| {
+        !l.trim_start().starts_with('#')
+            && l.contains("/mutable/TeslaCam")
+            && l.contains("/var/www/html/TeslaCam")
+            && l.contains("bind")
+    });
+    let fstab_has_legacy = fstab
+        .lines()
+        .any(|l| !l.trim_start().starts_with('#') && l.contains("mount.ctts#"));
 
-    if fstab_has_mount && mount_helper_ok && fuse_ok {
+    if fstab_has_bind && !fstab_has_legacy {
         return Ok(false);
     }
 
-    emitter.begin_phase("web_mount", "TeslaCam FUSE mount");
+    emitter.begin_phase("web_mount", "TeslaCam mount");
     emitter.progress("configuring web (SentryUSB mode)");
 
-    // Install the runtime packages the Rust binary needs. We skip the
-    // build toolchain (g++, libfuse-dev) that the bash script pulled in
-    // purely to compile cttseraser.cpp on-device; the Rust binary is
-    // already compiled for us.
+    // Install runtime packages for the network status APIs. The bind mount
+    // itself requires no userspace tooling beyond `mount(8)` (built-in).
     sentryusb_shell::run_with_timeout(
         Duration::from_secs(300),
         "apt-get",
-        &["-y", "install", "fuse3", "net-tools", "wireless-tools", "ethtool"],
-    ).await.context("failed to install FUSE + networking runtime packages")?;
+        &["-y", "install", "net-tools", "wireless-tools", "ethtool"],
+    ).await.context("failed to install networking runtime packages")?;
 
     // Nginx fight — SentryUSB owns port 80.
     if sentryusb_shell::run("systemctl", &["is-active", "--quiet", "nginx"]).await.is_ok() {
@@ -62,24 +61,26 @@ pub async fn configure_web_mount(emitter: &SetupEmitter) -> Result<bool> {
         let _ = sentryusb_shell::run("systemctl", &["disable", "nginx"]).await;
     }
 
-    // `/sbin/mount.ctts` — one-line wrapper that FUSE's mount helper
-    // protocol invokes via the `mount.ctts#` fstab syntax.
-    std::fs::write(
-        "/sbin/mount.ctts",
-        format!("#!/bin/bash -eu\n{} \"$@\" -o allow_other\n", CTTSERASER_BIN),
-    )?;
-    let _ = sentryusb_shell::run("chmod", &["+x", "/sbin/mount.ctts"]).await;
-
     // Source + target dirs.
     std::fs::create_dir_all("/mutable/TeslaCam")?;
     std::fs::create_dir_all("/var/www/html/TeslaCam")?;
 
-    // Replace any stale mount.ctts entry with the canonical one.
-    add_or_replace_fstab_ctts()?;
+    // Replace any legacy cttseraser entry with the bind-mount entry, then
+    // clear systemd's cached failed state so the unit activates immediately
+    // (without requiring a reboot on upgrade).
+    install_bind_mount_fstab()?;
+    let _ = sentryusb_shell::run("systemctl", &["daemon-reload"]).await;
+    let _ = sentryusb_shell::run(
+        "systemctl",
+        &["reset-failed", "var-www-html-TeslaCam.mount"],
+    ).await;
+    let _ = sentryusb_shell::run(
+        "systemctl",
+        &["start", "var-www-html-TeslaCam.mount"],
+    ).await;
 
-    // Allow non-root processes to traverse the FUSE mount. Without this
-    // even `read only = yes` Samba shares of /var/www/html/TeslaCam 403.
-    enable_user_allow_other()?;
+    // (Samba reads from /mutable/TeslaCam directly, so no FUSE allow_other
+    // configuration is required for it.)
 
     // Optional auto.www autofs for music/lightshow/boombox disk images.
     if Path::new("/backingfiles/music_disk.bin").exists()
@@ -103,61 +104,27 @@ pub async fn configure_web_mount(emitter: &SetupEmitter) -> Result<bool> {
     Ok(true)
 }
 
-/// Drop any existing `mount.ctts` fstab line and add the canonical one.
-fn add_or_replace_fstab_ctts() -> Result<()> {
-    const ENTRY: &str = "mount.ctts#/mutable/TeslaCam /var/www/html/TeslaCam fuse defaults,nofail,x-systemd.requires=/mutable 0 0";
+/// Strip any existing TeslaCam mount entry (legacy cttseraser or prior bind)
+/// from /etc/fstab and add the canonical bind-mount entry.
+fn install_bind_mount_fstab() -> Result<()> {
     let content = std::fs::read_to_string("/etc/fstab").unwrap_or_default();
     let kept: Vec<&str> = content
         .lines()
-        .filter(|l| !l.trim_start().starts_with("mount.ctts#"))
+        .filter(|l| {
+            let t = l.trim_start();
+            if t.starts_with('#') {
+                return true;
+            }
+            // Drop any existing line that targets /var/www/html/TeslaCam.
+            !l.contains("/var/www/html/TeslaCam")
+        })
         .collect();
     let mut new = kept.join("\n");
     if !new.is_empty() && !new.ends_with('\n') {
         new.push('\n');
     }
-    new.push_str(ENTRY);
+    new.push_str(FSTAB_BIND_LINE);
     new.push('\n');
     std::fs::write("/etc/fstab", new)?;
-    Ok(())
-}
-
-/// Uncomment `#user_allow_other` in /etc/fuse.conf, or add it if the line
-/// doesn't exist. Idempotent.
-fn enable_user_allow_other() -> Result<()> {
-    let path = "/etc/fuse.conf";
-    let existing = std::fs::read_to_string(path).unwrap_or_default();
-    if existing.lines().any(|l| l.trim() == "user_allow_other") {
-        return Ok(());
-    }
-
-    let mut found_commented = false;
-    let new: String = existing
-        .lines()
-        .map(|l| {
-            if l.trim_start() == "#user_allow_other" {
-                found_commented = true;
-                "user_allow_other".to_string()
-            } else {
-                l.to_string()
-            }
-        })
-        .collect::<Vec<_>>()
-        .join("\n");
-
-    let mut out = if found_commented {
-        new
-    } else {
-        // Append if the file exists but doesn't have the option at all.
-        let mut s = existing;
-        if !s.is_empty() && !s.ends_with('\n') {
-            s.push('\n');
-        }
-        s.push_str("user_allow_other");
-        s
-    };
-    if !out.ends_with('\n') {
-        out.push('\n');
-    }
-    std::fs::write(path, out)?;
     Ok(())
 }

--- a/crates/setup/src/runner.rs
+++ b/crates/setup/src/runner.rs
@@ -244,9 +244,9 @@ pub async fn run_full_setup(emitter: SetupEmitter) -> Result<()> {
     // readonly phase so /etc/auto.master.d is writable.
     crate::automount::configure_automount(&emitter).await?;
 
-    // TeslaCam FUSE mount wiring (cttseraser). Writes /sbin/mount.ctts,
-    // fstab entry, enables user_allow_other. Must run before readonly so
-    // /etc/fstab and /etc/fuse.conf are writable.
+    // TeslaCam bind-mount wiring. Writes /etc/fstab bind entry and
+    // activates var-www-html-TeslaCam.mount. Must run before readonly
+    // so /etc/fstab is still writable.
     crate::cttseraser_mount::configure_web_mount(&emitter).await?;
 
     // RTC.

--- a/install-pi.sh
+++ b/install-pi.sh
@@ -163,9 +163,9 @@ systemctl daemon-reload
 systemctl enable sentryusb
 ok "sentryusb.service installed and enabled"
 
-# ── Step 3b: cttseraser FUSE helper ────────────────────────────────
+# ── Step 3b: cttseraser (opt-in ctts stripper) ──────────────────────
 
-info "Installing cttseraser FUSE helper..."
+info "Installing cttseraser binary (opt-in ctts stripper)..."
 CTTS_INSTALL="$INSTALL_DIR/cttseraser"
 if [ -n "${1:-}" ] && [ -f "$(dirname "$1")/cttseraser" ]; then
     cp "$(dirname "$1")/cttseraser" "$CTTS_INSTALL"
@@ -177,7 +177,7 @@ else
         chmod +x "$CTTS_INSTALL"
         ok "cttseraser downloaded"
     else
-        warn "cttseraser binary not available — legacy FUSE feature disabled"
+        warn "cttseraser binary not available — opt-in ctts stripping unavailable"
     fi
 fi
 ln -sf "$CTTS_INSTALL" /usr/local/bin/cttseraser 2>/dev/null || true

--- a/pi-gen-sources/00-sentryusb-tweaks/00-packages
+++ b/pi-gen-sources/00-sentryusb-tweaks/00-packages
@@ -7,7 +7,6 @@ python3-pip
 nginx
 fcgiwrap
 libnginx-mod-http-fancyindex
-libfuse-dev
 exfatprogs
 ntpsec-ntpdig
 rsync

--- a/pi-gen-sources/00-sentryusb-tweaks/00-run.sh
+++ b/pi-gen-sources/00-sentryusb-tweaks/00-run.sh
@@ -135,15 +135,15 @@ for _tc_bin in tesla-control tesla-keygen; do
 done
 
 # ── Install cttseraser FUSE binary (TeslaCam ctts stripper) ──
-# build-image.sh drops the cross-compiled Rust binary under files/; the
-# runtime wiring (/sbin/mount.ctts, fstab entry, user_allow_other) happens
-# during the setup wizard. Without this block the image has the wrapper
-# but no binary behind it.
+# build-image.sh drops the cross-compiled Rust binary under files/ so it is
+# available as opt-in scaffolding; the setup wizard no longer activates it
+# by default (bind mount is used instead). Without this block, advanced
+# users who want ctts stripping would have no binary to manually mount.
 if [ -f "files/cttseraser" ]; then
     install -m 755 "files/cttseraser" "${ROOTFS_DIR}/opt/sentryusb/cttseraser"
     ln -sf /opt/sentryusb/cttseraser "${ROOTFS_DIR}/usr/local/bin/cttseraser"
 else
-    echo "WARNING: cttseraser binary not found in files/ — TeslaCam ctts fixup will be disabled"
+    echo "WARNING: cttseraser binary not found in files/ — opt-in ctts stripping unavailable"
 fi
 
 # ── Install remountfs_rw helper (needed by BLE daemon to save PIN on read-only rootfs) ──


### PR DESCRIPTION
## Problem

Two bugs in the TeslaCam HTTP serving path, both reliably reproducible. Captured live on a Radxa ROCK 4C+ running DietPi v10.3.3 + Linux 6.18.29 + Debian 13 + Rusty v2.6.x.

### Bug 1 — `var-www-html-TeslaCam.mount` fails on every cold boot

```
systemd[1]: Mounting var-www-html-TeslaCam.mount...
mount[481]: mount failed: Error calling mount() at "/var/www/html/TeslaCam":
            Invalid argument (os error 22)
systemd[1]: var-www-html-TeslaCam.mount: Mount process exited, code=exited, status=1/FAILURE
```

`os error 22` is `EINVAL`. The current fstab entry uses the legacy `helper#SOURCE` syntax:

```
mount.ctts#/mutable/TeslaCam /var/www/html/TeslaCam fuse defaults,nofail,x-systemd.requires=/mutable 0 0
```

`systemd-fstab-generator` translates this into a `.mount` unit that invokes `mount(2)` directly with `type="fuse"` and `source="mount.ctts#/mutable/TeslaCam"`. The kernel cannot dispatch FUSE helpers from a syscall — that's userspace `mount(8)`'s job — so it returns `EINVAL` and `/sbin/mount.ctts` is never invoked.

Result: `/var/www/html/TeslaCam` stays empty, every video URL 404s.

### Bug 2 — cttseraser returns ENOSYS on every symlink readlink

Once the mount is forced up manually, reads through it fail:

```
ERROR tower_http::services::fs::serve_dir: Failed to read file
error=Function not implemented (os error 38)
```

`os error 38` is `ENOSYS`. Reproducible at the shell:

```
$ ls -la /var/www/html/TeslaCam/RecentClips/2026-05-21/
ls: cannot read symbolic link '...front.mp4': Function not implemented
```

The snapshot tree at `/mutable/TeslaCam/` is composed of symlinks pointing into `/backingfiles/snapshots/snap-NNN/...`. `crates/cttseraser/src/main.rs:85,279` classifies these entries as `FileType::Symlink` via `symlink_metadata`, but the `Filesystem` trait impl never implements the `readlink` operation. The fuser crate's default returns `ENOSYS`, which propagates as `os error 38` to every consumer.

## First-principles analysis

cttseraser's only purpose is to strip the `ctts` (Composition Time to Sample) MP4 atom from Tesla's dashcam files. The atom is part of the standard MP4 spec; the stripping exists because some older browsers couldn't parse Tesla's specific encoding of it:

| Decoder | First clean `ctts` parsing | Released |
|---|---|---|
| Chromium / Chrome | v80 | Feb 2020 |
| Firefox | v70 | Oct 2019 |
| Safari (iOS) | iOS 13 | Sept 2019 |
| ExoPlayer (Android) | always | (handles natively) |

All shipping browsers in 2026 are 6+ years past the fix. The Pi only serves bytes; the browser does the decoding. The `ctts` stripping is no longer needed for the common case.

The right architectural fix is to bypass cttseraser entirely with a **kernel-level bind mount** of `/mutable/TeslaCam` → `/var/www/html/TeslaCam`. Tower-http's `ServeDir` uses `tokio::fs::File::open`, which follows symlinks natively through ext4. No FUSE userspace involved, no helper dispatch, no syscall games.

This change fixes both bugs:
- **No FUSE in the path** → no `readlink` ENOSYS
- **`none bind` fstab type** → kernel-recognized type, no helper dispatch needed → no EINVAL

## Empirical validation

Applied on a test Pi (Radxa ROCK 4C+) ~10 hours before this PR was written. Survived 1 cold reboot. Web UI in Chrome on Pixel 10 + browser scrubbing + multi-camera dynamic loading all work cleanly.

Active mount unit post-fix:
```
● var-www-html-TeslaCam.mount - /var/www/html/TeslaCam
     Loaded: loaded (/etc/fstab; generated)
     Active: active (mounted) since Fri 2026-05-22 02:00:02 UTC; 9h ago

$ findmnt /var/www/html/TeslaCam
TARGET                 SOURCE               FSTYPE OPTIONS
/var/www/html/TeslaCam /dev/sda1[/TeslaCam] ext4   rw,relatime,stripe=8191
```

HTTP smoke test:
```
$ curl -sI http://pi/TeslaCam/RecentClips/2026-05-21/<file>.mp4
HTTP/1.1 200 OK
content-type: video/mp4
accept-ranges: bytes
content-length: 36578646
```

Range request (the scrubbing critical path):
```
$ curl -sI -H "Range: bytes=0-99999" http://pi/TeslaCam/.../<file>.mp4
HTTP/1.1 206 Partial Content
content-range: bytes 0-99999/36578646
content-length: 100000
```

Throughput on a 36.5 MB clip, wired LAN: **31.16 MB/s** (249 Mbps), full file in 1.17 seconds. Output validates as `ISO Media, MP4 v2 [ISO 14496-14]`.

## Wins

- **Bug 1 fixed:** mount unit comes up cleanly on every boot
- **Bug 2 fixed:** symlinks resolve natively through ext4
- **Throughput:** kernel-level read with no userspace round-trip — 31 MB/s wired
- **RAM:** ~1-2 MB saved (cttseraser daemon process no longer running)
- **Code surface:** simpler install path, fewer moving parts
- **`fuse3` apt dep removed** from runtime install
- **`libfuse-dev` removed** from pi-gen pre-install (image is now FUSE-free unless cttseraser is opt-in)

## What we keep

- The `cttseraser` crate, binary build, install steps, and `/sbin/mount.ctts` helper all stay in place as opt-in scaffolding pending the maintainer's decision (see the open question at the bottom)
- The `/var/www/html/fs` autofs path (music/lightshow/boombox) is untouched

## What downstream code consumers see

All paths verified against the current Rusty codebase:

- `crates/api/src/clips.rs` reads from `/mutable/TeslaCam` directly via `TESLACAM_DIR` — unaffected
- `crates/api/src/files.rs` (`/api/files/download`) uses `ALLOWED_BASES` including `/mutable` — unaffected
- `crates/api/src/healthcheck.rs` checks `/mutable/TeslaCam` directly — unaffected
- `crates/setup/src/system.rs` Samba share path is `/mutable/TeslaCam` directly — unaffected
- `crates/sentryusb/src/main.rs` `ServeDir::new("/var/www/html/TeslaCam")` — now sees real files via the bind mount; symlinks followed natively by tokio

Only the file serving route (`/TeslaCam/*`) actually went through the FUSE mount. Everything else already bypassed it.

## Migration safety

Existing installs have a cached failed `.mount` unit that won't auto-clear until reboot. The PR explicitly calls:

```
systemctl daemon-reload                              # regenerate .mount unit from new fstab
systemctl reset-failed var-www-html-TeslaCam.mount   # clear cached failure
systemctl start var-www-html-TeslaCam.mount          # activate immediately
```

After upgrade, the mount activates without requiring a reboot. The legacy `mount.ctts#` fstab line is scrubbed during the same write.

The idempotency gate is updated to check for the new bind-mount line, not the old `mount.ctts#` line — so a second install run is a no-op as expected.

## Risk

Browsers older than ~2020 may show playback issues on Tesla MP4s if a user's environment is somehow constrained to them. Mitigation: cttseraser remains installed on disk; advanced users can re-enable it manually. (Note: cttseraser itself still has the `readlink` ENOSYS bug; if you want it to remain a viable opt-in, I can send a small follow-up PR fixing that — see the open question.) The default bind-mount path serves the majority case cleanly.

## Test plan

### 1. Apply on an existing install
```bash
sudo /opt/sentryusb/sentryusb-setup --run-phase web_mount
sudo systemctl status var-www-html-TeslaCam.mount   # Expected: Active: active (mounted)
sudo findmnt /var/www/html/TeslaCam                  # Expected: TARGET ... SOURCE /dev/<root>[/mutable/TeslaCam] ... bind
```

### 2. Smoke test the HTTP path
```bash
curl -sI http://localhost/TeslaCam/RecentClips/<date>/<file>.mp4
# Expected: HTTP/1.1 200 OK, content-type: video/mp4

curl -sI -H "Range: bytes=0-99999" http://localhost/TeslaCam/.../<file>.mp4
# Expected: HTTP/1.1 206 Partial Content, content-range: bytes 0-99999/<total>

curl -sI -H "Range: bytes=999999999999-" http://localhost/TeslaCam/.../<file>.mp4
# Expected: HTTP/1.1 416 Range Not Satisfiable
```

### 3. Cold reboot test
```bash
sudo reboot
sudo systemctl status var-www-html-TeslaCam.mount   # Expected: Active: active (mounted) (since BOOT TIME)
```

### 4. Browser test
- Open `http://<pi-host>/` in Chrome / Firefox / Safari
- Navigate to Recent → pick a clip → play, scrub
- Verify smooth playback + scrubbing

### 5. Migration test (existing install with the legacy line)
```bash
sudo bash -c 'echo "mount.ctts#/mutable/TeslaCam /var/www/html/TeslaCam fuse defaults,nofail,x-systemd.requires=/mutable 0 0" >> /etc/fstab'
sudo systemctl daemon-reload
sudo /opt/sentryusb/sentryusb-setup --run-phase web_mount

grep -n "TeslaCam" /etc/fstab
# Expected: ONE line, the bind entry. No "mount.ctts#" line.

sudo systemctl is-active var-www-html-TeslaCam.mount
# Expected: active
```

### 6. Throughput sanity check
```bash
time curl -o /dev/null http://localhost/TeslaCam/.../<largeclip>.mp4
# On Pi 4B with wired GbE: expect >100 MB/s
# On Pi Zero 2W (100 Mbit): expect ~10-11 MB/s
```

## Cross-SBC verification

The fix touches no SBC-specific code. The `none bind` mount type is supported across every Linux kernel ≥ 2.4 (released 2001), and `systemd-fstab-generator` has handled `none bind` correctly since systemd 209 (2014).

| SBC | Minimum kernel | Minimum systemd |
|---|---|---|
| Pi 4B, Pi 5 | 6.x | 252+ |
| Pi 3B+, Pi 3A+ | 6.x | 252+ |
| Pi Zero 2W | 6.x | 252+ |
| Rock 4C+ | 6.x | 252+ |
| Radxa Zero 3W | 6.x | 252+ |
| NanoPi R76S | 6.x | 252+ |

No risk of platform-specific regression.

## Open question for the maintainer

This PR removes cttseraser from the default serving path but leaves the crate, binary build steps, install steps, and `/sbin/mount.ctts` helper in place. **Do you want cttseraser to stay or to go?**

- **Stay** — the binary remains installed as opt-in scaffolding for users who want `ctts` stripping. I'll send a small follow-up PR fixing the `readlink` ENOSYS so it's actually usable (currently broken — same bug this PR sidesteps in the default path).
- **Go** — I'll send a follow-up PR removing the crate, build, install, and helper script. Modern browsers (Chrome 80+, Firefox 70+, Safari iOS 13+, ExoPlayer) all handle `ctts` natively in 2026, and the Pi only serves bytes — the client does the decoding — so the binary has no current purpose on any shipping platform.

Either way, this PR stands on its own. Just let me know your preference and I'll send the follow-up.