### PR TITLE
test(setup): scrub real IP/location from geoip test fixture

### DIFF
--- a/crates/setup/src/system.rs
+++ b/crates/setup/src/system.rs
@@ -697,9 +697,10 @@ mod timezone_extract_tests {
 
     #[test]
     fn parses_first_party_geoip_json() {
-        // Exact shape of sentryusb.com/api/geoip/me (camelCase `timeZone`).
-        let body = r#"{"ip":"100.37.225.74","country":"US","region":"NY","city":"Staten Island","timeZone":"America/New_York"}"#;
-        assert_eq!(extract_timezone(body).as_deref(), Some("America/New_York"));
+        // Shape of sentryusb.com/api/geoip/me (camelCase `timeZone`).
+        // Placeholder values — RFC 5737 documentation IP, no real location.
+        let body = r#"{"ip":"203.0.113.7","country":"US","region":"CA","city":"Mountain View","timeZone":"America/Los_Angeles"}"#;
+        assert_eq!(extract_timezone(body).as_deref(), Some("America/Los_Angeles"));
     }
 
     #[test]


### PR DESCRIPTION
Quick follow-up to #46. The `parses_first_party_geoip_json` test used a captured live response from `/api/geoip/me`, which left a real public IP + city string in the test fixture. Swapped for RFC 5737 documentation placeholders (`203.0.113.7` / Mountain View / `America/Los_Angeles`).

The test only asserts `timeZone` extraction, so the `ip`/`country`/`region`/`city` fields are irrelevant to what it verifies — the placeholder shape exercises the parser identically. All 4 `timezone_extract_tests` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)