### PR TITLE
fix(drives): render overlapping-RecentClips drives cleanly (map slash + garbled speed chart)

### DIFF
--- a/web/src/components/drives/DriveMap.tsx
+++ b/web/src/components/drives/DriveMap.tsx
@@ -301,6 +301,14 @@ export function DriveMap({
     // no visible gap at the transition. Falls back to a single-color
     // polyline (emerald for SEI, violet for Tessie-source) when
     // fsdStates is missing or length-mismatched.
+    // Break the route wherever consecutive points jump more than GAP_M apart.
+    // Happens on a genuine GPS dropout (tunnel/signal loss) and at the seam left
+    // when an overlapping/duplicate RecentClips segment is dropped upstream —
+    // without the break the polyline slashes a straight line across the map
+    // between the two. (The data layer's monotonic-time filter removes the bulk
+    // of any overlap; this catches the residual seam.)
+    const GAP_M = 300
+
     const hasFsdSegments =
       fsdStates !== undefined && fsdStates.length === points.length
     if (hasFsdSegments) {
@@ -308,7 +316,9 @@ export function DriveMap({
       for (let i = 1; i <= points.length; i++) {
         const prevEngaged = fsdStates[i - 1] > 0
         const curEngaged = i < points.length ? fsdStates[i] > 0 : !prevEngaged
-        if (curEngaged !== prevEngaged || i === points.length) {
+        const gap =
+          i < points.length && latLngs[i - 1].distanceTo(latLngs[i]) > GAP_M
+        if (curEngaged !== prevEngaged || gap || i === points.length) {
           const segPts = latLngs.slice(segStart, i)
           if (segPts.length >= 2) {
             L.polyline(segPts, {
@@ -318,17 +328,30 @@ export function DriveMap({
               smoothFactor: 1.2,
             }).addTo(map)
           }
-          segStart = Math.max(i - 1, 0)
+          // Gap → start fresh at i (don't bridge). State change → share the
+          // boundary point so the colors meet seamlessly.
+          segStart = gap ? i : Math.max(i - 1, 0)
         }
       }
     } else {
       const stroke = source === "tessie" ? COLOR_TESSIE : COLOR_FSD
-      L.polyline(latLngs, {
-        color: stroke,
-        weight: 4,
-        opacity: 1,
-        smoothFactor: 1.2,
-      }).addTo(map)
+      let segStart = 0
+      for (let i = 1; i <= latLngs.length; i++) {
+        const gap =
+          i < latLngs.length && latLngs[i - 1].distanceTo(latLngs[i]) > GAP_M
+        if (gap || i === latLngs.length) {
+          const segPts = latLngs.slice(segStart, i)
+          if (segPts.length >= 2) {
+            L.polyline(segPts, {
+              color: stroke,
+              weight: 4,
+              opacity: 1,
+              smoothFactor: 1.2,
+            }).addTo(map)
+          }
+          segStart = i
+        }
+      }
     }
 
     // Start / end / pulse all use DOM markers (divIcon) so the pulse

--- a/web/src/pages/DriveDetail.tsx
+++ b/web/src/pages/DriveDetail.tsx
@@ -130,9 +130,61 @@ function DriveDetailContent({ drive, onSaveTags }: DriveDetailContentProps) {
     }
   }, [drive.id])
 
+  // RecentClips can stitch overlapping/duplicate same-minute clips into one
+  // drive, which makes a point's synthesized time jump backward at the seam
+  // (and teleport position). Filter to a strictly non-decreasing time sequence
+  // so the colliding clip's backward points are dropped and EVERY consumer
+  // (map, scrubber, speed chart) shares one clean, monotonic, index-aligned
+  // sequence. fsdStates is parallel to points, so it's filtered in lockstep or
+  // the route's FSD/manual coloring would break. A normal contiguous drive is
+  // already monotonic → no-op.
+  const { monoPoints, monoFsdStates } = useMemo(() => {
+    // Drop points that break a single continuous trajectory: (1) backward-in-time
+    // samples from overlapping RecentClips clips, and (2) teleports — a position
+    // jump too far for the elapsed time to be real travel (the surviving tail of
+    // a colliding clip lands 3.7km away in a few ms = ~50,000 m/s). What remains
+    // is one clean, monotonic, index-aligned sequence shared by the map, scrubber
+    // and speed chart; fsdStates is filtered in lockstep so route coloring stays
+    // aligned. No-op on a normal contiguous drive.
+    const hav = (la1: number, lo1: number, la2: number, lo2: number) => {
+      const R = 6371000
+      const r = Math.PI / 180
+      const dLa = (la2 - la1) * r
+      const dLo = (lo2 - lo1) * r
+      const a =
+        Math.sin(dLa / 2) ** 2 +
+        Math.cos(la1 * r) * Math.cos(la2 * r) * Math.sin(dLo / 2) ** 2
+      return 2 * R * Math.asin(Math.sqrt(a))
+    }
+    const MAX_MPS = 60 // ~134 mph; faster than any real drive → a data teleport
+    const pts: typeof drive.points = []
+    const fsd: number[] = []
+    const hasFsd =
+      Array.isArray(drive.fsdStates) &&
+      drive.fsdStates.length === drive.points.length
+    let maxT = -Infinity
+    let last: (typeof drive.points)[number] | null = null
+    drive.points.forEach((p, i) => {
+      if (p[2] < maxT) return // backward in time → drop
+      if (last) {
+        const dt = (p[2] - last[2]) / 1000
+        const dist = hav(last[0], last[1], p[0], p[1])
+        if (dist > 50 && (dt <= 0 || dist / dt > MAX_MPS)) return // teleport → drop
+      }
+      pts.push(p)
+      if (hasFsd) fsd.push(drive.fsdStates![i])
+      maxT = p[2]
+      last = p
+    })
+    return {
+      monoPoints: pts,
+      monoFsdStates: hasFsd ? fsd : drive.fsdStates,
+    }
+  }, [drive.points, drive.fsdStates])
+
   useEffect(() => {
-    setTotal(drive.points.length)
-  }, [drive.points.length, setTotal])
+    setTotal(monoPoints.length)
+  }, [monoPoints.length, setTotal])
 
   const title = drive.endLocation ?? "Drive"
   // Only the "imported from Tessie" badge is informative — drives from
@@ -156,7 +208,7 @@ function DriveDetailContent({ drive, onSaveTags }: DriveDetailContentProps) {
   //     last value (most recent reading wins — matches what the
   //     scrubber would land on).
   const speedSeries = useMemo(() => {
-    const raw = drive.points
+    const raw = monoPoints
       .map((p, i) => ({
         index: i,
         time: p[2],
@@ -179,7 +231,7 @@ function DriveDetailContent({ drive, onSaveTags }: DriveDetailContentProps) {
       }
     }
     return out
-  }, [drive.points, metric])
+  }, [monoPoints, metric])
 
   const speedUnit = metric ? "km/h" : "mph"
   const fsdFull = drive.fsdPercent >= 100
@@ -219,8 +271,8 @@ function DriveDetailContent({ drive, onSaveTags }: DriveDetailContentProps) {
       <div className={hasFsdEvents ? "mt-2" : "mt-4"}>
         <div className="relative">
           <DriveMap
-            points={drive.points}
-            fsdStates={drive.fsdStates}
+            points={monoPoints}
+            fsdStates={monoFsdStates}
             fsdEvents={drive.fsdEvents}
             showEvents={showFsdEvents}
             source={drive.source}
@@ -238,9 +290,9 @@ function DriveDetailContent({ drive, onSaveTags }: DriveDetailContentProps) {
         {/* DriveScrubber now renders the FSD engagement overlay on its
             own track — the standalone FsdEngagementStripe is retired. */}
         <DriveScrubber
-          points={drive.points}
+          points={monoPoints}
           startTime={drive.startTime}
-          fsdStates={drive.fsdStates}
+          fsdStates={monoFsdStates}
         />
       </div>
 


### PR DESCRIPTION
## What

Some RecentClips drives stitch two clips covering the **same wall-clock minute at different places** (e.g. a date-bucketed copy alongside a flat copy, or a rolling-buffer re-record). Because each point's time is synthesized from the clip **filename** over a fixed 60s ramp (`crates/drives/src/grouper.rs`), overlapping clips produce **non-monotonic time** and a **position teleport** at the seam:

- the detail **map draws a straight line slashing across** (connecting the points before/after the seam), and
- the **speed chart** (which sorts points by time) **interleaves** the two clips into a garbled vertical band.

## Fix (render layer only — no backend/data change)

- **`DriveDetail.tsx`** — collapse the drive's points to a single continuous trajectory before they reach the map / scrubber / speed chart: drop backward-in-time samples *and* physically-impossible teleports (a position jump too far for the elapsed time, e.g. 3.7 km in 74 ms). `fsdStates` is filtered in lockstep so FSD/manual route coloring stays index-aligned. No-op on a normal contiguous drive.
- **`DriveMap.tsx`** — gap-split the detail polyline on >300 m jumps, so a genuine GPS dropout (tunnel) or any residual seam breaks cleanly instead of slashing across the map.

(The list **thumbnail** map is intentionally left unchanged — its route is heavily decimated, so a distance gap-split there would shatter normal routes.)

## Verified

On a real 51-clip RecentClips drive: the 14 backward-in-time jumps, the ~3.7 km map slash, and the speed-chart garble are all gone; a normal contiguous drive renders identically to before.

## Note

This is **defensive rendering** — it draws the existing data honestly. The underlying overlap (two same-minute clips landing in one drive, via the filename-derived timestamps in `grouper.rs`) is a data-assembly question; if you'd rather de-overlap at the source, that's a backend change I didn't want to guess at. Happy to dig in if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
