### PR TITLE
perf(drives): reuse path buffer + skip date String alloc in ingest loop

### DIFF
--- a/crates/drives/src/processor.rs
+++ b/crates/drives/src/processor.rs
@@ -149,6 +149,11 @@ impl Processor {
             "total": total,
         }));
 
+        // Reused across iterations to avoid one String alloc per clip.
+        // Cap matches typical relative path lengths so most clips don't
+        // trigger a realloc inside the push loop.
+        let mut full_path = String::with_capacity(self.clip_dir.len() + 128);
+
         for (i, file) in unprocessed.iter().enumerate() {
             {
                 let mut status = self.status.lock().await;
@@ -156,9 +161,15 @@ impl Processor {
                 status.processed_files = i;
             }
 
-            // Extract GPS from the file.
-            let full_path = format!("{}/{}", self.clip_dir, file);
-            let date = file.split('/').next().unwrap_or("").to_string();
+            // Build the full path into the reused buffer.
+            full_path.clear();
+            full_path.push_str(&self.clip_dir);
+            full_path.push('/');
+            full_path.push_str(file);
+
+            // `add_route` accepts `date_dir: &str` — no need to materialize
+            // an owned String just to take a slice of it.
+            let date: &str = file.split('/').next().unwrap_or("");
             match extract::extract_gps_from_file(&full_path) {
                 Ok(gps) => {
                     if !gps.points.is_empty() {
@@ -169,7 +180,7 @@ impl Processor {
                     // transaction per clip — durable on return.
                     match self.store.add_route(
                         file,
-                        &date,
+                        date,
                         &gps.points,
                         &gps.gear_states,
                         &gps.autopilot_states,


### PR DESCRIPTION
## Summary

Two small allocation wins in the per-clip ingest loop in `crates/drives/src/processor.rs::do_process`. With ~50 clips per Tesla recording cycle these add up modestly; the win compounds on `Reprocess All` sweeps which hit ~2000 clips in a single pass.

1. **`full_path` reuse.** Was `let full_path = format!("{}/{}", self.clip_dir, file)` — a fresh `String` allocation per clip. Now allocated once outside the loop with capacity hinting, `.clear()`-ed and rebuilt via `push_str` each iteration. One alloc per ingest sweep instead of N.

2. **Drop `.to_string()` on `date`.** Was materialized as an owned `String` solely to pass `&date` to `add_route(date_dir: &str, ...)`. `add_route` already accepts a `&str`, so we pass the slice directly from `file.split('/').next()` without the round-trip through an owned `String`.

No public-API change, no wire-format change. Identical bytes go into `extract_gps_from_file` and identical date prefix goes into `add_route`.

## Scope choice

The earlier `add_route` audit identified a bigger refactor — eliminate the `Route` struct construction in `add_route` itself (saves ~8 allocations per clip) — but doing it requires reshaping `compute_route_aggregates` to accept slices, which is the documented "single source of truth" for per-clip scalars and has 5 test callers plus the backfill code consuming it. That refactor deserves its own focused PR with proper test coverage rather than being lumped in here. Filing as a follow-up.

## Compatibility

- **No public-API change.**
- **No wire-format change.**
- **No new dependencies.**

## What I tested

- `cargo test --workspace` — all 168 tests pass (drives crate: 79 tests).
- Cross-compiled `aarch64-unknown-linux-gnu`, deployed to Rock Pi 4C+ stacked with other open perf PRs.
- **8-hour soak** with 4+ archiveloop cycles firing through the ingest path on real Tesla clips. Zero errors, no panics, no `add_route` failures, drive count stable.
- `Reprocess All` validated earlier in the same Pi via the PR 2 (#15) test pass — 641 clips through the ingest path, zero issues.

## Files

- `crates/drives/src/processor.rs` — `full_path: String` lifted out of the loop with capacity hint; `date` becomes `&str`; `add_route` call passes the slice instead of `&date` (+15 / -4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
