### PR TITLE
fix(ble): idle-keepalive on held car link to prevent sampler dropout

### DIFF
--- a/crates/tesla_ble/src/manager.rs
+++ b/crates/tesla_ble/src/manager.rs
@@ -444,11 +444,52 @@ impl PersistentSession {
     }
 }
 
+/// Idle-keepalive cadence for the held car link (Fix A1). A car can drop
+/// a GATT link that sees no application traffic for a while; between the
+/// scheduler's polls the link is otherwise silent — and that's where the
+/// drops cluster, especially while parked. ~8s is well inside typical
+/// car-side idle windows without wasting air time (do NOT drop to 2-3s).
+const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(8);
+/// Only send a keepalive if the link has actually been idle this long,
+/// so we skip a redundant feed right after a real command.
+const KEEPALIVE_IDLE: Duration = Duration::from_secs(6);
+
 async fn run_session_task(
     mut state: SessionState,
     mut cmd_rx: mpsc::Receiver<Command>,
 ) {
-    while let Some(cmd) = cmd_rx.recv().await {
+    // Idle keepalive (Fix A1): feed the held link on a timer between
+    // commands so the car doesn't drop an otherwise-silent GATT link.
+    let mut keepalive = tokio::time::interval(KEEPALIVE_INTERVAL);
+    keepalive.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    keepalive.tick().await; // consume the immediate first tick
+    let mut last_activity = Instant::now();
+    loop {
+        let cmd = tokio::select! {
+            maybe_cmd = cmd_rx.recv() => match maybe_cmd {
+                Some(c) => c,
+                None => break,
+            },
+            _ = keepalive.tick() => {
+                // Feed the link with the sleep-safe, unauthenticated
+                // body-controller query (no session key needed). Only
+                // when we hold a connection and it's genuinely idle. A
+                // failure here just drops + reconnects on the next op —
+                // which also proactively recovers a silently-dead link.
+                if state.conn.is_some() && last_activity.elapsed() >= KEEPALIVE_IDLE {
+                    let r = handle_body_controller(&mut state).await;
+                    handle_transport_error_if_any(&mut state, &r).await;
+                    match &r {
+                        Ok(_) => debug!("BLE keepalive: idle-feed ok"),
+                        Err(e) => debug!(
+                            "BLE keepalive: idle-feed failed (recovers on next op): {e:#}"
+                        ),
+                    }
+                    last_activity = Instant::now();
+                }
+                continue;
+            }
+        };
         // Time each command end-to-end so the latency window reflects
         // the full round-trip (refresh retry, scan, reconnect included).
         let started = Instant::now();
@@ -523,6 +564,7 @@ async fn run_session_task(
                 write_status_file(&state, ConnectionEvent::Connected);
             }
         }
+        last_activity = Instant::now();
     }
     if let Some(conn) = state.conn.take() {
         conn.close().await;


### PR DESCRIPTION
## Problem

When the BLE link to the car is held open between the scheduler's polls, the vehicle can drop a GATT link that has seen no application traffic for a while. Between samples the link is otherwise silent, and that's exactly where the drops cluster (especially while parked). It surfaces as **telemetry sampler dropout** — gaps in the speed/gear/location stream.

## Fix

Feed the held link on an **8s timer**, gated so it only fires when the link has actually been **idle ≥ 6s** — so the keepalive never competes with or duplicates real command traffic. It uses the existing **unauthenticated body-controller query**, which is sleep-safe (no session key, won't wake a sleeping car). On failure it just logs at debug and recovers on the next real op, which also proactively reconnects a silently-dead link rather than waiting for the next scheduled poll to discover it.

## Scope

- One file: `crates/tesla_ble/src/manager.rs` (+43 / -1)
- No new dependencies, no config, no API change
- Only touches the held-link idle path; command handling is unchanged (`last_activity` resets after every real command, so a keepalive never piggybacks a busy link)

Tuning note in-code: ~8s is well inside typical car-side idle windows without wasting air time — intentionally **not** 2-3s.

## Why a standalone PR

Split out of a larger keep-accessory branch so it can land independently. This is a pure reliability fix that benefits **every** sampler user regardless of that feature.
