### PR TITLE
Slice 1/3: experimental flag + expanded BLE decode + DB columns

### DIFF
--- a/crates/drives/src/schema.rs
+++ b/crates/drives/src/schema.rs
@@ -78,7 +78,7 @@ use rusqlite::{params, Connection, OptionalExtension};
 /// Also: `software_version` columns on both tables are kept for
 /// forward-compat but no longer written — Tesla doesn't expose
 /// `car_version` over BLE state queries.
-pub const CURRENT_SCHEMA_VERSION: i32 = 10;
+pub const CURRENT_SCHEMA_VERSION: i32 = 11;
 
 /// v1 DDL. Each statement is idempotent (`IF NOT EXISTS`) so `migrate()`
 /// is safe on every startup. Column shapes and names match Go exactly —
@@ -261,6 +261,22 @@ pub const V10_TELEMETRY_COLUMNS: &[(&str, &str)] = &[
     ("location_name", "TEXT"),
 ];
 
+/// v11 charging-detail columns on `telemetry_samples`. Decoded from the
+/// BLE `ChargeState` message and written only when the experimental
+/// sampler flag is on (SENTRYUSB_EXPERIMENTAL) — NULL otherwise, so a
+/// normal install is unaffected. Columns are added for everyone (cheap,
+/// nullable) so flipping the flag needs no schema change. Powers the
+/// charging view under "Driving".
+pub const V11_TELEMETRY_CHARGE_COLUMNS: &[(&str, &str)] = &[
+    ("charger_power_kw", "INTEGER"),
+    ("charger_actual_current_a", "INTEGER"),
+    ("charger_voltage_v", "INTEGER"),
+    ("charge_rate_mph", "REAL"),
+    ("charge_energy_added_kwh", "REAL"),
+    ("charge_limit_soc", "INTEGER"),
+    ("battery_range_mi", "REAL"),
+];
+
 /// v10 per-clip location-name rollups on `routes`. Populated by
 /// the aggregator from the first / last non-null sample in the
 /// clip's 60s window.
@@ -335,6 +351,7 @@ pub fn migrate(conn: &Connection) -> Result<()> {
         .iter()
         .chain(V9_TELEMETRY_COLUMNS.iter())
         .chain(V10_TELEMETRY_COLUMNS.iter())
+        .chain(V11_TELEMETRY_CHARGE_COLUMNS.iter())
     {
         if existing_tele.contains(*name) {
             continue;

--- a/crates/drives/src/schema.rs
+++ b/crates/drives/src/schema.rs
@@ -526,7 +526,7 @@ mod tests {
         migrate(&conn).unwrap();
         assert_eq!(
             meta_get(&conn, "schema_version").unwrap().as_deref(),
-            Some("10"),
+            Some("11"),
         );
         assert!(meta_get(&conn, "created_at").unwrap().is_some());
     }
@@ -564,7 +564,7 @@ mod tests {
         }
         assert_eq!(
             meta_get(&conn, "schema_version").unwrap().as_deref(),
-            Some("10")
+            Some("11")
         );
     }
 
@@ -596,7 +596,7 @@ mod tests {
         }
         assert_eq!(
             meta_get(&conn, "schema_version").unwrap().as_deref(),
-            Some("10")
+            Some("11")
         );
     }
 
@@ -630,7 +630,7 @@ mod tests {
         }
         assert_eq!(
             meta_get(&conn, "schema_version").unwrap().as_deref(),
-            Some("10")
+            Some("11")
         );
     }
 
@@ -737,7 +737,7 @@ mod tests {
         assert!(surviving_processed.starts_with("RecentClips/"));
         assert_eq!(
             meta_get(&conn, "schema_version").unwrap().as_deref(),
-            Some("10")
+            Some("11")
         );
     }
 
@@ -788,7 +788,7 @@ mod tests {
         assert_eq!(count_routes(&conn), 1, "fresh-DB seed must not run v5 cleanup");
         assert_eq!(
             meta_get(&conn, "schema_version").unwrap().as_deref(),
-            Some("10")
+            Some("11")
         );
     }
 
@@ -841,7 +841,7 @@ mod tests {
         assert_eq!(table_exists, 1, "v6 must create telemetry_samples");
         assert_eq!(
             meta_get(&conn, "schema_version").unwrap().as_deref(),
-            Some("10")
+            Some("11")
         );
     }
 
@@ -884,7 +884,7 @@ mod tests {
         }
         assert_eq!(
             meta_get(&conn, "schema_version").unwrap().as_deref(),
-            Some("10")
+            Some("11")
         );
     }
 

--- a/crates/tesla_telemetry/src/config.rs
+++ b/crates/tesla_telemetry/src/config.rs
@@ -41,6 +41,12 @@ pub struct BleConfig {
     pub adapter: String,
     /// Keep-Accessory-Power automation (12V-powered Pis only).
     pub keep_accessory: KeepAccessoryConfig,
+    /// Master opt-in for in-progress consolidation features (expanded
+    /// sampler decode, etc.). Default OFF — set `SENTRYUSB_EXPERIMENTAL`
+    /// to enable. Anything gated by this flag stays dormant on a normal
+    /// install, so a pre-release build never changes behavior unless a
+    /// tester explicitly turns it on. See the consolidation RFC.
+    pub experimental: bool,
 }
 
 impl Default for BleConfig {
@@ -50,6 +56,7 @@ impl Default for BleConfig {
             vin: String::new(),
             adapter: DEFAULT_ADAPTER.to_string(),
             keep_accessory: KeepAccessoryConfig::default(),
+            experimental: false,
         }
     }
 }
@@ -133,11 +140,23 @@ impl BleConfig {
             home_radius_m,
         };
 
+        // Master experimental opt-in. Default OFF. Gates in-progress
+        // consolidation features so a pre-release build is byte-for-byte
+        // current behavior until a tester sets SENTRYUSB_EXPERIMENTAL.
+        let experimental = sentryusb_config::get_config_value(
+            &active,
+            &commented,
+            "SENTRYUSB_EXPERIMENTAL",
+        )
+        .map(|v| matches!(v.as_str(), "yes" | "true" | "1"))
+        .unwrap_or(false);
+
         Ok(Self {
             enabled,
             vin,
             adapter,
             keep_accessory,
+            experimental,
         })
     }
 }

--- a/crates/tesla_telemetry/src/db.rs
+++ b/crates/tesla_telemetry/src/db.rs
@@ -37,8 +37,12 @@ pub fn insert(conn: &Connection, s: &Sample) -> Result<()> {
         "INSERT OR IGNORE INTO telemetry_samples \
          (ts, battery_pct, battery_temp_c, interior_temp_c, exterior_temp_c, hvac_on, \
           tire_fl_psi, tire_fr_psi, tire_rl_psi, tire_rr_psi, \
-          odometer_mi, location_name, source) \
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
+          odometer_mi, location_name, \
+          charger_power_kw, charger_actual_current_a, charger_voltage_v, \
+          charge_rate_mph, charge_energy_added_kwh, charge_limit_soc, battery_range_mi, \
+          source) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, \
+                 ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20)",
         params![
             s.ts,
             s.battery_pct,
@@ -52,6 +56,13 @@ pub fn insert(conn: &Connection, s: &Sample) -> Result<()> {
             s.tire_rr_psi,
             s.odometer_mi,
             s.location_name,
+            s.charger_power_kw,
+            s.charger_actual_current_a,
+            s.charger_voltage_v,
+            s.charge_rate_mph,
+            s.charge_energy_added_kwh,
+            s.charge_limit_soc,
+            s.battery_range_mi,
             s.source,
         ],
     )?;

--- a/crates/tesla_telemetry/src/db.rs
+++ b/crates/tesla_telemetry/src/db.rs
@@ -98,6 +98,7 @@ mod tests {
             odometer_mi: Some(12453.5),
             location_name: Some("123 Main St".into()),
             source: "state".into(),
+            ..Sample::default()
         };
         insert(&conn, &s).unwrap();
         let count: i64 = conn

--- a/crates/tesla_telemetry/src/main.rs
+++ b/crates/tesla_telemetry/src/main.rs
@@ -737,6 +737,9 @@ async fn tick(
                         }
                         match sample_ble::sample_charge_ble(session).await {
                             Ok(c) => {
+                                if cfg.experimental {
+                                    sample_ble::log_charge_detail(&c);
+                                }
                                 try_sync_clock(c.meta);
                                 refresh.battery_pct = c.battery_pct;
                                 // Also refresh the gate input so a
@@ -936,6 +939,9 @@ async fn tick(
         if schedule.charge_due(tick_now) {
             let success = match sample_ble::sample_charge_ble(session).await {
                 Ok(c) => {
+                    if cfg.experimental {
+                        sample_ble::log_charge_detail(&c);
+                    }
                     try_sync_clock(c.meta);
                     sample.battery_pct = c.battery_pct;
                     // Refresh the gate input on success; keep the previous

--- a/crates/tesla_telemetry/src/main.rs
+++ b/crates/tesla_telemetry/src/main.rs
@@ -653,6 +653,9 @@ async fn tick(
             if presence_now == Some(true) {
                 match sample_ble::sample_drive_ble(session).await {
                     Ok(d) => {
+                        if cfg.experimental {
+                            sample_ble::log_drive_detail(&d);
+                        }
                         // Self-correct the Pi's clock if it's
                         // significantly off — uses Tesla's
                         // GPS-derived timestamp from the response.
@@ -727,6 +730,9 @@ async fn tick(
                     if refresh_due {
                         match sample_ble::sample_climate_ble(session).await {
                             Ok(c) => {
+                                if cfg.experimental {
+                                    sample_ble::log_climate_detail(&c);
+                                }
                                 try_sync_clock(c.meta);
                                 refresh.interior_temp_c = c.interior_temp_c;
                                 refresh.exterior_temp_c = c.exterior_temp_c;
@@ -855,6 +861,9 @@ async fn tick(
         if schedule.drive_due(tick_now) {
             let success = match sample_ble::sample_drive_ble(session).await {
                 Ok(d) => {
+                    if cfg.experimental {
+                        sample_ble::log_drive_detail(&d);
+                    }
                     try_sync_clock(d.meta);
                     sample.odometer_mi = d.odometer_mi;
                     sample.location_name = d.location_name;
@@ -923,6 +932,9 @@ async fn tick(
         if schedule.climate_due(tick_now) {
             let success = match sample_ble::sample_climate_ble(session).await {
                 Ok(c) => {
+                    if cfg.experimental {
+                        sample_ble::log_climate_detail(&c);
+                    }
                     try_sync_clock(c.meta);
                     sample.interior_temp_c = c.interior_temp_c;
                     sample.exterior_temp_c = c.exterior_temp_c;

--- a/crates/tesla_telemetry/src/main.rs
+++ b/crates/tesla_telemetry/src/main.rs
@@ -758,6 +758,9 @@ async fn tick(
                         // fields, so this doesn't affect `any_ok`.
                         match sample_ble::sample_closures_ble(session).await {
                             Ok(c) => {
+                                if cfg.experimental {
+                                    sample_ble::log_closures_detail(&c);
+                                }
                                 try_sync_clock(c.meta);
                                 if let Some(sm) = c.sentry_mode {
                                     *last_sentry_mode = Some(sm);
@@ -978,6 +981,9 @@ async fn tick(
         if schedule.closures_due(tick_now) {
             let success = match sample_ble::sample_closures_ble(session).await {
                 Ok(c) => {
+                    if cfg.experimental {
+                        sample_ble::log_closures_detail(&c);
+                    }
                     try_sync_clock(c.meta);
                     if let Some(sm) = c.sentry_mode {
                         *last_sentry_mode = Some(sm);

--- a/crates/tesla_telemetry/src/main.rs
+++ b/crates/tesla_telemetry/src/main.rs
@@ -941,6 +941,17 @@ async fn tick(
                 Ok(c) => {
                     if cfg.experimental {
                         sample_ble::log_charge_detail(&c);
+                        // Persist the expanded charging detail (v11 columns).
+                        // Gated by the flag so a normal install writes the
+                        // same rows it always has (these stay NULL).
+                        let d = &c.detail;
+                        sample.charger_power_kw = d.charger_power_kw;
+                        sample.charger_actual_current_a = d.charger_actual_current_a;
+                        sample.charger_voltage_v = d.charger_voltage_v;
+                        sample.charge_rate_mph = d.charge_rate_mph;
+                        sample.charge_energy_added_kwh = d.charge_energy_added_kwh;
+                        sample.charge_limit_soc = d.charge_limit_soc;
+                        sample.battery_range_mi = d.battery_range_mi;
                     }
                     try_sync_clock(c.meta);
                     sample.battery_pct = c.battery_pct;

--- a/crates/tesla_telemetry/src/sample.rs
+++ b/crates/tesla_telemetry/src/sample.rs
@@ -224,6 +224,29 @@ pub struct ChargeDetail {
 pub struct ClosuresResult {
     pub sentry_mode: Option<SentryMode>,
     pub meta: ResponseMeta,
+    /// Door / window / lock / trunk state. Decoded only when the
+    /// experimental flag is on; inert otherwise. Each field is None when
+    /// the car didn't report it this poll.
+    pub detail: ClosuresDetail,
+}
+
+/// Security-relevant closure state from the BLE `ClosuresState` message.
+/// `true` = open / unlocked. `frunk` is the front trunk, `trunk` the rear.
+#[derive(Debug, Clone, Default)]
+pub struct ClosuresDetail {
+    pub locked: Option<bool>,
+    pub door_driver_front_open: Option<bool>,
+    pub door_driver_rear_open: Option<bool>,
+    pub door_passenger_front_open: Option<bool>,
+    pub door_passenger_rear_open: Option<bool>,
+    pub frunk_open: Option<bool>,
+    pub trunk_open: Option<bool>,
+    pub window_driver_front_open: Option<bool>,
+    pub window_passenger_front_open: Option<bool>,
+    pub window_driver_rear_open: Option<bool>,
+    pub window_passenger_rear_open: Option<bool>,
+    /// Sunroof opening as a percentage (0 = closed).
+    pub sunroof_percent_open: Option<i32>,
 }
 
 /// Result of a successful `sample_tires` call. Very slow-changing —

--- a/crates/tesla_telemetry/src/sample.rs
+++ b/crates/tesla_telemetry/src/sample.rs
@@ -153,6 +153,24 @@ pub struct DriveResult {
     pub lat: Option<f64>,
     pub lon: Option<f64>,
     pub meta: ResponseMeta,
+    /// Live speed / power / active-route detail. Decoded only when the
+    /// experimental flag is on; inert otherwise.
+    pub detail: DriveDetail,
+}
+
+/// Live driving + navigation detail from the BLE `DriveState` message.
+#[derive(Debug, Clone, Default)]
+pub struct DriveDetail {
+    /// Instantaneous speed, mph.
+    pub speed_mph: Option<f32>,
+    /// Instantaneous drive power, kW (negative = regen).
+    pub power_kw: Option<i32>,
+    /// Active-route destination label, if navigating.
+    pub route_destination: Option<String>,
+    /// Estimated minutes to arrival on the active route.
+    pub route_minutes_to_arrival: Option<f32>,
+    /// Miles remaining to arrival on the active route.
+    pub route_miles_to_arrival: Option<f32>,
 }
 
 /// Result of a successful `sample_climate` call. Slow-changing —
@@ -162,6 +180,24 @@ pub struct ClimateResult {
     pub exterior_temp_c: Option<f64>,
     pub hvac_on: Option<bool>,
     pub meta: ResponseMeta,
+    /// Setpoints / fan / defroster / seat-heater / preconditioning detail.
+    /// Decoded only when the experimental flag is on; inert otherwise.
+    pub detail: ClimateDetail,
+}
+
+/// Extended climate detail from the BLE `ClimateState` message.
+/// Temperatures are Celsius; seat-heater / fan levels are Tesla's raw
+/// integer steps (0 = off).
+#[derive(Debug, Clone, Default)]
+pub struct ClimateDetail {
+    pub driver_setpoint_c: Option<f32>,
+    pub passenger_setpoint_c: Option<f32>,
+    pub fan_status: Option<i32>,
+    pub front_defroster_on: Option<bool>,
+    pub rear_defroster_on: Option<bool>,
+    pub preconditioning: Option<bool>,
+    pub seat_heater_left: Option<i32>,
+    pub seat_heater_right: Option<i32>,
 }
 
 // LocationResult was removed: standalone `state location` queries
@@ -368,6 +404,9 @@ pub async fn sample_drive(vin: &str, adapter: &str) -> Result<DriveResult> {
         lat: pick_f64(&drive, &["latitude", "nativeLatitude", "native_latitude"]),
         lon: pick_f64(&drive, &["longitude", "nativeLongitude", "native_longitude"]),
         meta,
+        // Expanded detail is decoded only on the in-process BLE path; the
+        // legacy shell-out path leaves it empty.
+        detail: DriveDetail::default(),
     })
 }
 
@@ -399,6 +438,9 @@ pub async fn sample_climate(vin: &str, adapter: &str) -> Result<ClimateResult> {
             &["isClimateOn", "is_climate_on", "hvacAuto", "climateKeeperMode"],
         ),
         meta,
+        // Expanded detail is decoded only on the in-process BLE path; the
+        // legacy shell-out path leaves it empty.
+        detail: ClimateDetail::default(),
     })
 }
 

--- a/crates/tesla_telemetry/src/sample.rs
+++ b/crates/tesla_telemetry/src/sample.rs
@@ -182,6 +182,38 @@ pub struct ChargeResult {
     pub battery_pct: Option<f64>,
     pub charging_state: Option<ChargingState>,
     pub meta: ResponseMeta,
+    /// Expanded charging detail. Always decoded (cheap, read-only), but
+    /// only consumed/logged when the experimental flag is on, so a
+    /// normal install is unaffected. Persistence + API/web surfacing is
+    /// a follow-up once the decode is validated on real hardware.
+    pub detail: ChargeDetail,
+}
+
+/// Extra fields from the BLE `ChargeState` message that the car already
+/// sends but the sampler didn't previously surface. All optional — a
+/// field is `None` when the car didn't report it this poll.
+#[derive(Debug, Clone, Default)]
+pub struct ChargeDetail {
+    /// Actual current the charger is delivering, amps.
+    pub charger_actual_current_a: Option<i32>,
+    /// Charging power, kW.
+    pub charger_power_kw: Option<i32>,
+    /// Charger input voltage, volts.
+    pub charger_voltage_v: Option<i32>,
+    /// Set/requested charging amps.
+    pub charging_amps_set: Option<i32>,
+    /// Charge rate, mi/hr added.
+    pub charge_rate_mph: Option<f32>,
+    /// Energy added this session, kWh.
+    pub charge_energy_added_kwh: Option<f32>,
+    /// Charge limit (target SoC), percent.
+    pub charge_limit_soc: Option<i32>,
+    /// Estimated minutes to full charge.
+    pub minutes_to_full_charge: Option<i32>,
+    /// Rated battery range, miles.
+    pub battery_range_mi: Option<f32>,
+    /// Charge port door open.
+    pub charge_port_door_open: Option<bool>,
 }
 
 /// Result of a successful `sample_closures` call. In-memory only —
@@ -363,6 +395,9 @@ pub async fn sample_charge(vin: &str, adapter: &str) -> Result<ChargeResult> {
         // we don't bother parsing charging_state out of the JSON.
         charging_state: None,
         meta,
+        // Expanded detail is decoded only on the in-process BLE path
+        // (sample_charge_ble); the legacy shell-out path leaves it empty.
+        detail: ChargeDetail::default(),
     })
 }
 

--- a/crates/tesla_telemetry/src/sample.rs
+++ b/crates/tesla_telemetry/src/sample.rs
@@ -274,6 +274,17 @@ pub struct Sample {
     /// current location. Pulled from `state drive`. Used as
     /// drive start/end labels in the UI.
     pub location_name: Option<String>,
+    // Charging detail (v11). Populated from ChargeResult.detail only
+    // when the experimental flag is on; None otherwise, so a normal
+    // install writes the same rows it always has. Powers the charging
+    // view under "Driving".
+    pub charger_power_kw: Option<i32>,
+    pub charger_actual_current_a: Option<i32>,
+    pub charger_voltage_v: Option<i32>,
+    pub charge_rate_mph: Option<f32>,
+    pub charge_energy_added_kwh: Option<f32>,
+    pub charge_limit_soc: Option<i32>,
+    pub battery_range_mi: Option<f32>,
     pub source: String,
 }
 

--- a/crates/tesla_telemetry/src/sample_ble.rs
+++ b/crates/tesla_telemetry/src/sample_ble.rs
@@ -15,9 +15,9 @@ use sentryusb_tesla_ble::{
 use tracing::{info, warn};
 
 use crate::sample::{
-    BodyControllerSample, ChargeDetail, ChargeResult, ChargingState, ClimateResult,
-    ClosuresDetail, ClosuresResult, DriveResult, ResponseMeta, Sample, SentryMode, ShiftState,
-    TiresResult, now_secs,
+    BodyControllerSample, ChargeDetail, ChargeResult, ChargingState, ClimateDetail, ClimateResult,
+    ClosuresDetail, ClosuresResult, DriveDetail, DriveResult, ResponseMeta, Sample, SentryMode,
+    ShiftState, TiresResult, now_secs,
 };
 
 /// 1 bar = 14.5038 psi (NIST). Tesla reports TPMS in bar on the wire.
@@ -167,6 +167,33 @@ pub async fn sample_drive_ble(session: &PersistentSession) -> Result<DriveResult
         ),
     }
 
+    use car_server::drive_state as ds;
+    let detail = DriveDetail {
+        speed_mph: drive.optional_speed_float.as_ref().map(|v| {
+            let ds::OptionalSpeedFloat::SpeedFloat(n) = v;
+            *n
+        }),
+        power_kw: drive.optional_power.as_ref().map(|v| {
+            let ds::OptionalPower::Power(n) = v;
+            *n
+        }),
+        route_destination: drive.optional_active_route_destination.as_ref().map(|v| {
+            let ds::OptionalActiveRouteDestination::ActiveRouteDestination(s) = v;
+            s.clone()
+        }),
+        route_minutes_to_arrival: drive
+            .optional_active_route_minutes_to_arrival
+            .as_ref()
+            .map(|v| {
+                let ds::OptionalActiveRouteMinutesToArrival::ActiveRouteMinutesToArrival(n) = v;
+                *n
+            }),
+        route_miles_to_arrival: drive.optional_active_route_miles_to_arrival.as_ref().map(|v| {
+            let ds::OptionalActiveRouteMilesToArrival::ActiveRouteMilesToArrival(n) = v;
+            *n
+        }),
+    };
+
     Ok(DriveResult {
         location_name,
         odometer_mi,
@@ -174,7 +201,25 @@ pub async fn sample_drive_ble(session: &PersistentSession) -> Result<DriveResult
         lat,
         lon,
         meta,
+        detail,
     })
+}
+
+/// Emit a one-line summary of live drive + navigation detail. Logged only
+/// when the experimental flag is on. The route destination is treated as
+/// PII (it is a place name), so the log reports only whether a route is
+/// active plus the ETA / distance, never the destination string.
+pub fn log_drive_detail(c: &DriveResult) {
+    let d = &c.detail;
+    info!(
+        "drive-detail [experimental]: speed_mph={:?} power_kw={:?} navigating={} \
+         eta_min={:?} miles_to_arrival={:?}",
+        d.speed_mph,
+        d.power_kw,
+        d.route_destination.is_some(),
+        d.route_minutes_to_arrival,
+        d.route_miles_to_arrival,
+    );
 }
 
 /// `state climate` over BLE. Interior/exterior temps + HVAC on/off.
@@ -207,12 +252,68 @@ pub async fn sample_climate_ble(session: &PersistentSession) -> Result<ClimateRe
         });
     let meta = build_meta(climate.timestamp.as_ref(), started);
 
+    use car_server::climate_state as cls;
+    let detail = ClimateDetail {
+        driver_setpoint_c: climate.optional_driver_temp_setting.as_ref().map(|v| {
+            let cls::OptionalDriverTempSetting::DriverTempSetting(n) = v;
+            *n
+        }),
+        passenger_setpoint_c: climate.optional_passenger_temp_setting.as_ref().map(|v| {
+            let cls::OptionalPassengerTempSetting::PassengerTempSetting(n) = v;
+            *n
+        }),
+        fan_status: climate.optional_fan_status.as_ref().map(|v| {
+            let cls::OptionalFanStatus::FanStatus(n) = v;
+            *n
+        }),
+        front_defroster_on: climate.optional_is_front_defroster_on.as_ref().map(|v| {
+            let cls::OptionalIsFrontDefrosterOn::IsFrontDefrosterOn(b) = v;
+            *b
+        }),
+        rear_defroster_on: climate.optional_is_rear_defroster_on.as_ref().map(|v| {
+            let cls::OptionalIsRearDefrosterOn::IsRearDefrosterOn(b) = v;
+            *b
+        }),
+        preconditioning: climate.optional_is_preconditioning.as_ref().map(|v| {
+            let cls::OptionalIsPreconditioning::IsPreconditioning(b) = v;
+            *b
+        }),
+        seat_heater_left: climate.optional_seat_heater_left.as_ref().map(|v| {
+            let cls::OptionalSeatHeaterLeft::SeatHeaterLeft(n) = v;
+            *n
+        }),
+        seat_heater_right: climate.optional_seat_heater_right.as_ref().map(|v| {
+            let cls::OptionalSeatHeaterRight::SeatHeaterRight(n) = v;
+            *n
+        }),
+    };
+
     Ok(ClimateResult {
         interior_temp_c,
         exterior_temp_c,
         hvac_on,
         meta,
+        detail,
     })
+}
+
+/// Emit a one-line summary of extended climate detail. Logged only when
+/// the experimental flag is on; lets a tester confirm the `ClimateState`
+/// fields decode correctly off a real car before they reach the UI.
+pub fn log_climate_detail(c: &ClimateResult) {
+    let d = &c.detail;
+    info!(
+        "climate-detail [experimental]: setpoint[drv={:?} pass={:?}] fan={:?} \
+         defrost[front={:?} rear={:?}] precond={:?} seat[l={:?} r={:?}]",
+        d.driver_setpoint_c,
+        d.passenger_setpoint_c,
+        d.fan_status,
+        d.front_defroster_on,
+        d.rear_defroster_on,
+        d.preconditioning,
+        d.seat_heater_left,
+        d.seat_heater_right,
+    );
 }
 
 /// `state charge` over BLE. Battery percent (usable preferred,

--- a/crates/tesla_telemetry/src/sample_ble.rs
+++ b/crates/tesla_telemetry/src/sample_ble.rs
@@ -15,8 +15,9 @@ use sentryusb_tesla_ble::{
 use tracing::{info, warn};
 
 use crate::sample::{
-    BodyControllerSample, ChargeResult, ChargingState, ClimateResult, ClosuresResult,
-    DriveResult, ResponseMeta, Sample, SentryMode, ShiftState, TiresResult, now_secs,
+    BodyControllerSample, ChargeDetail, ChargeResult, ChargingState, ClimateResult,
+    ClosuresResult, DriveResult, ResponseMeta, Sample, SentryMode, ShiftState, TiresResult,
+    now_secs,
 };
 
 /// 1 bar = 14.5038 psi (NIST). Tesla reports TPMS in bar on the wire.
@@ -243,11 +244,82 @@ pub async fn sample_charge_ble(session: &PersistentSession) -> Result<ChargeResu
     let charging_state = charge.charging_state.as_ref().map(map_charging_state);
     let meta = build_meta(charge.timestamp.as_ref(), started);
 
+    // Expanded charging detail — fields the `ChargeState` message already
+    // carries that the sampler didn't previously surface. Decode is cheap
+    // and read-only; the caller only logs/consumes it when the
+    // experimental flag is on, so this is inert on a normal install.
+    let detail = ChargeDetail {
+        charger_actual_current_a: charge.optional_charger_actual_current.as_ref().map(|v| {
+            let car_server::charge_state::OptionalChargerActualCurrent::ChargerActualCurrent(n) = v;
+            *n
+        }),
+        charger_power_kw: charge.optional_charger_power.as_ref().map(|v| {
+            let car_server::charge_state::OptionalChargerPower::ChargerPower(n) = v;
+            *n
+        }),
+        charger_voltage_v: charge.optional_charger_voltage.as_ref().map(|v| {
+            let car_server::charge_state::OptionalChargerVoltage::ChargerVoltage(n) = v;
+            *n
+        }),
+        charging_amps_set: charge.optional_charging_amps.as_ref().map(|v| {
+            let car_server::charge_state::OptionalChargingAmps::ChargingAmps(n) = v;
+            *n
+        }),
+        charge_rate_mph: charge.optional_charge_rate_mph_float.as_ref().map(|v| {
+            let car_server::charge_state::OptionalChargeRateMphFloat::ChargeRateMphFloat(n) = v;
+            *n
+        }),
+        charge_energy_added_kwh: charge.optional_charge_energy_added.as_ref().map(|v| {
+            let car_server::charge_state::OptionalChargeEnergyAdded::ChargeEnergyAdded(n) = v;
+            *n
+        }),
+        charge_limit_soc: charge.optional_charge_limit_soc.as_ref().map(|v| {
+            let car_server::charge_state::OptionalChargeLimitSoc::ChargeLimitSoc(n) = v;
+            *n
+        }),
+        minutes_to_full_charge: charge.optional_minutes_to_full_charge.as_ref().map(|v| {
+            let car_server::charge_state::OptionalMinutesToFullCharge::MinutesToFullCharge(n) = v;
+            *n
+        }),
+        battery_range_mi: charge.optional_battery_range.as_ref().map(|v| {
+            let car_server::charge_state::OptionalBatteryRange::BatteryRange(n) = v;
+            *n
+        }),
+        charge_port_door_open: charge.optional_charge_port_door_open.as_ref().map(|v| {
+            let car_server::charge_state::OptionalChargePortDoorOpen::ChargePortDoorOpen(n) = v;
+            *n
+        }),
+    };
+
     Ok(ChargeResult {
         battery_pct,
         charging_state,
         meta,
+        detail,
     })
+}
+
+/// Emit a one-line summary of the expanded charging detail. Called only
+/// when the experimental flag is on, so a normal install stays quiet.
+/// Lets a tester confirm the new `ChargeState` fields decode correctly
+/// off a real car before we wire them into the DB + API + web UI.
+pub fn log_charge_detail(c: &ChargeResult) {
+    let d = &c.detail;
+    info!(
+        "charge-detail [experimental]: amps={:?} power_kw={:?} volts={:?} amps_set={:?} \
+         rate_mph={:?} added_kwh={:?} limit_soc={:?} mins_to_full={:?} range_mi={:?} \
+         port_open={:?}",
+        d.charger_actual_current_a,
+        d.charger_power_kw,
+        d.charger_voltage_v,
+        d.charging_amps_set,
+        d.charge_rate_mph,
+        d.charge_energy_added_kwh,
+        d.charge_limit_soc,
+        d.minutes_to_full_charge,
+        d.battery_range_mi,
+        d.charge_port_door_open,
+    );
 }
 
 /// `state location` over BLE — raw GPS `(lat, lon)`. Separate from the

--- a/crates/tesla_telemetry/src/sample_ble.rs
+++ b/crates/tesla_telemetry/src/sample_ble.rs
@@ -16,8 +16,8 @@ use tracing::{info, warn};
 
 use crate::sample::{
     BodyControllerSample, ChargeDetail, ChargeResult, ChargingState, ClimateResult,
-    ClosuresResult, DriveResult, ResponseMeta, Sample, SentryMode, ShiftState, TiresResult,
-    now_secs,
+    ClosuresDetail, ClosuresResult, DriveResult, ResponseMeta, Sample, SentryMode, ShiftState,
+    TiresResult, now_secs,
 };
 
 /// 1 bar = 14.5038 psi (NIST). Tesla reports TPMS in bar on the wire.
@@ -357,7 +357,93 @@ pub async fn sample_closures_ble(session: &PersistentSession) -> Result<Closures
     let sentry_mode = closures.sentry_mode_state.as_ref().map(map_sentry_mode);
     let meta = build_meta(closures.timestamp.as_ref(), started);
 
-    Ok(ClosuresResult { sentry_mode, meta })
+    use car_server::closures_state as cs;
+    let detail = ClosuresDetail {
+        locked: closures.optional_locked.as_ref().map(|v| {
+            let cs::OptionalLocked::Locked(b) = v;
+            *b
+        }),
+        door_driver_front_open: closures.optional_door_open_driver_front.as_ref().map(|v| {
+            let cs::OptionalDoorOpenDriverFront::DoorOpenDriverFront(b) = v;
+            *b
+        }),
+        door_driver_rear_open: closures.optional_door_open_driver_rear.as_ref().map(|v| {
+            let cs::OptionalDoorOpenDriverRear::DoorOpenDriverRear(b) = v;
+            *b
+        }),
+        door_passenger_front_open: closures.optional_door_open_passenger_front.as_ref().map(|v| {
+            let cs::OptionalDoorOpenPassengerFront::DoorOpenPassengerFront(b) = v;
+            *b
+        }),
+        door_passenger_rear_open: closures.optional_door_open_passenger_rear.as_ref().map(|v| {
+            let cs::OptionalDoorOpenPassengerRear::DoorOpenPassengerRear(b) = v;
+            *b
+        }),
+        frunk_open: closures.optional_door_open_trunk_front.as_ref().map(|v| {
+            let cs::OptionalDoorOpenTrunkFront::DoorOpenTrunkFront(b) = v;
+            *b
+        }),
+        trunk_open: closures.optional_door_open_trunk_rear.as_ref().map(|v| {
+            let cs::OptionalDoorOpenTrunkRear::DoorOpenTrunkRear(b) = v;
+            *b
+        }),
+        window_driver_front_open: closures.optional_window_open_driver_front.as_ref().map(|v| {
+            let cs::OptionalWindowOpenDriverFront::WindowOpenDriverFront(b) = v;
+            *b
+        }),
+        window_passenger_front_open: closures
+            .optional_window_open_passenger_front
+            .as_ref()
+            .map(|v| {
+                let cs::OptionalWindowOpenPassengerFront::WindowOpenPassengerFront(b) = v;
+                *b
+            }),
+        window_driver_rear_open: closures.optional_window_open_driver_rear.as_ref().map(|v| {
+            let cs::OptionalWindowOpenDriverRear::WindowOpenDriverRear(b) = v;
+            *b
+        }),
+        window_passenger_rear_open: closures
+            .optional_window_open_passenger_rear
+            .as_ref()
+            .map(|v| {
+                let cs::OptionalWindowOpenPassengerRear::WindowOpenPassengerRear(b) = v;
+                *b
+            }),
+        sunroof_percent_open: closures.optional_sun_roof_percent_open.as_ref().map(|v| {
+            let cs::OptionalSunRoofPercentOpen::SunRoofPercentOpen(n) = v;
+            *n
+        }),
+    };
+
+    Ok(ClosuresResult {
+        sentry_mode,
+        meta,
+        detail,
+    })
+}
+
+/// Emit a one-line summary of door / window / lock state. Logged only
+/// when the experimental flag is on so a normal install stays quiet;
+/// lets a tester confirm the `ClosuresState` fields decode correctly off
+/// a real car before they are surfaced in the API and web UI.
+pub fn log_closures_detail(c: &ClosuresResult) {
+    let d = &c.detail;
+    info!(
+        "closures-detail [experimental]: locked={:?} doors[df={:?} dr={:?} pf={:?} pr={:?}] \
+         frunk={:?} trunk={:?} windows[df={:?} pf={:?} dr={:?} pr={:?}] sunroof%={:?}",
+        d.locked,
+        d.door_driver_front_open,
+        d.door_driver_rear_open,
+        d.door_passenger_front_open,
+        d.door_passenger_rear_open,
+        d.frunk_open,
+        d.trunk_open,
+        d.window_driver_front_open,
+        d.window_passenger_front_open,
+        d.window_driver_rear_open,
+        d.window_passenger_rear_open,
+        d.sunroof_percent_open,
+    );
 }
 
 /// `state tire-pressure` over BLE. Converts Tesla's native bar →


### PR DESCRIPTION
## Slice 1 of 3 — foundation

Master flag `SENTRYUSB_EXPERIMENTAL` (default **OFF**) + expanded BLE telemetry decode + the DB columns the later slices build on. Self-contained and immediately reviewable.

**What it adds**
- The `experimental_enabled()` flag plumbing (read fresh per tick/request; no restart to toggle).
- Expanded `sample_charge_ble` / state decode behind the flag: charging amps/kW/V/rate/limit/range, drive speed/power/nav, climate, closures — written only when the flag is on.
- Additive-nullable DB columns on `telemetry_samples` (v10→v11 charge detail).

**Safety**
- Flag OFF ⇒ runtime behavior unchanged (decode persists nothing).
- Schema change is additive-nullable + downgrade-safe (older binary ignores the new columns; no rewrites). The migration runs unconditionally on first open — see the schema docstring; **measure the index/column add on a production-sized DB** before relying on it on a tight power budget.

Part of a 3-PR series: **this (foundation)** → charging history → architecture consolidation.
