### PR TITLE
Honour TEMPERATURE_UNIT in notifications + health check

### DIFF
--- a/crates/api/src/healthcheck.rs
+++ b/crates/api/src/healthcheck.rs
@@ -37,6 +37,30 @@ fn item(name: &str, status: &'static str, detail: Option<String>) -> HealthItem 
 pub async fn health_check(State(_s): State<AppState>) -> (StatusCode, Json<serde_json::Value>) {
     let mut categories: Vec<HealthCategory> = Vec::new();
 
+    // ── Config (needed early for temperature display unit) ────────────────
+    let active_cfg: std::collections::HashMap<String, String> =
+        sentryusb_config::parse_file(sentryusb_config::find_config_path())
+            .map(|(active, _commented)| active)
+            .unwrap_or_default();
+
+    let use_f = active_cfg
+        .get("TEMPERATURE_UNIT")
+        .map_or(false, |v| v.eq_ignore_ascii_case("F"));
+    let fmt_temp = |celsius: f64| -> String {
+        if use_f {
+            format!("{:.1}°F", celsius * 9.0 / 5.0 + 32.0)
+        } else {
+            format!("{:.1}°C", celsius)
+        }
+    };
+    let fmt_threshold = |celsius: f64| -> String {
+        if use_f {
+            format!("{:.0}°F", celsius * 9.0 / 5.0 + 32.0)
+        } else {
+            format!("{:.0}°C", celsius)
+        }
+    };
+
     // ── Hardware ──────────────────────────────────────────────────────────
     let mut hw = Vec::new();
     let mut cpu_temp_val: Option<f64> = None;
@@ -46,14 +70,22 @@ pub async fn health_check(State(_s): State<AppState>) -> (StatusCode, Json<serde
         }
     }
     match cpu_temp_val {
-        Some(t) if t >= 80.0 => hw.push(item("CPU temperature", "fail", Some(format!("{:.1}°C (>80°C)", t)))),
-        Some(t) if t >= 70.0 => hw.push(item("CPU temperature", "warn", Some(format!("{:.1}°C", t)))),
-        Some(t) => hw.push(item("CPU temperature", "pass", Some(format!("{:.1}°C", t)))),
-        None => hw.push(item("CPU temperature", "warn", Some("unavailable".to_string()))),
+        Some(t) if t >= 80.0 => hw.push(item("CPU temperature", "fail",
+            Some(format!("{} (>{})", fmt_temp(t), fmt_threshold(80.0))))),
+        Some(t) if t >= 70.0 => hw.push(item("CPU temperature", "warn",
+            Some(fmt_temp(t)))),
+        Some(t) => hw.push(item("CPU temperature", "pass",
+            Some(fmt_temp(t)))),
+        None => hw.push(item("CPU temperature", "warn",
+            Some("unavailable".to_string()))),
     }
     if let Ok(out) = sentryusb_shell::run("vcgencmd", &["measure_temp"]).await {
-        let s = out.trim().trim_start_matches("temp=").trim_end_matches("'C").to_string();
-        hw.push(item("GPU temperature", "pass", Some(s)));
+        let raw = out.trim().trim_start_matches("temp=").trim_end_matches("'C");
+        let detail = match raw.parse::<f64>() {
+            Ok(celsius) => fmt_temp(celsius),
+            Err(_) => raw.to_string(),
+        };
+        hw.push(item("GPU temperature", "pass", Some(detail)));
     }
     // Throttling
     if let Ok(out) = sentryusb_shell::run("vcgencmd", &["get_throttled"]).await {
@@ -116,14 +148,9 @@ pub async fn health_check(State(_s): State<AppState>) -> (StatusCode, Json<serde
         Some(p) => st.push(item("Backingfiles free space", "pass", Some(format!("{:.1}% free", p)))),
         None => st.push(item("Backingfiles free space", "warn", Some("partition not mounted".to_string()))),
     }
-    // Load the active config so we only nag about disks the user
-    // actually asked for. If MUSIC_SIZE=0 (or unset) the user opted
-    // out of the music disk entirely — warning "music disk image
-    // missing" when they never configured it is just noise.
-    let active_cfg: std::collections::HashMap<String, String> =
-        sentryusb_config::parse_file(sentryusb_config::find_config_path())
-            .map(|(active, _commented)| active)
-            .unwrap_or_default();
+    // Only nag about disks the user actually asked for. If MUSIC_SIZE=0
+    // (or unset) the user opted out of the music disk entirely — warning
+    // "music disk image missing" when they never configured it is just noise.
     let user_wants = |size_key: &str| -> bool {
         // "0", "0G", "0M", "0K", empty, unset → disabled. Any non-zero
         // numeric prefix → enabled. Strict-enough for health: the

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -698,18 +698,24 @@ function clean_cam_mount {
 #   lapvideo.mp4
 #   laptelemetry.csv
 # Read the SoC temperature directly from the thermal zone, formatted to match the
-# temperature_monitor output (e.g. "84.512°C"). Echoes nothing on devices with no
-# thermal sensor. Called inline at the moment of an archive failure so the value
-# reflects the temperature *before* the chip cools: overheating (WiFi drop /
-# throttling) is a common cause of archive failures, and the periodic monitor only
-# samples once a minute, so by the time it logs the chip has already cooled.
+# temperature_monitor output. Echoes nothing on devices with no thermal sensor.
+# Called inline at the moment of an archive failure so the value reflects the
+# temperature *before* the chip cools: overheating (WiFi drop / throttling) is a
+# common cause of archive failures, and the periodic monitor only samples once a
+# minute, so by the time it logs the chip has already cooled.
+# Respects TEMPERATURE_UNIT (from sentryusb.conf): "F" → Fahrenheit, else Celsius.
 function soc_temperature () {
   local zone=/sys/class/thermal/thermal_zone0/temp
   [ -e "$zone" ] || return 0
   local raw
   raw=$(cat "$zone" 2>/dev/null) || return 0
   [ -n "$raw" ] || return 0
-  echo "$((raw / 1000)).$((raw % 1000))°C"
+  local c="$((raw / 1000)).$((raw % 1000))"
+  if [ "${TEMPERATURE_UNIT:-C}" = "F" ]; then
+    awk "BEGIN { printf \"%.1f°F\", $c * 9/5 + 32 }"
+  else
+    echo "${c}°C"
+  fi
 }
 
 function archive_teslacam_clips () {

--- a/run/temperature_monitor
+++ b/run/temperature_monitor
@@ -10,10 +10,14 @@ then
   exit 0
 fi
 
-function readable() { 
+function readable() {
   local temp1=$(($1 / 1000))
   local temp2=$(($1 % 1000))
-  echo "${temp1}.${temp2}°C"
+  if [ "${TEMPERATURE_UNIT:-C}" = "F" ]; then
+    awk "BEGIN { printf \"%.1f°F\", ${temp1}.${temp2} * 9/5 + 32 }"
+  else
+    echo "${temp1}.${temp2}°C"
+  fi
 }
 
 counter=0


### PR DESCRIPTION
## Summary

Temperature notifications and the health-check endpoint always display °C, ignoring the user's `TEMPERATURE_UNIT` preference. Users who set Fahrenheit see °C in:
- Push notifications (Temperature Monitor alerts)
- Bridge Event Log / web UI notification history
- `/api/system/health-check` response

The `TEMPERATURE_UNIT` env var is already sourced from `sentryusb.conf` via `envsetup.sh` — it's in the environment, just unused by these code paths.

## Changes

- **`run/temperature_monitor`** — `readable()` checks `${TEMPERATURE_UNIT:-C}`, converts with `awk` when `"F"`
- **`run/archiveloop`** — `soc_temperature()` same pattern
- **`crates/api/src/healthcheck.rs`** — reads `TEMPERATURE_UNIT` from the config it already parses for disk checks (moved `active_cfg` earlier in the function); `fmt_temp`/`fmt_threshold` closures handle conversion; GPU temp now includes unit suffix (was bare number)

## What's NOT affected (verified)

| Component | Status |
|-----------|--------|
| `post-archive-process.sh` drive distance | Already reads `DRIVE_MAP_UNIT` ✓ |
| Web UI Dashboard CPU temp | `formatTemp(milli, useFahrenheit)` ✓ |
| Web UI TemperatureChart | Converts at render time ✓ |
| Web UI BLE TPMS card | `metric ? °C : °F` ✓ |
| Threshold comparisons | Stay in Celsius internally — only display converts |

## Evidence

Live Pi (v3.0.8) with `TEMPERATURE_UNIT=F` in `/root/sentryusb.conf`:
- Push Inbox (client-converted by companion app): `128.0°F`
- Bridge Event Log (raw from `/api/notifications/history`): `46.875°C`
- Same event, different units — the °C is baked into the message string server-side

## Testing

Default (`TEMPERATURE_UNIT` unset or `"C"`): no change — all output stays °C.
With `TEMPERATURE_UNIT=F`: notifications show `°F`, health check shows `°F`, thresholds convert (80°C → `>176°F`).