### PR TITLE
deps(cargo): bump prost stack to 0.14 (supersedes #55)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -868,6 +868,12 @@ dependencies = [
 
 [[package]]
 name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
@@ -1036,11 +1042,20 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
- "foldhash",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -1751,11 +1766,12 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "petgraph"
-version = "0.7.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
+ "hashbrown 0.15.5",
  "indexmap",
 ]
 
@@ -1862,9 +1878,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.5"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -1872,15 +1888,14 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.13.5"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
  "itertools",
  "log",
  "multimap",
- "once_cell",
  "petgraph",
  "prettyplease",
  "prost",
@@ -1892,9 +1907,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.13.5"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
  "itertools",
@@ -1905,9 +1920,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.13.5"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
  "prost",
 ]

--- a/crates/tesla_ble/Cargo.toml
+++ b/crates/tesla_ble/Cargo.toml
@@ -54,8 +54,8 @@ tracing-subscriber = { workspace = true }
 
 btleplug = "0.11"
 futures = "0.3"
-prost = "0.13"
-prost-types = "0.13"
+prost = "0.14"
+prost-types = "0.14"
 sha1 = "0.11"
 sha2 = "0.10"
 hex = "0.4"
@@ -71,7 +71,7 @@ pem = "3"
 aes-gcm = "0.10"
 
 [build-dependencies]
-prost-build = "0.13"
+prost-build = "0.14"
 # Vendored protoc so users don't need to apt install protobuf-compiler.
 protoc-bin-vendored = "3"
 

--- a/crates/tesla_telemetry/Cargo.toml
+++ b/crates/tesla_telemetry/Cargo.toml
@@ -34,7 +34,7 @@ sentryusb-config = { path = "../config", package = "sentryusb-config" }
 sentryusb-shell = { path = "../shell", package = "sentryusb-shell" }
 sentryusb-drives = { path = "../drives", package = "sentryusb-drives" }
 sentryusb-tesla-ble = { path = "../tesla_ble", package = "sentryusb-tesla-ble" }
-prost-types = "0.13"
+prost-types = "0.14"
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
Supersedes #55, which Dependabot opened to bump only `prost-types` to 0.14.

## Problem
`tesla_ble` pins `prost`, `prost-build`, and `prost-types` at 0.13; `tesla_telemetry` pins `prost-types` at 0.13. Bumping only `prost-types` to 0.14 (as #55 did) leaves two incompatible `prost` majors in the graph, so the prost-build-generated code fails to compile: `error[E0277]: the trait bound prost_types::Timestamp: prost::Message is not satisfied` in `car_server.rs` ("multiple different versions of crate prost").

## Fix
Bump `prost` and `prost-build` to 0.14 alongside `prost-types`, in both crates. No `build.rs` or source changes needed — prost 0.14 keeps the `compile_protos()` API, and this crate uses default features so the `prost-derive`->`derive` feature rename does not apply.

## Verification
`cargo check -p sentryusb-tesla-ble --lib --examples` passes (lib + all 7 BLE examples compile against prost 0.14.3). `tesla_telemetry`'s only prost-types use is a `prost_types::Timestamp` field read; it can't be host-compiled here due to an unrelated `libsqlite3-sys 0.38` / rustc-version issue that also affects `main`.
