### PR TITLE
perf(notify): reuse a process-wide reqwest::Client across sentry events

### DIFF
--- a/crates/notify/src/lib.rs
+++ b/crates/notify/src/lib.rs
@@ -220,15 +220,33 @@ pub async fn send_to_all(
 /// notifications. Passes the extra context through to providers that
 /// can use it (currently just Sentry Connect); others ignore the extras
 /// and use title + message.
+/// Process-wide shared client for outbound notification dispatches.
+/// Built once on first send; reused for the lifetime of the process so
+/// we don't repeatedly stand up a fresh TLS pool + DNS cache + idle
+/// connection pool per sentry event.
+static NOTIFY_CLIENT: std::sync::OnceLock<reqwest::Client> = std::sync::OnceLock::new();
+
+fn notify_client() -> &'static reqwest::Client {
+    NOTIFY_CLIENT.get_or_init(|| {
+        // Panic-on-error rather than fall back to `Client::default()`: the
+        // default builder discards our 30s/10s timeouts, so a TLS init
+        // failure would silently produce a no-timeout client that can
+        // hang a tokio worker indefinitely on a misconfigured push
+        // endpoint. Failing loudly at first send surfaces the real
+        // problem instead of pretending notifications still work.
+        reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .connect_timeout(std::time::Duration::from_secs(10))
+            .build()
+            .expect("reqwest Client::build failed (TLS init?)")
+    })
+}
+
 pub async fn send_to_all_with_context(
     config: &NotifyConfig,
     req: &NotifyRequest<'_>,
 ) -> Vec<(String, Result<()>)> {
-    let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(30))
-        .connect_timeout(std::time::Duration::from_secs(10))
-        .build()
-        .unwrap_or_default();
+    let client = notify_client();
 
     let title = req.title;
     let message = req.message;


### PR DESCRIPTION
## Summary

The notify dispatch path was rebuilding a fresh `reqwest::Client` on every call to `send_to_all_with_context` — once per sentry event sent. Each build stands up a TLS pool, DNS cache, and idle-connection pool, all of which are immediately torn down at the end of the function. On a Pi recording continuously, this is the hottest outbound-HTTP path.

Cache the client in a `static OnceLock<reqwest::Client>` so the first event pays the construction cost (timeouts unchanged: 30s request, 10s connect) and every subsequent event reuses it. Zero per-event client construction, warm connection pools to the notification backends, faster dispatch latency.

The auto-deref of `&'static reqwest::Client` is the same shape every reqwest-using provider already expects (`&reqwest::Client`) — verified by reading the signatures of the reqwest-using providers (`pushover`, `discord`, `telegram`, `slack`, `gotify`, `ntfy`, `ifttt`, `webhook`, `signal`, `matrix`, plus the in-tree sentry-connect path). The `sns` provider uses the AWS SDK directly and doesn't take a client parameter, so it's unaffected by this change. No call-site changes.

## Why fail loudly on build error

The `.build()` call uses `.expect("reqwest Client::build failed (TLS init?)")` rather than `unwrap_or_default()`. A silent fallback to `Client::default()` would discard the configured 30s/10s timeouts, so a TLS misconfiguration on the Pi would silently produce a no-timeout client that can hang a tokio worker indefinitely on a misbehaving push endpoint. Failing loudly at first send surfaces the real problem.

## Scope choice (smaller than the audit suggested)

The original audit for PR 3 identified ~20 additional `reqwest::Client::builder()` sites across `community.rs`, `support.rs`, `update.rs`, and `notifications.rs` that could all be plumbed through a shared `Arc<reqwest::Client>` on `AppState`. Those sites are all user-gesture-triggered cold paths — community proxy round-trips, support ticket sends, manual update checks. Their per-call client construction cost is dwarfed by the user-perceived gesture latency anyway.

Doing the AppState surgery for those 20 sites is a larger refactor than the hot-path win justifies, so I scoped this PR to just `send_to_all_with_context` — the one path that fires per sentry event. The cold sites can be revisited in a future PR if anyone ever profiles a slow community round-trip.

## Compatibility

- **No public-API change** — `send_to_all_with_context` signature unchanged.
- **No wire-format change** — same outbound HTTP requests with same timeouts.
- **No new dependencies.**

## What I tested

- `cargo test --workspace` — all 168 tests pass.
- Cross-compiled `aarch64-unknown-linux-gnu`, deployed to Rock Pi 4C+ stacked with other open perf PRs.
- **8-hour soak**: 3 Mobile Push notifications dispatched in the final minute window of the soak (`May 23 18:22:04 / 18:22:38 / 18:23:27 UTC`), all logged "sent successfully". The cached client survived the full uptime — no rebuild fired during steady-state operation.

## Files

- `crates/notify/src/lib.rs` — `static NOTIFY_CLIENT: OnceLock<reqwest::Client>` + `notify_client()` helper; `send_to_all_with_context` now calls `notify_client()` instead of building per-call (+23 / -5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
