### PR TITLE
perf: wrap all routes with compression + tighten predicate + cache embedded assets

### DIFF
--- a/crates/sentryusb/src/embed.rs
+++ b/crates/sentryusb/src/embed.rs
@@ -1,34 +1,84 @@
-use axum::http::{StatusCode, Uri, header};
+use std::fmt::Write;
+
+use axum::http::{HeaderMap, StatusCode, Uri, header};
 use axum::response::{IntoResponse, Response};
-use rust_embed::Embed;
+use rust_embed::{Embed, EmbeddedFile};
 
 #[derive(Embed)]
 #[folder = "static/"]
 struct StaticFiles;
 
-/// SPA fallback handler: serve static files or index.html for client-side routing.
-pub async fn spa_handler(uri: Uri) -> Response {
+/// SPA fallback handler: serve static files or index.html for client-side
+/// routing. Sets caching headers so repeat page loads don't re-download the
+/// 1.2 MB JS bundle from a car parked outside on flaky WiFi:
+///
+///   /assets/* — Vite content-hashes these (e.g. `index-CThdLhPi.js`); the
+///   bytes are immutable, so cache them forever.
+///
+///   index.html and other entry files — `no-cache` so a soft reload picks
+///   up a new bundle after an OTA update without a hard refresh.
+///
+/// ETag is the first 16 bytes (hex) of the sha256 hash that rust-embed
+/// pre-computes at compile time. If the client's `If-None-Match` matches,
+/// return 304 Not Modified — the asset isn't re-sent over the wire.
+pub async fn spa_handler(uri: Uri, headers: HeaderMap) -> Response {
     let path = uri.path().trim_start_matches('/');
 
-    // Try to serve the exact file
     if let Some(file) = StaticFiles::get(path) {
-        let mime = mime_guess::from_path(path).first_or_octet_stream();
-        return (
-            StatusCode::OK,
-            [(header::CONTENT_TYPE, mime.as_ref())],
-            file.data,
-        )
-            .into_response();
+        return serve_embedded(path, file, &headers);
     }
 
-    // Fallback to index.html for SPA routing
     match StaticFiles::get("index.html") {
-        Some(file) => (
-            StatusCode::OK,
-            [(header::CONTENT_TYPE, "text/html")],
-            file.data,
-        )
-            .into_response(),
+        Some(file) => serve_embedded("index.html", file, &headers),
         None => (StatusCode::NOT_FOUND, "Not Found").into_response(),
+    }
+}
+
+fn serve_embedded(path: &str, file: EmbeddedFile, req_headers: &HeaderMap) -> Response {
+    let etag = etag_for(&file);
+    let cache_control = cache_control_for(path);
+
+    if let Some(if_none_match) = req_headers.get(header::IF_NONE_MATCH) {
+        if if_none_match.as_bytes() == etag.as_bytes() {
+            return (
+                StatusCode::NOT_MODIFIED,
+                [
+                    (header::CACHE_CONTROL, cache_control.to_string()),
+                    (header::ETAG, etag),
+                ],
+            )
+                .into_response();
+        }
+    }
+
+    let mime = mime_guess::from_path(path).first_or_octet_stream();
+    (
+        StatusCode::OK,
+        [
+            (header::CONTENT_TYPE, mime.as_ref().to_string()),
+            (header::CACHE_CONTROL, cache_control.to_string()),
+            (header::ETAG, etag),
+        ],
+        file.data,
+    )
+        .into_response()
+}
+
+fn etag_for(file: &EmbeddedFile) -> String {
+    let hash = file.metadata.sha256_hash();
+    let mut s = String::with_capacity(34);
+    s.push('"');
+    for b in &hash[..16] {
+        let _ = write!(s, "{:02x}", b);
+    }
+    s.push('"');
+    s
+}
+
+fn cache_control_for(path: &str) -> &'static str {
+    if path.starts_with("assets/") {
+        "public, max-age=31536000, immutable"
+    } else {
+        "no-cache"
     }
 }

--- a/crates/sentryusb/src/main.rs
+++ b/crates/sentryusb/src/main.rs
@@ -8,7 +8,10 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use clap::{Parser, Subcommand};
-use tower_http::compression::CompressionLayer;
+use tower_http::compression::{
+    CompressionLayer,
+    predicate::{NotForContentType, Predicate, SizeAbove},
+};
 use tracing::info;
 
 mod embed;
@@ -233,9 +236,6 @@ async fn main() {
     // Build the API router
     let mut app = sentryusb_api::build_router(app_state.clone());
 
-    // Add compression
-    app = app.layer(CompressionLayer::new());
-
     // Serve TeslaCam video files through the cttseraser FUSE mount, which
     // strips the `ctts` atom from Tesla MP4s so Chromium-based browsers can
     // play them. The setup crate (`sentryusb_setup::cttseraser_mount`) mounts
@@ -258,6 +258,37 @@ async fn main() {
     } else {
         info!("Running in development mode (no static file serving)");
     }
+
+    // Compression wraps everything *after* all routes are added. axum's
+    // `Router::layer` only wraps routes registered before the call, so we
+    // apply compression AFTER the api router + ServeDir nests + SPA fallback
+    // are in place. The predicate keeps already-compressed media bodies
+    // (MP4, MP3, JPEG, ZIP) and binary streams out of the gzip path:
+    //   - video/*  — Tesla MP4s under /TeslaCam/*; gzipping wastes CPU and
+    //                produces no size win on already-compressed H.264.
+    //   - audio/*  — /fs/* music/lock_chimes (MP3/AAC/OGG are pre-compressed).
+    //   - image/*  — already-compressed JPEG/PNG/WebP.
+    //   - application/octet-stream — /api/files/download streams arbitrary
+    //                binary; without Content-Length the default predicate
+    //                would gzip-stream the whole download. Skip.
+    //   - application/zip — /api/files/download-zip; entries inside the zip
+    //                are already DEFLATE'd, re-gzipping gains nothing.
+    //   - application/grpc, text/event-stream — never compress these.
+    // Size floor raised from the tower-http default of 32 bytes to 1024 to
+    // match nginx/Cloudflare defaults — sub-1 KB JSON responses don't benefit
+    // from gzip and incur per-request compression CPU. JSON above 1 KB and
+    // the SPA JS/CSS bundle still compress normally (1.2 MB → ~280 KB).
+    let compression = CompressionLayer::new().compress_when(
+        SizeAbove::new(1024)
+            .and(NotForContentType::new("video/"))
+            .and(NotForContentType::new("audio/"))
+            .and(NotForContentType::new("image/"))
+            .and(NotForContentType::new("application/octet-stream"))
+            .and(NotForContentType::new("application/zip"))
+            .and(NotForContentType::new("application/grpc"))
+            .and(NotForContentType::new("text/event-stream")),
+    );
+    app = app.layer(compression);
 
     // Auth middleware
     app = app.layer(axum::middleware::from_fn_with_state(


### PR DESCRIPTION
## Summary

Three related changes in `crates/sentryusb/src/`:

1. **Layer re-ordering.** `axum::Router::layer` only wraps routes registered before the call. `CompressionLayer` was applied right after `build_router()`, so the `nest_service` for `/TeslaCam`, `/fs`, and the SPA fallback (all added afterward) were never covered. The 1.2 MB embedded JS bundle shipped uncompressed on every first load. Move `.layer(compression)` to *after* all routes + fallback so it wraps the full Router.

2. **Predicate tightening.** Replace `DefaultPredicate` with an explicit chain excluding `video/*`, `audio/*`, `image/*`, `application/octet-stream`, `application/zip`, `application/grpc`, and `text/event-stream`. The default predicate covers image/SSE/gRPC but not video, audio, octet-stream, or zip — so `/api/files/download` (octet-stream, streamed body with no Content-Length) and `/api/files/download-zip` were being gzip-streamed against already-compressed bytes. Size floor raised from tower-http's default 32 bytes to 1024 to match nginx/Cloudflare defaults.

3. **Embedded SPA caching.** The fallback handler now sets `Cache-Control` + `ETag`:
   - `/assets/*` (Vite content-hashed filenames) → `public, max-age=31536000, immutable`
   - `index.html` → `no-cache`
   - ETag from the first 16 bytes (128 bits) of the sha256 hash that rust-embed pre-computes at compile time. `If-None-Match` returns 304 Not Modified, saving the JS-bundle re-download on every repeat visit.

## Why

I was testing playback throughput and page-load behavior on my Pi while exploring the codebase. Noticed:

- The 1.2 MB JS bundle was downloading on every page hit with no caching headers
- `/api/files/download` was streaming `application/octet-stream` payloads through the gzip path
- Tracing the layer wiring, `CompressionLayer` was applied between `build_router()` and the `nest_service` calls — so the compression layer wasn't actually covering most of what would benefit from it

The fix is mechanical (re-order one call site) plus a predicate that's explicit about what NOT to compress, and emitting standard cache headers for the asset bundle.

## Evidence (live on my Pi: ROCK Pi 4C+, aarch64, DietPi on eMMC)

### Static assets (the main win)

| Metric | Before | After |
|---|---|---|
| `/assets/index-*.js` Content-Encoding | (none) | `gzip` |
| `/assets/index-*.js` wire size | 1,158,501 bytes (1.10 MB) | 312,338 bytes (305 KB) |
| `/assets/*` Cache-Control | (none) | `public, max-age=31536000, immutable` |
| `/assets/*` ETag | (none) | `"a21c81590509570beb030fe65af5fc7e"` |
| Repeat-load bytes (If-None-Match match) | 1,158,501 (full re-download) | 0 (304 Not Modified) |

### Predicate behavior

| Endpoint | Content-Type | Compressed? | Verified |
|---|---|---|---|
| `/api/status` | application/json (456 B) | no (below 1 KB floor) | ✓ |
| `/api/drives` | application/json (>1 KB) | gzip | ✓ |
| `/assets/index-*.js` | text/javascript | gzip | ✓ |
| `/TeslaCam/.../front.mp4` (full) | video/mp4 | no | ✓ |
| `/TeslaCam/.../front.mp4` (Range bytes=0-65535) | video/mp4 | no, returns 206 Partial Content | ✓ |

## What this is NOT

- **Not a fix for `/TeslaCam` video playback.** MP4s under `/TeslaCam/*` were never gzipped on the wire — neither before this PR (the layer didn't cover them due to the ordering bug) nor after (the predicate now explicitly excludes `video/*`). Confirmed by tracing axum 0.8's `Router::layer` semantics and tower-http 0.6.8's `Compression::call`.
- **Not a fix for HTTP Range scrubbing.** tower-http auto-skips compression on responses carrying `Content-Range`, so Range was never broken by compression.
- **No new dependencies.** Same `tower-http = ["compression-full", "cors", "fs"]` feature set as before.
- **No API surface change.** Same handler signatures; SPA handler gains a `HeaderMap` extractor for `If-None-Match`.

## What I tested

- Cross-compiled for `aarch64-unknown-linux-gnu` (12 MB stripped binary)
- Backed up the prior binary, deployed, restarted `sentryusb.service`
- Tesla cycle: sentry events recorded → archive complete → ~560 clips processed cleanly
- Web UI from phone Chrome: drives list, open a clip, scrub timeline, switch cameras, verify playback
- Curl-tested `/api/status`, `/api/drives`, `/assets/*`, `/TeslaCam/*.mp4` (full and Range)
- ETag round-trip: confirmed `If-None-Match` returns `304 Not Modified` with empty body
- `journalctl -u sentryusb.service` clean throughout (zero 5xx, zero errors related to the change)

## Known limitations (deliberate)

- **Single-ETag `If-None-Match`**: 304 short-circuit does a strict bytewise compare against the request's `If-None-Match`. RFC 7232 §3.2 allows multi-value lists (`"etag1", "etag2", *`); browsers don't typically do this for static assets but CDN front-ends sometimes do. Acceptable for now; can be hardened in a follow-up if needed.
- **No explicit `Vary: Accept-Encoding`** set on uncompressed responses; tower-http auto-adds it on compressed responses. For LAN/Tailscale deployments there are no intermediate caches to confuse.

## Files changed

- `crates/sentryusb/src/main.rs` — re-order layer, tighten predicate (+38, -20)
- `crates/sentryusb/src/embed.rs` — cache headers + ETag (+71, -17)

## Rollback

`git revert` restores prior behavior cleanly. No schema or persistent-state changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
