### PR TITLE
Remove DietPi Bluetooth blacklist during BLE setup

### DIFF
--- a/setup/pi/setup-sentryusb
+++ b/setup/pi/setup-sentryusb
@@ -383,6 +383,10 @@ function install_ble_daemon () {
     fi
   done
 
+  # DietPi ships a modprobe blacklist that prevents Bluetooth kernel modules
+  # from loading at boot. Remove it so hci0 is available after reboot.
+  rm -f /etc/modprobe.d/dietpi-disable_bluetooth.conf 2>/dev/null || true
+
   chmod +x /root/bin/sentryusb-ble.py 2>/dev/null || true
 
   # Install D-Bus policy file so BlueZ can call GATT methods on our daemon.

--- a/setup/pi/setup-sentryusb
+++ b/setup/pi/setup-sentryusb
@@ -387,6 +387,21 @@ function install_ble_daemon () {
   # from loading at boot. Remove it so hci0 is available after reboot.
   rm -f /etc/modprobe.d/dietpi-disable_bluetooth.conf 2>/dev/null || true
 
+  # Radxa Zero 3W: the AIC8800 BT chip is on UART and needs hciattach to
+  # create hci0. Unlike BCM4345C0 (4C+, Pi 4) which auto-attaches via
+  # device-tree, the Zero 3W's DT has no bluetooth node — hciattach must
+  # run on every boot before sentryusb-ble can advertise.
+  if grep -qi "ZERO 3" /proc/device-tree/model 2>/dev/null; then
+    setup_progress "Radxa Zero 3W detected — installing AIC8800 BT UART attach service..."
+    mkdir -p /etc/systemd/system
+    printf '[Unit]\nDescription=Attach AIC8800 Bluetooth via UART\nBefore=bluetooth.service sentryusb-ble.service\nAfter=local-fs.target\n\n[Service]\nType=forking\nExecStart=/usr/bin/hciattach -s 1500000 /dev/ttyS1 any 1500000 flow nosleep\nRemainAfterExit=yes\nExecStop=/usr/bin/killall hciattach\n\n[Install]\nWantedBy=multi-user.target\n' > /etc/systemd/system/aic8800-bluetooth.service
+    systemctl daemon-reload
+    systemctl enable aic8800-bluetooth 2>/dev/null || true
+    systemctl start aic8800-bluetooth 2>/dev/null || true
+    sleep 3
+    setup_progress "AIC8800 BT UART attached"
+  fi
+
   chmod +x /root/bin/sentryusb-ble.py 2>/dev/null || true
 
   # Install D-Bus policy file so BlueZ can call GATT methods on our daemon.


### PR DESCRIPTION
## Summary

Two DietPi-specific Bluetooth issues prevent `sentryusb-ble` from advertising after setup:

### 1. DietPi modprobe blacklist (all boards)

DietPi ships `/etc/modprobe.d/dietpi-disable_bluetooth.conf` which blacklists BT kernel modules (`bluetooth`, `btbcm`, `rfcomm`, `hidp`, `bnep`). The setup script installs bluez and enables the BLE service, but never removes this blacklist.

**Fix:** `rm -f` in `install_ble_daemon()` after the package install loop. No-op on non-DietPi.

**Affected:** Rock Pi 4C+ (BCM4345C0), Pi 4, Pi 5 — any board where the kernel supports BT but DietPi blocks the modules.

### 2. Radxa Zero 3W AIC8800 UART attach (board-specific)

The Zero 3W's AIC8800 WiFi/BT chip has no device-tree bluetooth node in the DietPi/Armbian kernel. Unlike BCM4345C0 boards where BT auto-attaches via DT, the Zero 3W needs `hciattach` on `/dev/ttyS1` at 1500000 baud to create `hci0`.

**Fix:** Detect `ZERO 3` in `/proc/device-tree/model`, install a systemd service (`aic8800-bluetooth.service`) that runs `hciattach` before `bluetooth.service` and `sentryusb-ble.service` on every boot.

**Validated by:** Two independent DietPi users — Rock Pi 4C+ (blacklist fix) and Radxa Zero 3W (blacklist + UART attach), both on kernel `6.18.29-current-rockchip64`.

## Changes

`setup/pi/setup-sentryusb` — `install_ble_daemon()`:
- Remove DietPi BT blacklist file (1 line, safe no-op on non-DietPi)
- Detect Zero 3W → create + enable `aic8800-bluetooth.service` for UART attach

## Safety

- Blacklist removal: `rm -f` on a non-existent file = no-op
- Zero 3W detection: `grep -qi "ZERO 3" /proc/device-tree/model` — only matches that specific board
- systemd service: `Type=forking`, `RemainAfterExit=yes` — hciattach runs as background daemon, service stays active
- No impact on non-DietPi distros or non-Zero-3W boards