### PR TITLE
Keep parked Unknown-shift Teslas awake during archives

### DIFF
--- a/crates/tesla_telemetry/src/lock.rs
+++ b/crates/tesla_telemetry/src/lock.rs
@@ -212,6 +212,17 @@ fn is_nudge_alive() -> bool {
     Path::new(&format!("/proc/{pid}")).exists()
 }
 
+/// True when something currently wants the car kept awake: an archive
+/// cycle (fresh `archive_status.json`) or any keep-awake nudge loop
+/// (`awake_start`'s Case-3 PID file — archiveloop, web-UI, drive
+/// processing). The quiet-mode gate consults this so it never green-lights
+/// sleep out from under an in-flight archive. Both inputs self-clear — the
+/// status file goes stale (120s), the PID dies — so this can't wedge the
+/// car permanently awake once the work finishes.
+pub fn keep_awake_requested() -> bool {
+    is_archive_active() || is_nudge_alive()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/tesla_telemetry/src/main.rs
+++ b/crates/tesla_telemetry/src/main.rs
@@ -365,6 +365,31 @@ async fn main() -> Result<()> {
     }
 }
 
+/// Whether the gate may drop to sleep-permitting (Quiet) polling.
+/// Quiet means "let the car sleep": permitted only when the car is
+/// parked-or-asleep AND nothing has a reason to hold it awake — not
+/// charging, sentry off, and no keep-awake (archive cycle or web-UI /
+/// manual nudge) in effect.
+///
+/// The keep-awake term is the fix for letting a parked car sleep
+/// mid-archive: an archive disconnects the USB gadget, so the car both
+/// confirms Park (drive computer powers down → Unknown shift) and later
+/// trips `car_truly_asleep` (cam_disk stops updating). The override has to
+/// sit on the whole decision, not just one path, or a >5min archive slips
+/// through the asleep door.
+fn should_enter_quiet(
+    car_truly_asleep: bool,
+    parked_confirmed: bool,
+    actively_charging: bool,
+    sentry_on: bool,
+    keep_awake_active: bool,
+) -> bool {
+    (car_truly_asleep || parked_confirmed)
+        && !actively_charging
+        && !sentry_on
+        && !keep_awake_active
+}
+
 /// One main-loop iteration; returns how long to sleep before the next.
 ///
 /// Two phases, decided each tick:
@@ -444,12 +469,25 @@ async fn tick(
         .unwrap_or(true);
     let sentry_on = last_sentry_mode.map(|s| s.is_on()).unwrap_or(true);
 
+    // A keep-awake in effect — an archive cycle or any nudge loop (web-UI,
+    // drive processing) — must pin us Active. Dropping to sleep-safe
+    // polling mid-archive lets the car sleep, which cuts USB power and
+    // aborts the copy. Self-clears when the work finishes, so it can't
+    // wedge the car permanently awake (see lock::keep_awake_requested).
+    let keep_awake_active = lock::keep_awake_requested();
+
     // Two paths to quiet mode: car_truly_asleep (no recent clip writes)
-    // or parked_confirmed (Park 3+ polls). Both also require the car
-    // isn't charging or running sentry — those keep it awake, and
-    // quieting would leave battery_pct / sentry_mode_state stale.
-    let want_quiet = car_truly_asleep || parked_confirmed;
-    let in_quiet_mode = want_quiet && !actively_charging && !sentry_on;
+    // or parked_confirmed (Park 3+ polls). Both also require the car isn't
+    // charging, running sentry, or being held awake for an archive — those
+    // keep it awake, and quieting would leave battery_pct/sentry stale or
+    // break the copy.
+    let in_quiet_mode = should_enter_quiet(
+        car_truly_asleep,
+        parked_confirmed,
+        actively_charging,
+        sentry_on,
+        keep_awake_active,
+    );
 
     // Diagnostic: the car is parked/asleep but we're staying Active
     // because charging or sentry says it has a reason to be awake. This
@@ -476,11 +514,13 @@ async fn tick(
             } else {
                 "DEFAULTED: unread"
             };
-            // Quiet needs (asleep || parked_confirmed) && !charge && !sentry.
-            // Log all four so a stuck-Active gate is diagnosable.
+            // Quiet needs (asleep || parked_confirmed) && !charge &&
+            // !sentry && !keep_awake. Log all five so a stuck-Active gate
+            // is diagnosable; keep_awake_active=true is an archive/nudge
+            // hold (the deliberate stay-awake during a copy).
             info!(
                 "gate: staying Active — car_truly_asleep={}, parked_polls={}/{}, \
-                 sentry_on={} [{}], actively_charging={} [{}]",
+                 sentry_on={} [{}], actively_charging={} [{}], keep_awake_active={}",
                 car_truly_asleep,
                 *parked_polls,
                 PARK_CONFIRMATIONS_BEFORE_QUIET,
@@ -488,6 +528,7 @@ async fn tick(
                 sentry_src,
                 actively_charging,
                 charge_src,
+                keep_awake_active,
             );
         }
     }
@@ -879,16 +920,18 @@ async fn tick(
                 // Park, or Unknown (drive computer asleep).
                 *parked_polls = parked_polls.saturating_add(1);
                 if *parked_polls == PARK_CONFIRMATIONS_BEFORE_QUIET {
-                    // One-shot on first confirm; charge/sentry decide the
-                    // next tick.
-                    if actively_charging || sentry_on {
+                    // One-shot on first confirm; charge/sentry/keep-awake
+                    // decide the next tick.
+                    if actively_charging || sentry_on || keep_awake_active {
                         info!(
                             "{} consecutive parked observations — but staying Active \
-                             (actively_charging={}, sentry_on={}); car is awake for \
-                             a reason, quiet polling would freeze battery/sentry signals",
+                             (actively_charging={}, sentry_on={}, keep_awake_active={}); \
+                             car is awake for a reason, quiet polling would freeze \
+                             battery/sentry signals or break an in-flight archive",
                             PARK_CONFIRMATIONS_BEFORE_QUIET,
                             actively_charging,
                             sentry_on,
+                            keep_awake_active,
                         );
                     } else {
                         info!(
@@ -1205,5 +1248,53 @@ async fn release_radio() {
     // is a no-op and sentryusb-ble runs continuously.
     if let Err(e) = lock::release(OWNER) {
         warn!("failed to release radio lock: {e}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // `should_enter_quiet` is the gate's sleep decision. Quiet = "let the
+    // car sleep"; permitted only when the car is parked or asleep AND
+    // nothing has a reason to hold it awake. Args, in order:
+    // (car_truly_asleep, parked_confirmed, actively_charging, sentry_on,
+    //  keep_awake_active).
+
+    #[test]
+    fn parked_idle_car_is_allowed_to_sleep() {
+        // Parked, sentry off, not charging, nothing running → may sleep.
+        // The behavior we preserve for a genuinely idle parked car.
+        assert!(should_enter_quiet(false, true, false, false, false));
+    }
+
+    #[test]
+    fn keep_awake_pins_active_while_parked() {
+        // The regression (commit fba51ce): parked + sentry off + not
+        // charging would quiet, but an archive / keep-awake nudge is
+        // running, so the car must NOT be allowed to sleep mid-archive.
+        assert!(!should_enter_quiet(false, true, false, false, true));
+    }
+
+    #[test]
+    fn keep_awake_pins_active_even_when_car_looks_asleep() {
+        // A long archive disconnects the USB gadget, so cam_disk.bin stops
+        // updating and the car trips "truly asleep" after 5 min even though
+        // it's awake. The override must cover this second path too — hence
+        // it sits on the whole decision, not just the parked-polls counter.
+        assert!(should_enter_quiet(true, false, false, false, false));
+        assert!(!should_enter_quiet(true, false, false, false, true));
+    }
+
+    #[test]
+    fn charging_or_sentry_still_pins_active() {
+        assert!(!should_enter_quiet(false, true, true, false, false)); // charging
+        assert!(!should_enter_quiet(false, true, false, true, false)); // sentry on
+    }
+
+    #[test]
+    fn moving_car_never_quiets() {
+        // Not parked-confirmed and not asleep (e.g. driving).
+        assert!(!should_enter_quiet(false, false, false, false, false));
     }
 }

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -668,9 +668,13 @@ function clean_cam_mount {
     rm -f /tmp/rmcandidates.txt /tmp/rmcandidatesbytime.txt
   fi
 
-  # delete directories that are now empty
+  # delete directories that are now empty (encrypted-clip dirs included; they
+  # don't exist on pre-2026.20 cars, so suppress find's missing-path errors)
   find "$CAM_MOUNT/TeslaCam/RecentClips" "$CAM_MOUNT/TeslaCam/SavedClips" \
-    "$CAM_MOUNT/TeslaCam/SentryClips" "$CAM_MOUNT/TeslaTrackMode" -mindepth 1 -type d -empty -delete || true
+    "$CAM_MOUNT/TeslaCam/SentryClips" \
+    "$CAM_MOUNT/TeslaCam/EncryptedClips/RecentClips" "$CAM_MOUNT/TeslaCam/EncryptedClips/SavedClips" \
+    "$CAM_MOUNT/TeslaCam/EncryptedClips/SentryClips" \
+    "$CAM_MOUNT/TeslaTrackMode" -mindepth 1 -type d -empty -delete 2>/dev/null || true
 
   # Trim the camera archive to reduce the number of blocks in the snapshot.
   trim_free_space "$CAM_MOUNT"
@@ -741,19 +745,27 @@ function archive_teslacam_clips () {
 
   # Find files by name only. Don't follow the symlinks yet, since that
   # would cause all snapshots to be mounted.
+  #
+  # Tesla firmware 2026.20+ writes encrypted clips to a parallel
+  # TeslaCam/EncryptedClips/{RecentClips,SavedClips,SentryClips} tree (mirrored
+  # into /mutable/TeslaCam/EncryptedClips/ by make_snapshot.sh). Each category's
+  # encrypted variant rides the SAME on/off flag as its plain counterpart, so
+  # enabling SavedClips archiving also archives encrypted SavedClips. They're
+  # copied verbatim (still .mp4, just encrypted) and land under
+  # <archive>/EncryptedClips/... for later decryption via the owner's account.
   local -a savedclipsopt
   local -a sentryclipsopt
   local -a trackmodeclipsopt
   local -a recentclipsopt
   if [ "${ARCHIVE_SAVEDCLIPS:-true}" = "true" ]
   then
-    savedclipsopt=("-path" "./SavedClips/*")
+    savedclipsopt=("-path" "./SavedClips/*" "-o" "-path" "./EncryptedClips/SavedClips/*")
   else
     savedclipsopt=("-false")
   fi
   if [ "${ARCHIVE_SENTRYCLIPS:-true}" = "true" ]
   then
-    sentryclipsopt=("-o" "-path" "./SentryClips/*")
+    sentryclipsopt=("-o" "-path" "./SentryClips/*" "-o" "-path" "./EncryptedClips/SentryClips/*")
   fi
   if [ "${ARCHIVE_TRACKMODECLIPS:-true}" = "true" ]
   then
@@ -761,7 +773,7 @@ function archive_teslacam_clips () {
   fi
   if [ "${ARCHIVE_RECENTCLIPS:-false}" = "true" ]
   then
-    recentclipsopt=("-o" "-path" "./RecentClips/*")
+    recentclipsopt=("-o" "-path" "./RecentClips/*" "-o" "-path" "./EncryptedClips/RecentClips/*")
   fi
   (cd "$overlaylower"; find . \( \( "${savedclipsopt[@]}" "${sentryclipsopt[@]}" "${trackmodeclipsopt[@]}" "${recentclipsopt[@]}" \) -type l \) \
         -a -fprintf "$sentrylist" '%P\n')

--- a/run/make_snapshot.sh
+++ b/run/make_snapshot.sh
@@ -101,6 +101,36 @@ function make_links_for_snapshot {
     fi
     ln -sf "$f" "$track"
   done
+  # Encrypted clips (Tesla firmware 2026.20+): the car writes a parallel
+  # TeslaCam/EncryptedClips/{RecentClips,SavedClips,SentryClips} tree whose
+  # video contents are encrypted (decryptable only via the owner's Tesla
+  # account at dashcam.tesla.com). Mirror it into a SEPARATE
+  # /mutable/TeslaCam/EncryptedClips/ subtree so it archives to
+  # <archive>/EncryptedClips/... and stays isolated from the plain-MP4
+  # RecentClips view used by the web viewer and drive map — the encrypted
+  # files won't play, so they must not be cross-linked into RecentClips.
+  local encrecent=/mutable/TeslaCam/EncryptedClips/RecentClips
+  local encsaved=/mutable/TeslaCam/EncryptedClips/SavedClips
+  local encsentry=/mutable/TeslaCam/EncryptedClips/SentryClips
+  for f in "$curmnt/TeslaCam/EncryptedClips/RecentClips/"*
+  do
+    local efilename=${f##/*/}
+    [[ "$efilename" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}.* ]] || continue
+    mkdir -p "$encrecent/${efilename:0:10}"
+    ln -sf "${f/"$curmnt"/$finalmnt}" "$encrecent/${efilename:0:10}"
+  done
+  for f in "$curmnt/TeslaCam/EncryptedClips/SavedClips"/*/*
+  do
+    local eeventtime=${f%/*}; eeventtime=${eeventtime##/*/}
+    mkdir -p "$encsaved/$eeventtime"
+    ln -sf "${f/"$curmnt"/$finalmnt}" "$encsaved/$eeventtime"
+  done
+  for f in "$curmnt/TeslaCam/EncryptedClips/SentryClips"/*/*
+  do
+    local eeventtime=${f%/*}; eeventtime=${eeventtime##/*/}
+    mkdir -p "$encsentry/$eeventtime"
+    ln -sf "${f/"$curmnt"/$finalmnt}" "$encsentry/$eeventtime"
+  done
   log "made all links for $curmnt"
   $restore_nullglob
 }

--- a/web/src/components/settings/sections/BlePairButton.tsx
+++ b/web/src/components/settings/sections/BlePairButton.tsx
@@ -1084,11 +1084,11 @@ function TelemetryOutputPanel({
           )}
           {sample.shift_state === "Unknown" && (
             <p className="pt-1 text-[10px] text-amber-400/80">
-              Shift reads <strong>Unknown</strong> — this is expected on older
-              (Intel-based) Teslas. Tesla powers down the gear computer when the
-              car is in Park with nobody inside, so the gear is no longer
-              reported. We treat <strong>Unknown as Park</strong> so the car is
-              still allowed to sleep.
+              Shift reads <strong>Unknown</strong> — normal for a parked Tesla.
+              The car powers down its drive computer shortly after you park, so
+              it stops reporting the gear (this happens on both AMD- and
+              Intel-MCU cars). We treat <strong>Unknown as Park</strong>: the car
+              may sleep when idle, but stays awake while an archive is running.
             </p>
           )}
           <Row label="Interior temp" value={fmtTemp(sample.interior_temp_c, metric)} />


### PR DESCRIPTION
The telemetry quiet-mode gate dropped to sleep-permitting body-controller polling ~45s after parking whenever shift read Park/Unknown with Sentry off and not charging — with no awareness of an in-flight archive. On any Tesla that sheds shift_state as its drive computer powers down on parking (AMD and Intel MCUs alike), this let the car sleep mid-archive, cutting USB power and aborting the copy (logged as "user drove away").

Consult the keep-awake signal the daemon already tracks — a fresh archive_status.json or a live keep-awake nudge PID — in the gate decision, so an archive or any keep-awake pins the daemon Active. Both inputs self-clear, so a genuinely idle parked car still sleeps once the work finishes.

- lock: add pub keep_awake_requested() wrapping is_archive_active() / is_nudge_alive()
- telemetry: route the gate through a new pure should_enter_quiet() that also covers the car_truly_asleep path (a >5min archive trips the asleep door too, since the gadget is disconnected and cam_disk goes stale); surface keep_awake_active in both gate logs
- tests: 5 cases for should_enter_quiet incl. the regression
- ui: reword the shift=Unknown note — not Intel-specific, notes the archive hold

<!--
Note: this project is source-available under the PolyForm Noncommercial
License 1.0.0. By contributing you agree your contribution may be licensed
under that license and, per the CLA, relicensed commercially by the Maintainers.
-->
