### PR TITLE
perf: stop blocking tokio workers with sync std::process calls

### DIFF
--- a/crates/api/src/notifications.rs
+++ b/crates/api/src/notifications.rs
@@ -305,8 +305,9 @@ async fn register_code_with_backend(
     creds: &NotificationCredentials,
     code: &str,
 ) -> Result<(), String> {
-    let hostname = std::process::Command::new("hostname")
+    let hostname = tokio::process::Command::new("hostname")
         .output()
+        .await
         .ok()
         .and_then(|o| String::from_utf8(o.stdout).ok())
         .map(|s| s.trim().to_string())

--- a/crates/api/src/setup.rs
+++ b/crates/api/src/setup.rs
@@ -193,8 +193,9 @@ fn spawn_setup(hub: sentryusb_ws::Hub) {
                 let line = format!("ERROR: setup failed: {:#}", e);
                 let stamped = format!(
                     "{} : {}",
-                    std::process::Command::new("date")
+                    tokio::process::Command::new("date")
                         .output()
+                        .await
                         .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
                         .unwrap_or_else(|_| "???".to_string()),
                     line,

--- a/crates/api/src/status.rs
+++ b/crates/api/src/status.rs
@@ -247,11 +247,17 @@ struct StorageBreakdown {
 pub async fn get_storage_breakdown(
     State(_state): State<AppState>,
 ) -> (StatusCode, Json<serde_json::Value>) {
+    let (cam, music, lightshow, boombox) = tokio::join!(
+        disk_usage("/backingfiles/cam_disk.bin"),
+        disk_usage("/backingfiles/music_disk.bin"),
+        disk_usage("/backingfiles/lightshow_disk.bin"),
+        disk_usage("/backingfiles/boombox_disk.bin"),
+    );
     let mut sb = StorageBreakdown {
-        cam_size: disk_usage("/backingfiles/cam_disk.bin"),
-        music_size: disk_usage("/backingfiles/music_disk.bin"),
-        lightshow_size: disk_usage("/backingfiles/lightshow_disk.bin"),
-        boombox_size: disk_usage("/backingfiles/boombox_disk.bin"),
+        cam_size: cam,
+        music_size: music,
+        lightshow_size: lightshow,
+        boombox_size: boombox,
         snapshots_size: 0,
         total_space: 0,
         free_space: 0,
@@ -523,12 +529,15 @@ fn iface_is_up(dev: &str) -> bool {
         .unwrap_or(false)
 }
 
-fn disk_usage(path: &str) -> i64 {
+async fn disk_usage(path: &str) -> i64 {
     // On Linux, use stat to get st_blocks * 512 for actual disk usage
-    // (handles sparse files and reflink copies correctly)
-    if let Ok(out) = std::process::Command::new("stat")
+    // (handles sparse files and reflink copies correctly).
+    // Async to avoid blocking the tokio worker thread on /api/status
+    // polls — hit ~every 15 s by the SC companion app per device.
+    if let Ok(out) = tokio::process::Command::new("stat")
         .args(["--format=%b", path])
         .output()
+        .await
     {
         if out.status.success() {
             let s = String::from_utf8_lossy(&out.stdout);

--- a/crates/cloud_uploader/src/pairing.rs
+++ b/crates/cloud_uploader/src/pairing.rs
@@ -219,11 +219,9 @@ pub fn pi_metadata() -> serde_json::Value {
         })
         .unwrap_or_else(|| "sentryusb".to_string());
 
-    let kernel = std::process::Command::new("uname")
-        .arg("-r")
-        .output()
-        .ok()
-        .and_then(|o| String::from_utf8(o.stdout).ok())
+    // /proc/sys/kernel/osrelease is the same string `uname -r` prints,
+    // kernel-resident, no subprocess fork.
+    let kernel = std::fs::read_to_string("/proc/sys/kernel/osrelease")
         .map(|s| s.trim().to_string())
         .unwrap_or_default();
 


### PR DESCRIPTION
## Summary

Four sites in async contexts were calling `std::process::Command::output()` synchronously, parking the tokio worker thread for each fork+exec+wait. None is hot enough to matter alone, but the cumulative effect under SC's 15-second status polling is non-trivial.

## Changes

- **`crates/api/src/status.rs::disk_usage`** — `stat --format=%b` on four backing-disk paths per `/api/status/storage` poll. Converted to async + **parallelized the four calls via `tokio::join!`**. Hottest of the four sites — every SC client hits this every 15s.

- **`crates/api/src/notifications.rs::register_code_with_backend`** — `hostname` during push pairing. Cold path, trivial fix.

- **`crates/api/src/setup.rs`** — `date` in the setup-error logging arm. Cold path, async match arm.

- **`crates/cloud_uploader/src/pairing.rs::pi_metadata`** — `uname -r`. The caller chain is sync (`pi_metadata()` is sync, called from `CloudClient::new` etc), so converting to `tokio::process` would ripple through the public API. Replaced with a direct read of `/proc/sys/kernel/osrelease` — kernel-resident, no subprocess at all, returns the identical string `uname -r` prints.

## Compatibility

No wire-format changes. Same `cam_size`/`music_size`/`hostname`/`kernel` JSON fields, just produced without blocking tokio worker threads.

## Validation — live on Rock Pi 4C+

- 20 cycles of `/api/status` + `/api/status/storage` every 15s (mimicking SC poll loop): zero errors, RSS bounded
- 100 concurrent `/api/status/storage` burst: handled cleanly
- Manual phone tests with SC (drive list refresh, map tiles, health check): all good
- `/api/drives` continues returning full payload (~100 KB for ~150 drives)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
