### PR TITLE
deps(web): typescript 6.0 + drop deprecated baseUrl (supersedes #38)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -32,7 +32,7 @@
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.6.0",
         "tailwindcss": "^4.1.18",
-        "typescript": "~5.9.3",
+        "typescript": "~6.0.3",
         "typescript-eslint": "^8.60.1",
         "vite": "^7.3.1"
       }
@@ -3842,10 +3842,11 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/web/package.json
+++ b/web/package.json
@@ -34,7 +34,7 @@
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.6.0",
     "tailwindcss": "^4.1.18",
-    "typescript": "~5.9.3",
+    "typescript": "~6.0.3",
     "typescript-eslint": "^8.60.1",
     "vite": "^7.3.1"
   }

--- a/web/tsconfig.app.json
+++ b/web/tsconfig.app.json
@@ -23,7 +23,6 @@
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }


### PR DESCRIPTION
Supersedes #38 (typescript 5.9 -> 6.0).

## Problem
TS 6.0 turns the deprecated `baseUrl` option into a hard error (TS5101), so `tsc -b` (and thus `npm run build`) fails.

## Fix
Remove `baseUrl` from `web/tsconfig.app.json`. It only anchored the `@/* -> ./src/*` path alias; since TS 5.0 `paths` resolves relative to the tsconfig without `baseUrl`, and Vite resolves the real bundling alias via `resolve.alias` in `vite.config.ts`. No source imports change.

## Verification
`npm run build` (`tsc -b && vite build`) passes with typescript 6.0.3; the `@/`-aliased imports still type-check and bundle.
