### PR TITLE
fix(systemd): source sentryusb.conf via bash, not EnvironmentFile=

### DIFF
--- a/server/ble/sentryusb-telemetry.service
+++ b/server/ble/sentryusb-telemetry.service
@@ -30,9 +30,17 @@ ExecStartPre=-/bin/bash -c 'f=/tmp/ble_radio_owner; if [ -e "$f" ] && [ "$(head 
 # inside the daemon's env. The Rust code re-reads on each iteration,
 # but seeding the initial env here makes the systemd status output
 # show the active VIN.
-EnvironmentFile=-/root/sentryusb.conf
-EnvironmentFile=-/boot/firmware/sentryusb.conf
-ExecStart=/root/bin/sentryusb-tesla-telemetry
+#
+# We can't use systemd's `EnvironmentFile=` directive: its parser only
+# accepts bare `KEY=value` and silently rejects every line starting
+# with `export KEY=value`. The user-facing /root/sentryusb.conf is
+# bash-style (archiveloop and other legacy shell scripts source it
+# directly), so EnvironmentFile= leaves the daemon with an empty env.
+#
+# Source via bash instead: `set -a` auto-exports every var sourced,
+# `source` understands `export` as a no-op when sourcing, and `exec`
+# swaps to the binary so systemd's PID tracking still works.
+ExecStart=/bin/bash -c 'set -a; source /root/sentryusb.conf 2>/dev/null; source /boot/firmware/sentryusb.conf 2>/dev/null; set +a; exec /root/bin/sentryusb-tesla-telemetry'
 Restart=always
 RestartSec=10
 StandardOutput=journal


### PR DESCRIPTION
## What's broken

`sentryusb-telemetry.service` uses two `EnvironmentFile=` directives to seed `TESLA_BLE_VIN` etc. into the daemon's env. systemd's parser only accepts bare `KEY=value`, but `/root/sentryusb.conf` is bash-style (`export KEY=value`) because archiveloop and other legacy shell scripts source it directly. Result, repeated for every line in the conf, every service restart:

```
sentryusb-telemetry.service: Ignoring invalid environment assignment 'export TESLA_BLE_VIN=...': /root/sentryusb.conf
```

The sampler binary then starts with no env vars. It survives because `sentryusb_config::parse_file()` handles `export` correctly when reading the conf directly, but combined with `StartLimitBurst=20 / StartLimitIntervalSec=120` the restart cycling can leave the unit `inactive (dead)`. Drives ingested while the service is down have zero telemetry attached (no `battery_pct_start`, `odometer_mi`, `tire_*_psi`, `interior_temp_c`, `exterior_temp_c`, `hvac_on`, `location_name`).

## Repro

On a Rock Pi 4C+ running v2.9.3 with a freshly paired Tesla:
- Before patch: `sentryusb-telemetry.service` shows `inactive (dead)`, journal full of "Ignoring invalid environment assignment" warnings. Drive 153 (ingested fresh, 6.91mi, 29 clips) had zero telemetry fields.
- After patch: service stays active, `body-controller poll: ok(2785ms)` fires within 3s of start, `systemctl status` shows the populated VIN.

## Fix

Replace the two `EnvironmentFile=` lines with an `ExecStart` that bash-sources both conf paths.

- `set -a` — auto-export every variable sourced
- `source FILE` — evaluate bash syntax (the `export` keyword is a no-op when sourcing)
- `2>/dev/null` — silent if the file is absent (matches `EnvironmentFile=-`'s tolerance)
- `exec ...` — swap to the binary so systemd PID tracking still works

Conf file format is unchanged. Archiveloop and other shell consumers continue to source it normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)