### PR TITLE
Slice 2/3: charging history (web + API) [stacked on #66]

### DIFF
--- a/crates/api/src/charging.rs
+++ b/crates/api/src/charging.rs
@@ -1,0 +1,336 @@
+//! Charging history derived on-demand from `telemetry_samples`.
+//!
+//! Charge sessions are not a stored table — they are grouped at query
+//! time from the per-sample charge columns the experimental sampler
+//! writes (`charger_power_kw`, `charge_rate_mph`, ...). A session is a
+//! contiguous run of actively-charging samples; a gap longer than
+//! `SESSION_GAP_SECS` starts a new one. Energy reported by the car is
+//! cumulative within a plug-in and resets to zero on unplug, so the
+//! per-session total is the span between the first and last reading.
+//!
+//! When the experimental flag is off the charge columns are NULL for
+//! every row, so the grouping yields nothing and both endpoints return
+//! empty results. The flag is also checked up front so a normal install
+//! does no query work and surfaces no charging UI.
+
+use axum::Json;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use serde::Serialize;
+
+use crate::router::AppState;
+
+/// A gap larger than this between consecutive charging samples ends the
+/// session. The sampler polls charge state well inside this window while
+/// a car is plugged in; 30 minutes tolerates a missed poll or two
+/// without merging two genuinely separate plug-ins.
+const SESSION_GAP_SECS: i64 = 30 * 60;
+
+/// One row pulled from `telemetry_samples`, already filtered to samples
+/// where the car was drawing power.
+struct ChargeRow {
+    ts: i64,
+    power_kw: Option<i64>,
+    current_a: Option<i64>,
+    voltage_v: Option<i64>,
+    rate_mph: Option<f64>,
+    energy_added_kwh: Option<f64>,
+    limit_soc: Option<i64>,
+    range_mi: Option<f64>,
+    battery_pct: Option<f64>,
+    location: Option<String>,
+}
+
+/// Summary of one charge session for the list view.
+#[derive(Serialize)]
+struct ChargeSessionSummary {
+    /// Session id == start timestamp in unix seconds. Stable and
+    /// directly usable as the detail-endpoint key.
+    id: i64,
+    start_ms: i64,
+    end_ms: i64,
+    duration_secs: i64,
+    location: Option<String>,
+    energy_added_kwh: Option<f64>,
+    peak_power_kw: Option<i64>,
+    start_soc: Option<f64>,
+    end_soc: Option<f64>,
+    start_range_mi: Option<f64>,
+    end_range_mi: Option<f64>,
+    charge_limit_soc: Option<i64>,
+}
+
+/// One point on the detail charts.
+#[derive(Serialize)]
+struct ChargePoint {
+    ts: i64,
+    power_kw: Option<i64>,
+    rate_mph: Option<f64>,
+    soc: Option<f64>,
+    range_mi: Option<f64>,
+    energy_added_kwh: Option<f64>,
+}
+
+#[derive(Serialize)]
+struct ChargeSessionDetail {
+    #[serde(flatten)]
+    summary: ChargeSessionSummary,
+    peak_current_a: Option<i64>,
+    peak_voltage_v: Option<i64>,
+    peak_rate_mph: Option<f64>,
+    points: Vec<ChargePoint>,
+}
+
+/// Whether the master experimental opt-in is set. Mirrors how the
+/// telemetry sampler reads the same key, so both sides agree on what
+/// "on" means. Read fresh per request — config changes without a
+/// daemon restart and these endpoints are low-traffic.
+fn experimental_enabled() -> bool {
+    let path = sentryusb_config::find_config_path();
+    match sentryusb_config::parse_file(path) {
+        Ok((active, commented)) => {
+            match sentryusb_config::get_config_value(&active, &commented, "SENTRYUSB_EXPERIMENTAL") {
+                Some(v) => matches!(v.trim().to_ascii_lowercase().as_str(), "yes" | "true" | "1"),
+                None => false,
+            }
+        }
+        Err(_) => false,
+    }
+}
+
+/// A sample counts as actively charging when the car reports nonzero
+/// power or a nonzero charge rate. Parked-and-plugged rows (power 0,
+/// carried-over energy) are excluded so they don't pad a session.
+fn is_charging(power_kw: Option<i64>, rate_mph: Option<f64>) -> bool {
+    power_kw.is_some_and(|p| p > 0) || rate_mph.is_some_and(|r| r > 0.0)
+}
+
+/// Pull charging samples in `[from, to]` ordered by time. `to` of
+/// `None` means "no upper bound".
+fn load_charge_rows(
+    conn: &rusqlite::Connection,
+    from: i64,
+    to: Option<i64>,
+) -> anyhow::Result<Vec<ChargeRow>> {
+    let upper = to.unwrap_or(i64::MAX);
+    let mut stmt = conn.prepare(
+        "SELECT ts, charger_power_kw, charger_actual_current_a, charger_voltage_v, \
+                charge_rate_mph, charge_energy_added_kwh, charge_limit_soc, \
+                battery_range_mi, battery_pct, location_name \
+         FROM telemetry_samples \
+         WHERE ts BETWEEN ?1 AND ?2 \
+           AND (charger_power_kw IS NOT NULL OR charge_rate_mph IS NOT NULL) \
+         ORDER BY ts ASC",
+    )?;
+    let rows = stmt.query_map(rusqlite::params![from, upper], |r| {
+        Ok(ChargeRow {
+            ts: r.get(0)?,
+            power_kw: r.get(1)?,
+            current_a: r.get(2)?,
+            voltage_v: r.get(3)?,
+            rate_mph: r.get(4)?,
+            energy_added_kwh: r.get(5)?,
+            limit_soc: r.get(6)?,
+            range_mi: r.get(7)?,
+            battery_pct: r.get(8)?,
+            location: r.get(9)?,
+        })
+    })?;
+    let mut out = Vec::new();
+    for row in rows {
+        let row = row?;
+        if is_charging(row.power_kw, row.rate_mph) {
+            out.push(row);
+        }
+    }
+    Ok(out)
+}
+
+/// Split time-ordered, already-filtered charging rows into sessions on
+/// the gap threshold. Each inner Vec is one session, in time order.
+fn group_sessions(rows: Vec<ChargeRow>) -> Vec<Vec<ChargeRow>> {
+    let mut sessions: Vec<Vec<ChargeRow>> = Vec::new();
+    for row in rows {
+        match sessions.last_mut() {
+            Some(cur) if row.ts - cur.last().unwrap().ts <= SESSION_GAP_SECS => cur.push(row),
+            _ => sessions.push(vec![row]),
+        }
+    }
+    sessions
+}
+
+/// Reduce one session's rows to a summary. `rows` is non-empty and
+/// time-ordered.
+fn summarize(rows: &[ChargeRow]) -> ChargeSessionSummary {
+    let first = &rows[0];
+    let last = &rows[rows.len() - 1];
+
+    // Energy is cumulative within a plug-in; the span between the first
+    // and last reading is what this session added. Clamp at zero so a
+    // mid-session counter reset can't produce a negative.
+    let energy_added_kwh = match (first.energy_added_kwh, last.energy_added_kwh) {
+        (Some(a), Some(b)) => Some((b - a).max(0.0)),
+        (None, Some(b)) => Some(b),
+        _ => None,
+    };
+
+    ChargeSessionSummary {
+        id: first.ts,
+        start_ms: first.ts * 1000,
+        end_ms: last.ts * 1000,
+        duration_secs: last.ts - first.ts,
+        location: rows.iter().find_map(|r| r.location.clone()),
+        energy_added_kwh,
+        peak_power_kw: rows.iter().filter_map(|r| r.power_kw).max(),
+        start_soc: rows.iter().find_map(|r| r.battery_pct),
+        end_soc: rows.iter().rev().find_map(|r| r.battery_pct),
+        start_range_mi: rows.iter().find_map(|r| r.range_mi),
+        end_range_mi: rows.iter().rev().find_map(|r| r.range_mi),
+        charge_limit_soc: rows.iter().rev().find_map(|r| r.limit_soc),
+    }
+}
+
+/// GET /api/charging
+///
+/// Charge sessions newest-first. Empty when the experimental flag is off
+/// or no charging has been sampled.
+pub async fn list_charging(
+    State(state): State<AppState>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    if !experimental_enabled() {
+        return (StatusCode::OK, Json(serde_json::json!({ "sessions": [] })));
+    }
+
+    let result = state
+        .drives
+        .store
+        .with_locked_conn(|conn| load_charge_rows(conn, 0, None));
+
+    match result {
+        Ok(rows) => {
+            let mut sessions: Vec<ChargeSessionSummary> =
+                group_sessions(rows).iter().map(|s| summarize(s)).collect();
+            sessions.sort_by(|a, b| b.id.cmp(&a.id));
+            (
+                StatusCode::OK,
+                Json(serde_json::json!({ "sessions": sessions })),
+            )
+        }
+        Err(e) => crate::json_error(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
+    }
+}
+
+/// GET /api/charging/{id}
+///
+/// Detail for the session whose start timestamp is `id`, including the
+/// per-sample series for the power / SoC charts. Rows are re-grouped
+/// from `id` forward and the first session returned, so the endpoint is
+/// stateless and needs no stored session table.
+pub async fn single_charging(
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    if !experimental_enabled() {
+        return crate::json_error(StatusCode::NOT_FOUND, "charging history not enabled");
+    }
+
+    // Bound the scan so a session that never closes can't read the whole
+    // table. One plug-in can't plausibly exceed this; the gap split ends
+    // the session well before the bound in practice.
+    let window_end = id + 7 * 24 * 60 * 60;
+    let result = state
+        .drives
+        .store
+        .with_locked_conn(|conn| load_charge_rows(conn, id, Some(window_end)));
+
+    let rows = match result {
+        Ok(rows) => rows,
+        Err(e) => return crate::json_error(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
+    };
+
+    let session = match group_sessions(rows).into_iter().next() {
+        Some(s) => s,
+        None => return crate::json_error(StatusCode::NOT_FOUND, "charge session not found"),
+    };
+
+    let summary = summarize(&session);
+    let points: Vec<ChargePoint> = session
+        .iter()
+        .map(|r| ChargePoint {
+            ts: r.ts * 1000,
+            power_kw: r.power_kw,
+            rate_mph: r.rate_mph,
+            soc: r.battery_pct,
+            range_mi: r.range_mi,
+            energy_added_kwh: r.energy_added_kwh,
+        })
+        .collect();
+
+    let detail = ChargeSessionDetail {
+        peak_current_a: session.iter().filter_map(|r| r.current_a).max(),
+        peak_voltage_v: session.iter().filter_map(|r| r.voltage_v).max(),
+        peak_rate_mph: session
+            .iter()
+            .filter_map(|r| r.rate_mph)
+            .fold(None, |acc: Option<f64>, v| Some(acc.map_or(v, |a| a.max(v)))),
+        summary,
+        points,
+    };
+
+    (StatusCode::OK, Json(serde_json::to_value(detail).unwrap()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(ts: i64, power: Option<i64>, rate: Option<f64>, energy: Option<f64>) -> ChargeRow {
+        ChargeRow {
+            ts,
+            power_kw: power,
+            current_a: None,
+            voltage_v: None,
+            rate_mph: rate,
+            energy_added_kwh: energy,
+            limit_soc: None,
+            range_mi: None,
+            battery_pct: None,
+            location: None,
+        }
+    }
+
+    #[test]
+    fn gap_splits_into_two_sessions() {
+        let rows = vec![
+            row(1_000, Some(7), Some(25.0), Some(0.0)),
+            row(1_300, Some(7), Some(25.0), Some(1.0)),
+            // > 30 min later — new session
+            row(1_300 + SESSION_GAP_SECS + 1, Some(11), Some(40.0), Some(0.0)),
+        ];
+        let sessions = group_sessions(rows);
+        assert_eq!(sessions.len(), 2);
+        assert_eq!(sessions[0].len(), 2);
+        assert_eq!(sessions[1].len(), 1);
+    }
+
+    #[test]
+    fn energy_total_is_first_to_last_span() {
+        let rows = vec![
+            row(1_000, Some(7), Some(25.0), Some(2.0)),
+            row(1_300, Some(7), Some(25.0), Some(9.4)),
+        ];
+        let s = summarize(&rows);
+        assert_eq!(s.energy_added_kwh, Some(7.4));
+        assert_eq!(s.peak_power_kw, Some(7));
+        assert_eq!(s.duration_secs, 300);
+        assert_eq!(s.id, 1_000);
+    }
+
+    #[test]
+    fn non_charging_rows_excluded_by_is_charging() {
+        assert!(!is_charging(Some(0), Some(0.0)));
+        assert!(!is_charging(None, None));
+        assert!(is_charging(Some(7), None));
+        assert!(is_charging(None, Some(12.0)));
+    }
+}

--- a/crates/api/src/charging.rs
+++ b/crates/api/src/charging.rs
@@ -38,6 +38,9 @@ struct ChargeRow {
     limit_soc: Option<i64>,
     range_mi: Option<f64>,
     battery_pct: Option<f64>,
+    battery_temp_c: Option<f64>,
+    interior_temp_c: Option<f64>,
+    exterior_temp_c: Option<f64>,
     location: Option<String>,
 }
 
@@ -60,24 +63,35 @@ struct ChargeSessionSummary {
     charge_limit_soc: Option<i64>,
 }
 
-/// One point on the detail charts.
+/// One point on the detail charts. Carries every per-sample series the
+/// charging view plots — all sourced from columns the sampler already
+/// records, so adding them costs nothing extra on the device.
 #[derive(Serialize)]
 struct ChargePoint {
     ts: i64,
     power_kw: Option<i64>,
+    current_a: Option<i64>,
+    voltage_v: Option<i64>,
     rate_mph: Option<f64>,
     soc: Option<f64>,
     range_mi: Option<f64>,
     energy_added_kwh: Option<f64>,
+    battery_temp_c: Option<f64>,
+    interior_temp_c: Option<f64>,
+    exterior_temp_c: Option<f64>,
 }
 
 #[derive(Serialize)]
 struct ChargeSessionDetail {
     #[serde(flatten)]
     summary: ChargeSessionSummary,
+    avg_power_kw: Option<f64>,
     peak_current_a: Option<i64>,
+    avg_current_a: Option<f64>,
     peak_voltage_v: Option<i64>,
+    avg_voltage_v: Option<f64>,
     peak_rate_mph: Option<f64>,
+    avg_battery_temp_c: Option<f64>,
     points: Vec<ChargePoint>,
 }
 
@@ -98,6 +112,18 @@ fn experimental_enabled() -> bool {
     }
 }
 
+/// Mean of an iterator of values, or None when it yields nothing. Used
+/// for the detail view's average power / current / voltage / temp stats.
+fn avg(it: impl Iterator<Item = f64>) -> Option<f64> {
+    let mut sum = 0.0;
+    let mut n = 0u32;
+    for v in it {
+        sum += v;
+        n += 1;
+    }
+    if n == 0 { None } else { Some(sum / n as f64) }
+}
+
 /// A sample counts as actively charging when the car reports nonzero
 /// power or a nonzero charge rate. Parked-and-plugged rows (power 0,
 /// carried-over energy) are excluded so they don't pad a session.
@@ -116,7 +142,8 @@ fn load_charge_rows(
     let mut stmt = conn.prepare(
         "SELECT ts, charger_power_kw, charger_actual_current_a, charger_voltage_v, \
                 charge_rate_mph, charge_energy_added_kwh, charge_limit_soc, \
-                battery_range_mi, battery_pct, location_name \
+                battery_range_mi, battery_pct, \
+                battery_temp_c, interior_temp_c, exterior_temp_c, location_name \
          FROM telemetry_samples \
          WHERE ts BETWEEN ?1 AND ?2 \
            AND (charger_power_kw IS NOT NULL OR charge_rate_mph IS NOT NULL) \
@@ -133,7 +160,10 @@ fn load_charge_rows(
             limit_soc: r.get(6)?,
             range_mi: r.get(7)?,
             battery_pct: r.get(8)?,
-            location: r.get(9)?,
+            battery_temp_c: r.get(9)?,
+            interior_temp_c: r.get(10)?,
+            exterior_temp_c: r.get(11)?,
+            location: r.get(12)?,
         })
     })?;
     let mut out = Vec::new();
@@ -259,20 +289,29 @@ pub async fn single_charging(
         .map(|r| ChargePoint {
             ts: r.ts * 1000,
             power_kw: r.power_kw,
+            current_a: r.current_a,
+            voltage_v: r.voltage_v,
             rate_mph: r.rate_mph,
             soc: r.battery_pct,
             range_mi: r.range_mi,
             energy_added_kwh: r.energy_added_kwh,
+            battery_temp_c: r.battery_temp_c,
+            interior_temp_c: r.interior_temp_c,
+            exterior_temp_c: r.exterior_temp_c,
         })
         .collect();
 
     let detail = ChargeSessionDetail {
+        avg_power_kw: avg(session.iter().filter_map(|r| r.power_kw.map(|v| v as f64))),
         peak_current_a: session.iter().filter_map(|r| r.current_a).max(),
+        avg_current_a: avg(session.iter().filter_map(|r| r.current_a.map(|v| v as f64))),
         peak_voltage_v: session.iter().filter_map(|r| r.voltage_v).max(),
+        avg_voltage_v: avg(session.iter().filter_map(|r| r.voltage_v.map(|v| v as f64))),
         peak_rate_mph: session
             .iter()
             .filter_map(|r| r.rate_mph)
             .fold(None, |acc: Option<f64>, v| Some(acc.map_or(v, |a| a.max(v)))),
+        avg_battery_temp_c: avg(session.iter().filter_map(|r| r.battery_temp_c)),
         summary,
         points,
     };
@@ -295,6 +334,9 @@ mod tests {
             limit_soc: None,
             range_mi: None,
             battery_pct: None,
+            battery_temp_c: None,
+            interior_temp_c: None,
+            exterior_temp_c: None,
             location: None,
         }
     }

--- a/crates/api/src/charging.rs
+++ b/crates/api/src/charging.rs
@@ -42,6 +42,8 @@ struct ChargeRow {
     interior_temp_c: Option<f64>,
     exterior_temp_c: Option<f64>,
     location: Option<String>,
+    lat: Option<f64>,
+    lon: Option<f64>,
 }
 
 /// Summary of one charge session for the list view.
@@ -54,6 +56,8 @@ struct ChargeSessionSummary {
     end_ms: i64,
     duration_secs: i64,
     location: Option<String>,
+    location_lat: Option<f64>,
+    location_lon: Option<f64>,
     energy_added_kwh: Option<f64>,
     peak_power_kw: Option<i64>,
     start_soc: Option<f64>,
@@ -143,7 +147,8 @@ fn load_charge_rows(
         "SELECT ts, charger_power_kw, charger_actual_current_a, charger_voltage_v, \
                 charge_rate_mph, charge_energy_added_kwh, charge_limit_soc, \
                 battery_range_mi, battery_pct, \
-                battery_temp_c, interior_temp_c, exterior_temp_c, location_name \
+                battery_temp_c, interior_temp_c, exterior_temp_c, location_name, \
+                latitude, longitude \
          FROM telemetry_samples \
          WHERE ts BETWEEN ?1 AND ?2 \
            AND (charger_power_kw IS NOT NULL OR charge_rate_mph IS NOT NULL) \
@@ -164,6 +169,8 @@ fn load_charge_rows(
             interior_temp_c: r.get(10)?,
             exterior_temp_c: r.get(11)?,
             location: r.get(12)?,
+            lat: r.get(13)?,
+            lon: r.get(14)?,
         })
     })?;
     let mut out = Vec::new();
@@ -210,6 +217,8 @@ fn summarize(rows: &[ChargeRow]) -> ChargeSessionSummary {
         end_ms: last.ts * 1000,
         duration_secs: last.ts - first.ts,
         location: rows.iter().find_map(|r| r.location.clone()),
+        location_lat: rows.iter().find_map(|r| r.lat),
+        location_lon: rows.iter().find_map(|r| r.lon),
         energy_added_kwh,
         peak_power_kw: rows.iter().filter_map(|r| r.power_kw).max(),
         start_soc: rows.iter().find_map(|r| r.battery_pct),
@@ -338,6 +347,8 @@ mod tests {
             interior_temp_c: None,
             exterior_temp_c: None,
             location: None,
+            lat: None,
+            lon: None,
         }
     }
 

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -26,6 +26,7 @@ pub mod devices;
 pub mod cloud;
 pub mod snapshots;
 pub mod keep_accessory;
+pub mod charging;
 
 pub use auth::{AuthState, init_auth};
 pub use router::build_router;

--- a/crates/api/src/router.rs
+++ b/crates/api/src/router.rs
@@ -200,6 +200,10 @@ pub fn build_router(state: AppState) -> Router {
             "/api/telemetry/tire-history",
             get(crate::drives_handler::tire_history),
         )
+        // Charging — sessions derived on-demand from the per-sample
+        // charge columns. Empty unless the experimental flag is on.
+        .route("/api/charging", get(crate::charging::list_charging))
+        .route("/api/charging/{id}", get(crate::charging::single_charging))
         // Keep-awake
         .route("/api/keep-awake/start", post(crate::keep_awake::start))
         .route("/api/keep-awake/stop", post(crate::keep_awake::stop))

--- a/crates/drives/src/schema.rs
+++ b/crates/drives/src/schema.rs
@@ -78,7 +78,7 @@ use rusqlite::{params, Connection, OptionalExtension};
 /// Also: `software_version` columns on both tables are kept for
 /// forward-compat but no longer written — Tesla doesn't expose
 /// `car_version` over BLE state queries.
-pub const CURRENT_SCHEMA_VERSION: i32 = 11;
+pub const CURRENT_SCHEMA_VERSION: i32 = 12;
 
 /// v1 DDL. Each statement is idempotent (`IF NOT EXISTS`) so `migrate()`
 /// is safe on every startup. Column shapes and names match Go exactly —
@@ -277,6 +277,17 @@ pub const V11_TELEMETRY_CHARGE_COLUMNS: &[(&str, &str)] = &[
     ("battery_range_mi", "REAL"),
 ];
 
+/// v12 raw GPS columns on `telemetry_samples`. The coordinates are
+/// already decoded from the bundled `LocationState` (they feed the
+/// keep-accessory geofence); persisting them lets a parked-and-charging
+/// sample carry the charger's location so the charging view can pin it
+/// on a map. Written only when the experimental flag is on — NULL
+/// otherwise, so a normal install is unaffected.
+pub const V12_TELEMETRY_GPS_COLUMNS: &[(&str, &str)] = &[
+    ("latitude", "REAL"),
+    ("longitude", "REAL"),
+];
+
 /// v10 per-clip location-name rollups on `routes`. Populated by
 /// the aggregator from the first / last non-null sample in the
 /// clip's 60s window.
@@ -352,6 +363,7 @@ pub fn migrate(conn: &Connection) -> Result<()> {
         .chain(V9_TELEMETRY_COLUMNS.iter())
         .chain(V10_TELEMETRY_COLUMNS.iter())
         .chain(V11_TELEMETRY_CHARGE_COLUMNS.iter())
+        .chain(V12_TELEMETRY_GPS_COLUMNS.iter())
     {
         if existing_tele.contains(*name) {
             continue;

--- a/crates/drives/src/schema.rs
+++ b/crates/drives/src/schema.rs
@@ -34,12 +34,12 @@ use rusqlite::{params, Connection, OptionalExtension};
 /// via `state tire-pressure` in PSI. Per-route columns store the
 /// latest non-null reading per tire within each clip's 60s window;
 /// per-drive rollup takes the latest across the drive's clips.
-/// All nullable — cars without TPMS or pre-TPMS-sampler drives
+/// All nullable â€” cars without TPMS or pre-TPMS-sampler drives
 /// simply stay NULL and the UI hides the row.
 ///
 /// v7 -> v8: TPMS unit fix. v7 sampler stored raw `state
 /// tire-pressure` values as `tire_*_psi` but Tesla actually returns
-/// BAR — typical readings showed up as 3.0 instead of the expected
+/// BAR â€” typical readings showed up as 3.0 instead of the expected
 /// ~43 PSI. v8 multiplies any historically-stored value < 5 by
 /// 14.5038 in both `telemetry_samples` and `routes`. The bound is
 /// safe because a real PSI reading can't be < 5 on a drivable tire,
@@ -53,35 +53,35 @@ use rusqlite::{params, Connection, OptionalExtension};
 /// at a 15-min throttle so we don't waste BLE air time on a field
 /// that changes once per OTA. The per-drive rollup uses
 /// `software_version` to map to a FSD release (via a hardcoded
-/// lookup) — but only displayed on drives where FSD was actually
+/// lookup) â€” but only displayed on drives where FSD was actually
 /// engaged at some point.
 ///
 /// `idx_routes_start_ts` cleanup (version-agnostic): the index over
-/// `routes.start_ts` — shipped by every V1_SCHEMA from v1 through v9
-/// — indexed an always-NULL column (start_ts is bound to SQL NULL on
+/// `routes.start_ts` â€” shipped by every V1_SCHEMA from v1 through v9
+/// â€” indexed an always-NULL column (start_ts is bound to SQL NULL on
 /// every insert). V1_SCHEMA no longer ships it; `migrate()` runs an
 /// unconditional `DROP INDEX IF EXISTS` near the top so every cohort
 /// (pre-v6 / v6 / v7 / v8 / v9 / fresh) ends up without the dead
 /// index in one pass. `IF EXISTS` makes the call a no-op on fresh
 /// DBs and on any subsequent open.
 ///
-/// v9 -> v10: add `location_name` (TEXT) to `telemetry_samples` —
+/// v9 -> v10: add `location_name` (TEXT) to `telemetry_samples` â€”
 /// Tesla's reverse-geocoded address string from `state drive`'s
 /// `locationState.locationName` field. Per-clip rollups
 /// `location_name_start` / `location_name_end` added to `routes`,
 /// populated by the aggregator from the first / last non-null
 /// sample in each clip's 60s window. The per-drive rollup chains
 /// these across clips so each drive in the list gets a friendly
-/// start → end label without needing to call an external
+/// start â†’ end label without needing to call an external
 /// reverse-geocoding API.
 ///
 /// Also: `software_version` columns on both tables are kept for
-/// forward-compat but no longer written — Tesla doesn't expose
+/// forward-compat but no longer written â€” Tesla doesn't expose
 /// `car_version` over BLE state queries.
 pub const CURRENT_SCHEMA_VERSION: i32 = 12;
 
 /// v1 DDL. Each statement is idempotent (`IF NOT EXISTS`) so `migrate()`
-/// is safe on every startup. Column shapes and names match Go exactly —
+/// is safe on every startup. Column shapes and names match Go exactly â€”
 /// cross-binary DBs must not diverge.
 const V1_SCHEMA: &[&str] = &[
     "CREATE TABLE IF NOT EXISTS meta (
@@ -110,7 +110,7 @@ const V1_SCHEMA: &[&str] = &[
     ) WITHOUT ROWID",
 
     "CREATE INDEX IF NOT EXISTS idx_routes_date_dir ON routes(date_dir)",
-    // Note: idx_routes_start_ts is intentionally NOT created here — see
+    // Note: idx_routes_start_ts is intentionally NOT created here â€” see
     // the `idx_routes_start_ts cleanup` paragraph above CURRENT_SCHEMA_VERSION
     // for the reasoning. migrate() drops any pre-existing copy
     // unconditionally on every open.
@@ -164,7 +164,7 @@ pub const V3_ROUTE_CLOUD_COLUMNS: &[(&str, &str)] = &[
     ("cloud_route_id", "TEXT"),
 ];
 
-/// Partial index on `cloud_uploaded_at IS NULL` rows only — keeps the
+/// Partial index on `cloud_uploaded_at IS NULL` rows only â€” keeps the
 /// steady-state size near zero (uploaded rows aren't indexed). Drives the
 /// uploader's `SELECT file FROM routes WHERE cloud_uploaded_at IS NULL`
 /// hot path.
@@ -183,7 +183,7 @@ pub const V4_ROUTE_TESSIE_COLUMNS: &[(&str, &str)] = &[
 
 /// v6 telemetry rollups on `routes`. Populated by the aggregator from
 /// `telemetry_samples` rows whose `ts` falls in `[start_ts, end_ts]`.
-/// All nullable — a drive that ran before telemetry was enabled, or one
+/// All nullable â€” a drive that ran before telemetry was enabled, or one
 /// where the sampler missed every window, simply has NULLs here. The
 /// drives-tab UI reads these directly so the hot path never joins the
 /// samples table at render time.
@@ -199,7 +199,7 @@ pub const V6_ROUTE_TELEMETRY_COLUMNS: &[(&str, &str)] = &[
 
 /// v6 standalone tables. `telemetry_samples` is keyed on `ts` (unix
 /// seconds) and uses WITHOUT ROWID so the PK doubles as the storage
-/// order — range scans on `ts` for the aggregator's per-route joins
+/// order â€” range scans on `ts` for the aggregator's per-route joins
 /// are then a B-tree slice with no separate index needed. Every
 /// telemetry column is nullable because the sampler uses two source
 /// paths: `state climate/charge` (full data) and `body-controller-state`
@@ -234,7 +234,7 @@ pub const V7_TELEMETRY_TPMS_COLUMNS: &[(&str, &str)] = &[
 /// v7 TPMS rollup columns on `routes`. Latest non-null reading per
 /// tire within the clip's 60s window. Tire pressure changes slowly
 /// (minutes-to-hours) so "latest" is a sensible single-value
-/// representative — drive-level rollup takes the latest across all
+/// representative â€” drive-level rollup takes the latest across all
 /// the drive's clips.
 pub const V7_ROUTE_TPMS_COLUMNS: &[(&str, &str)] = &[
     ("tire_fl_psi", "REAL"),
@@ -247,14 +247,14 @@ pub const V7_ROUTE_TPMS_COLUMNS: &[(&str, &str)] = &[
 /// `odometer_mi` is Tesla's native unit. `software_version` is the
 /// Tesla OS version string (e.g. "2026.2.9.10"). The sampler only
 /// re-fetches software_version every ~15 min, so most sample rows
-/// will have it NULL — the per-route aggregator picks the latest
+/// will have it NULL â€” the per-route aggregator picks the latest
 /// non-null in each window.
 pub const V9_TELEMETRY_COLUMNS: &[(&str, &str)] = &[
     ("odometer_mi", "REAL"),
     ("software_version", "TEXT"),
 ];
 
-/// v10 `location_name` column on `telemetry_samples` — Tesla's
+/// v10 `location_name` column on `telemetry_samples` â€” Tesla's
 /// reverse-geocoded address from `state drive`. Free human-readable
 /// drive start/end labels without needing to call a geocoder.
 pub const V10_TELEMETRY_COLUMNS: &[(&str, &str)] = &[
@@ -263,7 +263,7 @@ pub const V10_TELEMETRY_COLUMNS: &[(&str, &str)] = &[
 
 /// v11 charging-detail columns on `telemetry_samples`. Decoded from the
 /// BLE `ChargeState` message and written only when the experimental
-/// sampler flag is on (SENTRYUSB_EXPERIMENTAL) — NULL otherwise, so a
+/// sampler flag is on (SENTRYUSB_EXPERIMENTAL) â€” NULL otherwise, so a
 /// normal install is unaffected. Columns are added for everyone (cheap,
 /// nullable) so flipping the flag needs no schema change. Powers the
 /// charging view under "Driving".
@@ -281,7 +281,7 @@ pub const V11_TELEMETRY_CHARGE_COLUMNS: &[(&str, &str)] = &[
 /// already decoded from the bundled `LocationState` (they feed the
 /// keep-accessory geofence); persisting them lets a parked-and-charging
 /// sample carry the charger's location so the charging view can pin it
-/// on a map. Written only when the experimental flag is on — NULL
+/// on a map. Written only when the experimental flag is on â€” NULL
 /// otherwise, so a normal install is unaffected.
 pub const V12_TELEMETRY_GPS_COLUMNS: &[(&str, &str)] = &[
     ("latitude", "REAL"),
@@ -307,7 +307,7 @@ pub const V9_ROUTE_COLUMNS: &[(&str, &str)] = &[
     ("software_version", "TEXT"),
 ];
 
-/// Bring the DB up to `CURRENT_SCHEMA_VERSION`. Safe on every open —
+/// Bring the DB up to `CURRENT_SCHEMA_VERSION`. Safe on every open â€”
 /// idempotent by construction.
 pub fn migrate(conn: &Connection) -> Result<()> {
     for stmt in V1_SCHEMA {
@@ -317,12 +317,12 @@ pub fn migrate(conn: &Connection) -> Result<()> {
 
     // Drop the legacy `idx_routes_start_ts` index that every V1_SCHEMA
     // through v9 shipped. `routes.start_ts` has only ever been written
-    // NULL (see `db.rs::insert_or_update_route` — start_ts is bound to
+    // NULL (see `db.rs::insert_or_update_route` â€” start_ts is bound to
     // SQL NULL), so the index has nothing to index but charges B-tree
     // maintenance on every insert. Unconditional + `IF EXISTS` handles
     // every cohort in one shot: fresh DBs (no-op, V1_SCHEMA no longer
     // ships the CREATE), and every upgraded DB (pre-v6 / v6 / v7 / v8
-    // / v9 — all inherited the index from the old V1_SCHEMA). The
+    // / v9 â€” all inherited the index from the old V1_SCHEMA). The
     // `routes.start_ts` column itself stays.
     conn.execute("DROP INDEX IF EXISTS idx_routes_start_ts", [])?;
 
@@ -356,7 +356,7 @@ pub fn migrate(conn: &Connection) -> Result<()> {
 
     // v7 upgrade: add TPMS columns to existing telemetry_samples
     // tables. Fresh DBs land via V6_NEW_TABLES which doesn't include
-    // them — caught here on the first migrate after the v7 bump.
+    // them â€” caught here on the first migrate after the v7 bump.
     let existing_tele = list_telemetry_columns(conn)?;
     for (name, typ) in V7_TELEMETRY_TPMS_COLUMNS
         .iter()
@@ -410,7 +410,7 @@ pub fn migrate(conn: &Connection) -> Result<()> {
 
     // v7 -> v8: scrub TPMS values that were stored in BAR rather
     // than PSI by the v7 sampler. Idempotent + gated on a stored
-    // version < 8 marker — if the column is already in PSI (>= 5)
+    // version < 8 marker â€” if the column is already in PSI (>= 5)
     // the WHERE clause matches nothing and the UPDATE is a no-op
     // anyway, but the version gate keeps us from re-running on
     // every open in steady state.
@@ -435,7 +435,7 @@ pub fn migrate(conn: &Connection) -> Result<()> {
     // schema_version handling:
     //   * first-ever migrate: seed to CURRENT_SCHEMA_VERSION.
     //   * upgrading from an older version: bump up to current.
-    //   * downgrades (future-version marker): preserve — never clobber
+    //   * downgrades (future-version marker): preserve â€” never clobber
     //     a marker we don't understand.
     match meta_get(conn, "schema_version")? {
         None => {
@@ -538,7 +538,7 @@ mod tests {
         migrate(&conn).unwrap();
         assert_eq!(
             meta_get(&conn, "schema_version").unwrap().as_deref(),
-            Some("11"),
+            Some("12"),
         );
         assert!(meta_get(&conn, "created_at").unwrap().is_some());
     }
@@ -576,7 +576,7 @@ mod tests {
         }
         assert_eq!(
             meta_get(&conn, "schema_version").unwrap().as_deref(),
-            Some("11")
+            Some("12")
         );
     }
 
@@ -608,7 +608,7 @@ mod tests {
         }
         assert_eq!(
             meta_get(&conn, "schema_version").unwrap().as_deref(),
-            Some("11")
+            Some("12")
         );
     }
 
@@ -642,7 +642,7 @@ mod tests {
         }
         assert_eq!(
             meta_get(&conn, "schema_version").unwrap().as_deref(),
-            Some("11")
+            Some("12")
         );
     }
 
@@ -749,7 +749,7 @@ mod tests {
         assert!(surviving_processed.starts_with("RecentClips/"));
         assert_eq!(
             meta_get(&conn, "schema_version").unwrap().as_deref(),
-            Some("11")
+            Some("12")
         );
     }
 
@@ -760,7 +760,7 @@ mod tests {
         // After the first migrate, schema_version is "5", so a second
         // migrate must NOT re-run the cleanup. Seed an event-folder row
         // AFTER the version is set, and confirm the second migrate leaves
-        // it alone — proves the cleanup is gated on schema_version.
+        // it alone â€” proves the cleanup is gated on schema_version.
         conn.execute(
             "INSERT INTO routes (file, date_dir, points_blob, updated_at) VALUES (?1, ?2, X'', 0)",
             params!["SavedClips/x/y-front.mp4", "SavedClips"],
@@ -773,7 +773,7 @@ mod tests {
     #[test]
     fn migrate_v5_skips_cleanup_on_fresh_db() {
         // A fresh DB (no stored schema_version) shouldn't even attempt
-        // the DELETE — there's nothing to clean. Verify by inserting an
+        // the DELETE â€” there's nothing to clean. Verify by inserting an
         // event-folder row after we manually create the schema but before
         // calling migrate, and observe that the row survives because
         // schema_version is None on entry.
@@ -800,7 +800,7 @@ mod tests {
         assert_eq!(count_routes(&conn), 1, "fresh-DB seed must not run v5 cleanup");
         assert_eq!(
             meta_get(&conn, "schema_version").unwrap().as_deref(),
-            Some("11")
+            Some("12")
         );
     }
 
@@ -853,7 +853,7 @@ mod tests {
         assert_eq!(table_exists, 1, "v6 must create telemetry_samples");
         assert_eq!(
             meta_get(&conn, "schema_version").unwrap().as_deref(),
-            Some("11")
+            Some("12")
         );
     }
 
@@ -896,14 +896,14 @@ mod tests {
         }
         assert_eq!(
             meta_get(&conn, "schema_version").unwrap().as_deref(),
-            Some("11")
+            Some("12")
         );
     }
 
     #[test]
     fn migrate_v8_converts_bar_tpms_to_psi() {
         // Stand up a v7 DB with mixed-unit tpms values: some still in
-        // BAR (the bug — values < 5) and some that happen to be in
+        // BAR (the bug â€” values < 5) and some that happen to be in
         // PSI already. v8 should convert the bar values and leave
         // the PSI ones alone.
         let conn = open();
@@ -911,7 +911,7 @@ mod tests {
         // Pretend the DB came from v7 by rolling the marker back.
         meta_set(&conn, "schema_version", "7").unwrap();
 
-        // Bar (typical: 3.0 = 43.5 PSI) — should be converted.
+        // Bar (typical: 3.0 = 43.5 PSI) â€” should be converted.
         conn.execute(
             "INSERT INTO telemetry_samples \
              (ts, source, tire_fl_psi, tire_fr_psi, tire_rl_psi, tire_rr_psi) \
@@ -919,7 +919,7 @@ mod tests {
             params![1_700_000_000_i64, "state", 3.0_f64, 3.1_f64, 2.9_f64, 3.0_f64],
         )
         .unwrap();
-        // Already-correct PSI — should pass through untouched.
+        // Already-correct PSI â€” should pass through untouched.
         conn.execute(
             "INSERT INTO telemetry_samples \
              (ts, source, tire_fl_psi, tire_fr_psi, tire_rl_psi, tire_rr_psi) \
@@ -927,7 +927,7 @@ mod tests {
             params![1_700_000_100_i64, "state", 42.0_f64, 43.0_f64, 41.5_f64, 42.5_f64],
         )
         .unwrap();
-        // Mixed NULL row — should stay all NULL.
+        // Mixed NULL row â€” should stay all NULL.
         conn.execute(
             "INSERT INTO telemetry_samples (ts, source) VALUES (?1, ?2)",
             params![1_700_000_200_i64, "body_controller"],

--- a/crates/tesla_telemetry/src/db.rs
+++ b/crates/tesla_telemetry/src/db.rs
@@ -40,9 +40,10 @@ pub fn insert(conn: &Connection, s: &Sample) -> Result<()> {
           odometer_mi, location_name, \
           charger_power_kw, charger_actual_current_a, charger_voltage_v, \
           charge_rate_mph, charge_energy_added_kwh, charge_limit_soc, battery_range_mi, \
+          latitude, longitude, \
           source) \
          VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, \
-                 ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20)",
+                 ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22)",
         params![
             s.ts,
             s.battery_pct,
@@ -63,6 +64,8 @@ pub fn insert(conn: &Connection, s: &Sample) -> Result<()> {
             s.charge_energy_added_kwh,
             s.charge_limit_soc,
             s.battery_range_mi,
+            s.latitude,
+            s.longitude,
             s.source,
         ],
     )?;

--- a/crates/tesla_telemetry/src/main.rs
+++ b/crates/tesla_telemetry/src/main.rs
@@ -1081,6 +1081,15 @@ async fn tick(
         // Persist whatever this tick collected; sparse rows (e.g.
         // drive-only) are handled downstream.
         if any_call_ran {
+            // Stamp the held last-known GPS onto the row (experimental
+            // only) so a parked-and-charging sample carries the
+            // charger's location for the charging-view map pin. Parked
+            // polls omit fresh coords, so `*last_lat`/`*last_lon` (held
+            // across ticks) is the right source.
+            if cfg.experimental {
+                sample.latitude = *last_lat;
+                sample.longitude = *last_lon;
+            }
             persist(conn, sample);
         }
 

--- a/crates/tesla_telemetry/src/sample.rs
+++ b/crates/tesla_telemetry/src/sample.rs
@@ -344,6 +344,11 @@ pub struct Sample {
     pub charge_energy_added_kwh: Option<f32>,
     pub charge_limit_soc: Option<i32>,
     pub battery_range_mi: Option<f32>,
+    // Raw GPS (v12). Populated from the bundled LocationState only when
+    // the experimental flag is on; None otherwise. Lets a parked-and-
+    // charging sample carry the charger's location for the map pin.
+    pub latitude: Option<f64>,
+    pub longitude: Option<f64>,
     pub source: String,
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -17,6 +17,10 @@ const Logs = lazy(() => import("@/pages/Logs"))
 const Settings = lazy(() => import("@/pages/Settings"))
 const Drives = lazy(() => import("@/pages/Drives"))
 const DriveDetail = lazy(() => import("@/pages/DriveDetail"))
+const Charging = lazy(() => import("@/pages/Charging"))
+const ChargeSessionDetail = lazy(() => import("@/pages/ChargeSessionDetail"))
+// Dev-only mock-data preview of in-progress UI; not routed in production.
+const PreviewCharging = lazy(() => import("@/pages/PreviewCharging"))
 const Support = lazy(() => import("@/pages/Support"))
 const Terminal = lazy(() => import("@/pages/Terminal"))
 const FSDAnalytics = lazy(() => import("@/pages/FSDAnalytics"))
@@ -197,6 +201,8 @@ function AppContent() {
             <Route path="/logs" element={<Logs />} />
             <Route path="/drives" element={<Drives />} />
             <Route path="/drives/:id" element={<DriveDetail />} />
+            <Route path="/charging" element={<Charging />} />
+            <Route path="/charging/:id" element={<ChargeSessionDetail />} />
             <Route path="/fsd" element={<FSDAnalytics />} />
             <Route path="/support" element={<Support />} />
             <Route path="/terminal" element={<Terminal />} />
@@ -205,6 +211,9 @@ function AppContent() {
             <Route path="/snapshots" element={<Snapshots />} />
             <Route path="/settings" element={<Settings />} />
           </Route>
+          {import.meta.env.DEV && (
+            <Route path="/preview/charging" element={<PreviewCharging />} />
+          )}
         </Routes>
       </Suspense>
     </BrowserRouter>

--- a/web/src/api/charging.ts
+++ b/web/src/api/charging.ts
@@ -1,0 +1,19 @@
+import type {
+  ChargeSessionDetail,
+  ChargeSessionSummary,
+} from "@/types/charging"
+
+export async function fetchChargeSessions(): Promise<ChargeSessionSummary[]> {
+  const res = await fetch("/api/charging")
+  if (!res.ok) throw new Error(`charging: ${res.status}`)
+  const data = await res.json()
+  return Array.isArray(data.sessions) ? data.sessions : []
+}
+
+export async function fetchChargeSession(
+  id: string | number,
+): Promise<ChargeSessionDetail> {
+  const res = await fetch(`/api/charging/${id}`)
+  if (!res.ok) throw new Error(`charge session ${id}: ${res.status}`)
+  return res.json()
+}

--- a/web/src/components/charging/ChargePowerChart.tsx
+++ b/web/src/components/charging/ChargePowerChart.tsx
@@ -1,0 +1,153 @@
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts"
+import type { ChargePoint } from "@/types/charging"
+
+// Power on the left axis (kW), state-of-charge on the right (%) — the
+// two natural y-scales of a charge session. Mirrors TemperatureChart's
+// dark theme and tick styling so the charging detail reads as part of
+// the same UI. Nulls render as gaps (connectNulls keeps the line whole
+// across a missed sample).
+const POWER_COLOR = "#34d399" // emerald — energy in
+const SOC_COLOR = "#60a5fa" // blue — battery level
+
+const LEFT_MARGIN = 4
+const RIGHT_MARGIN = 8
+const YAXIS_WIDTH = 40
+
+export default function ChargePowerChart({ points }: { points: ChargePoint[] }) {
+  return (
+    <div className="h-56 w-full" aria-label="Charging power and state-of-charge chart">
+      <ResponsiveContainer minHeight={0} minWidth={0}>
+        <LineChart
+          data={points}
+          margin={{ top: 10, right: RIGHT_MARGIN, bottom: 24, left: LEFT_MARGIN }}
+        >
+          <CartesianGrid stroke="#1e242f" strokeDasharray="3 3" vertical={false} />
+          <XAxis
+            dataKey="ts"
+            type="number"
+            domain={["dataMin", "dataMax"]}
+            tickFormatter={formatTick}
+            stroke="#475569"
+            tick={{ fill: "#64748b", fontSize: 11 }}
+            tickLine={false}
+            axisLine={false}
+            tickMargin={10}
+            minTickGap={56}
+          />
+          <YAxis
+            yAxisId="power"
+            stroke="#475569"
+            tick={{ fill: "#64748b", fontSize: 11 }}
+            tickFormatter={(n: number) => `${Math.round(n)}`}
+            tickLine={false}
+            axisLine={false}
+            tickMargin={4}
+            width={YAXIS_WIDTH}
+            domain={[0, "dataMax + 2"]}
+          />
+          <YAxis
+            yAxisId="soc"
+            orientation="right"
+            stroke="#475569"
+            tick={{ fill: "#64748b", fontSize: 11 }}
+            tickFormatter={(n: number) => `${Math.round(n)}%`}
+            tickLine={false}
+            axisLine={false}
+            tickMargin={4}
+            width={YAXIS_WIDTH}
+            domain={[0, 100]}
+          />
+          <Tooltip
+            content={({ active, payload }) => {
+              if (!active || !payload || payload.length === 0) return null
+              const p = payload[0].payload as ChargePoint
+              return (
+                <div className="rounded-md border border-white/10 bg-slate-900/95 px-2 py-1.5 text-xs text-slate-200 shadow-xl">
+                  <div className="mb-1 text-[10px] text-slate-500 tabular-nums">
+                    {formatTooltipTime(p.ts)}
+                  </div>
+                  {p.powerKw != null && (
+                    <Row color={POWER_COLOR} label="Power" value={`${p.powerKw} kW`} />
+                  )}
+                  {p.soc != null && (
+                    <Row color={SOC_COLOR} label="Battery" value={`${Math.round(p.soc)}%`} />
+                  )}
+                  {p.rangeMi != null && (
+                    <Row color="#94a3b8" label="Range" value={`${Math.round(p.rangeMi)} mi`} />
+                  )}
+                </div>
+              )
+            }}
+          />
+          <Legend
+            verticalAlign="bottom"
+            height={20}
+            iconType="line"
+            wrapperStyle={{ fontSize: 11, color: "#94a3b8" }}
+          />
+          <Line
+            yAxisId="power"
+            type="monotone"
+            name="Power (kW)"
+            dataKey="powerKw"
+            stroke={POWER_COLOR}
+            strokeWidth={2}
+            dot={false}
+            isAnimationActive={false}
+            connectNulls
+          />
+          <Line
+            yAxisId="soc"
+            type="monotone"
+            name="Battery (%)"
+            dataKey="soc"
+            stroke={SOC_COLOR}
+            strokeWidth={2}
+            dot={false}
+            isAnimationActive={false}
+            connectNulls
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}
+
+function Row({ color, label, value }: { color: string; label: string; value: string }) {
+  return (
+    <div className="flex items-center gap-2 tabular-nums">
+      <span
+        className="inline-block h-2 w-2 rounded-full"
+        style={{ background: color }}
+        aria-hidden
+      />
+      <span className="text-slate-400">{label}</span>
+      <span className="ml-auto font-medium">{value}</span>
+    </div>
+  )
+}
+
+function formatTick(ms: number): string {
+  const t = new Date(ms)
+  if (Number.isNaN(t.getTime())) return ""
+  return t.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })
+}
+
+function formatTooltipTime(ms: number): string {
+  const t = new Date(ms)
+  if (Number.isNaN(t.getTime())) return ""
+  return t.toLocaleTimeString([], {
+    hour: "numeric",
+    minute: "2-digit",
+    second: "2-digit",
+  })
+}

--- a/web/src/components/charging/ChargingLineChart.tsx
+++ b/web/src/components/charging/ChargingLineChart.tsx
@@ -1,0 +1,137 @@
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts"
+import type { ChargePoint } from "@/types/charging"
+
+export interface ChargeSeries {
+  // Key into ChargePoint. Kept loose so callers can also pass derived
+  // keys after mapping points; the chart only reads number | null.
+  key: keyof ChargePoint
+  name: string
+  color: string
+}
+
+// One generic line chart over a charge session's per-sample points,
+// plotting one or more series on a shared left axis. Mirrors the dark
+// theme and tick styling of the drive charts so the charging detail
+// reads as part of the same UI. Used for range, amperage, voltage and
+// the temperature series — each is a separate card with its own unit,
+// matching how Tessie / TeslaScope present them.
+export default function ChargingLineChart({
+  points,
+  series,
+  unit,
+  yDomain = [0, "auto"],
+}: {
+  points: ChargePoint[]
+  series: ChargeSeries[]
+  unit: string
+  yDomain?: [number | string, number | string]
+}) {
+  return (
+    <div className="h-48 w-full" aria-label={`${series.map((s) => s.name).join(", ")} chart`}>
+      <ResponsiveContainer minHeight={0} minWidth={0}>
+        <LineChart data={points} margin={{ top: 10, right: 8, bottom: 24, left: 4 }}>
+          <CartesianGrid stroke="#1e242f" strokeDasharray="3 3" vertical={false} />
+          <XAxis
+            dataKey="ts"
+            type="number"
+            domain={["dataMin", "dataMax"]}
+            tickFormatter={formatTick}
+            stroke="#475569"
+            tick={{ fill: "#64748b", fontSize: 11 }}
+            tickLine={false}
+            axisLine={false}
+            tickMargin={10}
+            minTickGap={56}
+          />
+          <YAxis
+            stroke="#475569"
+            tick={{ fill: "#64748b", fontSize: 11 }}
+            tickFormatter={(n: number) => `${Math.round(n)}${unit}`}
+            tickLine={false}
+            axisLine={false}
+            tickMargin={4}
+            width={48}
+            domain={yDomain}
+          />
+          <Tooltip
+            content={({ active, payload }) => {
+              if (!active || !payload || payload.length === 0) return null
+              const p = payload[0].payload as ChargePoint
+              return (
+                <div className="rounded-md border border-white/10 bg-slate-900/95 px-2 py-1.5 text-xs text-slate-200 shadow-xl">
+                  <div className="mb-1 text-[10px] text-slate-500 tabular-nums">
+                    {formatTooltipTime(p.ts)}
+                  </div>
+                  {series.map((s) => {
+                    const v = p[s.key]
+                    if (v == null || typeof v !== "number") return null
+                    return (
+                      <div key={String(s.key)} className="flex items-center gap-2 tabular-nums">
+                        <span
+                          className="inline-block h-2 w-2 rounded-full"
+                          style={{ background: s.color }}
+                          aria-hidden
+                        />
+                        <span className="text-slate-400">{s.name}</span>
+                        <span className="ml-auto font-medium">
+                          {Math.round(v)}
+                          {unit}
+                        </span>
+                      </div>
+                    )
+                  })}
+                </div>
+              )
+            }}
+          />
+          {series.length > 1 && (
+            <Legend
+              verticalAlign="bottom"
+              height={20}
+              iconType="line"
+              wrapperStyle={{ fontSize: 11, color: "#94a3b8" }}
+            />
+          )}
+          {series.map((s) => (
+            <Line
+              key={String(s.key)}
+              type="monotone"
+              name={s.name}
+              dataKey={s.key as string}
+              stroke={s.color}
+              strokeWidth={2}
+              dot={false}
+              isAnimationActive={false}
+              connectNulls
+            />
+          ))}
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}
+
+function formatTick(ms: number): string {
+  const t = new Date(ms)
+  if (Number.isNaN(t.getTime())) return ""
+  return t.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })
+}
+
+function formatTooltipTime(ms: number): string {
+  const t = new Date(ms)
+  if (Number.isNaN(t.getTime())) return ""
+  return t.toLocaleTimeString([], {
+    hour: "numeric",
+    minute: "2-digit",
+    second: "2-digit",
+  })
+}

--- a/web/src/components/charging/ChargingSummaryStrip.tsx
+++ b/web/src/components/charging/ChargingSummaryStrip.tsx
@@ -1,0 +1,98 @@
+import { BatteryCharging, Clock, Gauge, Zap } from "lucide-react"
+import { fmtDuration } from "@/lib/charge-format"
+
+export interface ChargingStats {
+  count: number
+  totalEnergyKwh: number
+  totalDurationSecs: number
+}
+
+// Compact stats strip for the Charging page, mirroring the Drives
+// summary strip: a few aggregate cells for the current filter set,
+// recomputed live as the date filter changes. No session-count cell is
+// duplicated in the pagination row, but charging has no pagination yet
+// so the count stays here.
+export function ChargingSummaryStrip({
+  stats,
+  loading,
+}: {
+  stats: ChargingStats
+  loading: boolean
+}) {
+  if (loading && stats.count === 0) {
+    return (
+      <div className="flex flex-wrap items-center gap-x-5 gap-y-2">
+        <div className="h-8 w-24 animate-pulse rounded-md bg-white/[0.04]" />
+        <div className="h-8 w-20 animate-pulse rounded-md bg-white/[0.04]" />
+        <div className="h-8 w-20 animate-pulse rounded-md bg-white/[0.04]" />
+      </div>
+    )
+  }
+
+  const avgKwh = stats.count > 0 ? stats.totalEnergyKwh / stats.count : 0
+
+  return (
+    <div className="flex flex-wrap items-center gap-x-5 gap-y-2">
+      <StatCell
+        icon={<BatteryCharging className="h-3.5 w-3.5" />}
+        label="Sessions"
+        value={stats.count.toLocaleString()}
+      />
+      <Divider />
+      <StatCell
+        icon={<Zap className="h-3.5 w-3.5 text-emerald-300" />}
+        label="Energy added"
+        value={`${stats.totalEnergyKwh.toFixed(1)} kWh`}
+      />
+      <Divider />
+      <StatCell
+        icon={<Clock className="h-3.5 w-3.5" />}
+        label="Time charging"
+        value={fmtDuration(stats.totalDurationSecs)}
+      />
+      {stats.count > 0 && (
+        <>
+          <Divider />
+          <StatCell
+            icon={<Gauge className="h-3.5 w-3.5" />}
+            label="Avg / session"
+            value={`${avgKwh.toFixed(1)} kWh`}
+          />
+        </>
+      )}
+    </div>
+  )
+}
+
+function StatCell({
+  icon,
+  label,
+  value,
+}: {
+  icon: React.ReactNode
+  label: string
+  value: React.ReactNode
+}) {
+  return (
+    <div className="flex min-w-0 items-center gap-2">
+      <span
+        className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-white/[0.04] ring-1 ring-inset ring-white/10 text-slate-300"
+        aria-hidden
+      >
+        {icon}
+      </span>
+      <div className="min-w-0">
+        <div className="text-[9px] font-semibold uppercase tracking-wider text-slate-500">
+          {label}
+        </div>
+        <div className="text-sm font-semibold tabular-nums leading-tight text-slate-100">
+          {value}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function Divider() {
+  return <span aria-hidden className="hidden h-7 w-px bg-white/[0.06] sm:block" />
+}

--- a/web/src/components/charging/ChargingSummaryStrip.tsx
+++ b/web/src/components/charging/ChargingSummaryStrip.tsx
@@ -32,7 +32,10 @@ export function ChargingSummaryStrip({
   const avgKwh = stats.count > 0 ? stats.totalEnergyKwh / stats.count : 0
 
   return (
-    <div className="flex flex-wrap items-center gap-x-5 gap-y-2">
+    // 2x2 grid when space is tight (mobile / shrunk browser); a single
+    // flex row with dividers once there's room (sm+). Dividers are
+    // hidden below sm so they don't take grid cells.
+    <div className="grid grid-cols-2 gap-x-4 gap-y-3 sm:flex sm:flex-wrap sm:items-center sm:gap-x-5 sm:gap-y-2">
       <StatCell
         icon={<BatteryCharging className="h-3.5 w-3.5" />}
         label="Sessions"

--- a/web/src/components/charging/MiniPinMap.tsx
+++ b/web/src/components/charging/MiniPinMap.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useRef, useState } from "react"
+import L from "leaflet"
+import "leaflet/dist/leaflet.css"
+
+// A charge session is parked, so its map is a single pin at the
+// charger's location — not a route polyline. Mirrors MiniRouteMap's
+// lazy-on-visible, interaction-disabled, dark-tile styling so it sits
+// next to the drive thumbnails consistently. Renders nothing (an empty
+// rounded box) when there are no coordinates.
+const DARK_TILES =
+  "https://{s}.basemaps.cartocdn.com/dark_nolabels/{z}/{x}/{y}{r}.png"
+
+const PIN_COLOR = "#34d399" // emerald — matches the charging accent
+
+export function MiniPinMap({
+  lat,
+  lon,
+  zoom = 15,
+  className = "h-20 w-32",
+}: {
+  lat: number | null | undefined
+  lon: number | null | undefined
+  zoom?: number
+  className?: string
+}) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const mapRef = useRef<L.Map | null>(null)
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    const el = containerRef.current
+    if (!el) return
+    const io = new IntersectionObserver(
+      (entries) => {
+        for (const e of entries) {
+          if (e.isIntersecting) {
+            setVisible(true)
+            io.disconnect()
+            break
+          }
+        }
+      },
+      { rootMargin: "200px" },
+    )
+    io.observe(el)
+    return () => io.disconnect()
+  }, [])
+
+  useEffect(() => {
+    if (!visible) return
+    const el = containerRef.current
+    if (!el || mapRef.current) return
+    if (lat == null || lon == null) return
+
+    const map = L.map(el, {
+      attributionControl: false,
+      zoomControl: false,
+      dragging: false,
+      scrollWheelZoom: false,
+      doubleClickZoom: false,
+      touchZoom: false,
+      keyboard: false,
+      boxZoom: false,
+    })
+    mapRef.current = map
+
+    L.tileLayer(DARK_TILES, { maxZoom: 18, minZoom: 3 }).addTo(map)
+    map.setView([lat, lon], zoom)
+
+    L.circleMarker([lat, lon], {
+      radius: 5,
+      color: PIN_COLOR,
+      weight: 2,
+      fillColor: PIN_COLOR,
+      fillOpacity: 0.9,
+    }).addTo(map)
+
+    return () => {
+      map.remove()
+      mapRef.current = null
+    }
+  }, [visible, lat, lon, zoom])
+
+  return (
+    <div
+      ref={containerRef}
+      className={`relative shrink-0 overflow-hidden rounded-lg bg-slate-900/60 ring-1 ring-inset ring-white/5 ${className}`}
+      role="img"
+      aria-label="Charge location"
+    />
+  )
+}

--- a/web/src/components/drives/ChargingSection.tsx
+++ b/web/src/components/drives/ChargingSection.tsx
@@ -1,0 +1,73 @@
+import { BatteryCharging, Gauge, Plug, Zap } from "lucide-react"
+
+import { SectionHeading, StatTile } from "@/components/drives/StatTile"
+
+export interface ChargeDetail {
+  powerKw?: number | null
+  currentA?: number | null
+  voltageV?: number | null
+  rateMph?: number | null
+  energyAddedKwh?: number | null
+  limitSoc?: number | null
+  rangeMi?: number | null
+}
+
+function fmt(
+  v: number | null | undefined,
+  suffix: string,
+  digits = 0,
+): string {
+  if (v === null || v === undefined) return "—"
+  return `${v.toFixed(digits)}${suffix}`
+}
+
+export function ChargingSection({ charge }: { charge: ChargeDetail }) {
+  return (
+    <>
+      <SectionHeading>Charging</SectionHeading>
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+        <StatTile
+          label="Power"
+          value={fmt(charge.powerKw, " kW")}
+          icon={<Zap className="h-4 w-4" />}
+          info="Power the charger is delivering."
+        />
+        <StatTile
+          label="Current"
+          value={fmt(charge.currentA, " A")}
+          icon={<Plug className="h-4 w-4" />}
+          info="Actual current the charger is supplying."
+        />
+        <StatTile
+          label="Voltage"
+          value={fmt(charge.voltageV, " V")}
+          icon={<Zap className="h-4 w-4" />}
+        />
+        <StatTile
+          label="Charge rate"
+          value={fmt(charge.rateMph, " mi/hr")}
+          icon={<Gauge className="h-4 w-4" />}
+          info="Range added per hour at the current rate."
+        />
+        <StatTile
+          label="Energy added"
+          value={fmt(charge.energyAddedKwh, " kWh", 1)}
+          icon={<BatteryCharging className="h-4 w-4" />}
+          info="Energy added this charging session."
+        />
+        <StatTile
+          label="Charge limit"
+          value={fmt(charge.limitSoc, "%")}
+          icon={<BatteryCharging className="h-4 w-4" />}
+          info="Target state of charge."
+        />
+        <StatTile
+          label="Range"
+          value={fmt(charge.rangeMi, " mi")}
+          icon={<Gauge className="h-4 w-4" />}
+          info="Estimated rated range."
+        />
+      </div>
+    </>
+  )
+}

--- a/web/src/components/layout/MobileNav.tsx
+++ b/web/src/components/layout/MobileNav.tsx
@@ -20,6 +20,7 @@ import {
   BellRing,
   Wifi,
   Camera,
+  BatteryCharging,
 } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useAwayMode } from "@/hooks/useAwayMode"
@@ -28,6 +29,7 @@ import { useUpdateAvailable } from "@/hooks/useUpdateAvailable"
 import { useConnectionStatus } from "@/hooks/useConnectionStatus"
 import { useAuth } from "@/hooks/useAuth"
 import { useCommunityPrefs } from "@/hooks/useCommunityPrefs"
+import { useExperimental } from "@/hooks/useExperimental"
 
 interface MobileNavProps {
   open: boolean
@@ -46,8 +48,18 @@ const baseNavItems = [
   { to: "/settings", icon: Settings, label: "Settings" },
 ]
 
-function buildNavItems(mode: ReturnType<typeof useCommunityPrefs>["mode"]) {
-  return baseNavItems
+function buildNavItems(
+  mode: ReturnType<typeof useCommunityPrefs>["mode"],
+  experimental: boolean,
+) {
+  const items = experimental
+    ? baseNavItems.flatMap((item) =>
+        item.to === "/drives"
+          ? [item, { to: "/charging", icon: BatteryCharging, label: "Charging" }]
+          : [item],
+      )
+    : baseNavItems
+  return items
     .filter((item) => item.to !== "/community" || mode !== "none")
     .map((item) => {
       if (item.to !== "/community") return item
@@ -65,8 +77,9 @@ export function MobileNav({ open, onClose }: MobileNavProps) {
   const { state: connState } = useConnectionStatus()
   const { authRequired, logout } = useAuth()
   const { mode: communityMode } = useCommunityPrefs()
+  const experimental = useExperimental()
   const [version, setVersion] = useState<string | null>(null)
-  const navItems = buildNavItems(communityMode)
+  const navItems = buildNavItems(communityMode, experimental === true)
 
   useEffect(() => {
     fetch("/api/system/version")

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -21,6 +21,7 @@ import {
   BellRing,
   Wifi,
   Camera,
+  BatteryCharging,
 } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useAwayMode } from "@/hooks/useAwayMode"
@@ -29,6 +30,7 @@ import { useUpdateAvailable } from "@/hooks/useUpdateAvailable"
 import { useConnectionStatus } from "@/hooks/useConnectionStatus"
 import { useAuth } from "@/hooks/useAuth"
 import { useCommunityPrefs } from "@/hooks/useCommunityPrefs"
+import { useExperimental } from "@/hooks/useExperimental"
 
 interface SidebarProps {
   collapsed: boolean
@@ -47,8 +49,21 @@ const baseNavItems = [
   { to: "/settings", icon: Settings, label: "Settings" },
 ]
 
-function buildNavItems(mode: ReturnType<typeof useCommunityPrefs>["mode"]) {
-  return baseNavItems
+function buildNavItems(
+  mode: ReturnType<typeof useCommunityPrefs>["mode"],
+  experimental: boolean,
+) {
+  // Charging history is gated behind the experimental opt-in (the
+  // sampler only writes charge columns when it's on). Slot it right
+  // after Drives so the two telemetry views sit together.
+  const items = experimental
+    ? baseNavItems.flatMap((item) =>
+        item.to === "/drives"
+          ? [item, { to: "/charging", icon: BatteryCharging, label: "Charging" }]
+          : [item],
+      )
+    : baseNavItems
+  return items
     .filter((item) => item.to !== "/community" || mode !== "none")
     .map((item) => {
       if (item.to !== "/community") return item
@@ -66,8 +81,9 @@ export function Sidebar({ collapsed, onToggle }: SidebarProps) {
   const { state: connState } = useConnectionStatus()
   const { authRequired, logout } = useAuth()
   const { mode: communityMode } = useCommunityPrefs()
+  const experimental = useExperimental()
   const [version, setVersion] = useState<string | null>(null)
-  const navItems = buildNavItems(communityMode)
+  const navItems = buildNavItems(communityMode, experimental === true)
 
   useEffect(() => {
     fetch("/api/system/version")

--- a/web/src/hooks/useDrivesList.ts
+++ b/web/src/hooks/useDrivesList.ts
@@ -96,7 +96,7 @@ function readFilters(params: URLSearchParams): DrivesFilters {
   }
 }
 
-function rangeBounds(range: DateRange, now: Date): { from?: Date; to?: Date } {
+export function rangeBounds(range: DateRange, now: Date): { from?: Date; to?: Date } {
   if (range.kind === "custom") {
     return { from: new Date(range.start), to: new Date(range.end) }
   }

--- a/web/src/hooks/useExperimental.ts
+++ b/web/src/hooks/useExperimental.ts
@@ -1,0 +1,56 @@
+import { useEffect, useState } from "react"
+
+// Reads the master experimental opt-in (SENTRYUSB_EXPERIMENTAL) from
+// the same /api/setup/config the rest of the app uses. Returns null
+// while the fetch is in flight so callers can distinguish "not yet
+// known" from a definite false and avoid flashing experimental UI on
+// during the initial load. Mirrors the config-entry shape Drives.tsx
+// already consumes ({ value, active } | string).
+//
+// Module-scope cache so every consumer (sidebar, mobile nav, pages)
+// shares one fetch instead of each issuing its own round trip on mount.
+let cached: boolean | null = null
+let inflight: Promise<boolean> | null = null
+
+function readExperimental(): Promise<boolean> {
+  if (cached !== null) return Promise.resolve(cached)
+  if (inflight) return inflight
+  inflight = fetch("/api/setup/config")
+    .then((r) => r.json())
+    .then((cfg) => {
+      const entry = cfg?.SENTRYUSB_EXPERIMENTAL
+      const raw =
+        typeof entry === "object"
+          ? entry?.active
+            ? entry.value
+            : null
+          : entry
+      const on =
+        typeof raw === "string" &&
+        ["yes", "true", "1"].includes(raw.trim().toLowerCase())
+      cached = on
+      return on
+    })
+    .catch(() => {
+      cached = false
+      return false
+    })
+    .finally(() => {
+      inflight = null
+    })
+  return inflight
+}
+
+export function useExperimental(): boolean | null {
+  const [enabled, setEnabled] = useState<boolean | null>(cached)
+  useEffect(() => {
+    let cancelled = false
+    readExperimental().then((on) => {
+      if (!cancelled) setEnabled(on)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+  return enabled
+}

--- a/web/src/lib/charge-format.ts
+++ b/web/src/lib/charge-format.ts
@@ -1,0 +1,32 @@
+// Display formatters for charge-session values. Each tolerates
+// null/undefined and renders an em dash so the UI never shows "NaN" or
+// "null" when a sample column was empty.
+
+export function fmtEnergy(kwh: number | null | undefined): string {
+  if (kwh == null) return "—"
+  return `${kwh.toFixed(1)} kWh`
+}
+
+export function fmtSoc(pct: number | null | undefined): string {
+  if (pct == null) return "—"
+  return `${Math.round(pct)}%`
+}
+
+export function fmtPower(kw: number | null | undefined): string {
+  if (kw == null) return "—"
+  return `${Math.round(kw)} kW`
+}
+
+export function fmtRange(mi: number | null | undefined): string {
+  if (mi == null) return "—"
+  return `${Math.round(mi)} mi`
+}
+
+export function fmtDuration(secs: number | null | undefined): string {
+  if (secs == null || secs <= 0) return "—"
+  const h = Math.floor(secs / 3600)
+  const m = Math.floor((secs % 3600) / 60)
+  if (h > 0) return `${h}h ${m}m`
+  if (m > 0) return `${m}m`
+  return `${secs}s`
+}

--- a/web/src/pages/ChargeSessionDetail.tsx
+++ b/web/src/pages/ChargeSessionDetail.tsx
@@ -1,0 +1,223 @@
+import { useEffect, useState } from "react"
+import { Link, useParams } from "react-router-dom"
+import {
+  ArrowLeft,
+  BatteryCharging,
+  Gauge,
+  Loader2,
+  MapPin,
+  Plug,
+  Zap,
+} from "lucide-react"
+import { fetchChargeSession } from "@/api/charging"
+import type { ChargeSessionDetail } from "@/types/charging"
+import { SectionHeading, StatTile } from "@/components/drives/StatTile"
+import ChargePowerChart from "@/components/charging/ChargePowerChart"
+import ChargingLineChart from "@/components/charging/ChargingLineChart"
+import type { ChargePoint } from "@/types/charging"
+import { fmtDuration, fmtEnergy, fmtPower, fmtRange, fmtSoc } from "@/lib/charge-format"
+
+export default function ChargeSessionDetailPage() {
+  const { id } = useParams<{ id: string }>()
+  const [session, setSession] = useState<ChargeSessionDetail | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!id) return
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+    fetchChargeSession(id)
+      .then((s) => {
+        if (!cancelled) setSession(s)
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e))
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [id])
+
+  const rangeAdded =
+    session?.startRangeMi != null && session?.endRangeMi != null
+      ? session.endRangeMi - session.startRangeMi
+      : null
+
+  // Battery temperature is stored in °C; charge sessions are shown in
+  // °F to match the rest of the US-default UI. Map once so the chart's
+  // axis, line and tooltip all speak °F. Nulls stay null → render gaps.
+  const tempPoints: ChargePoint[] = (session?.points ?? []).map((p) => ({
+    ...p,
+    batteryTempC: p.batteryTempC == null ? null : (p.batteryTempC * 9) / 5 + 32,
+  }))
+  const hasTemp = tempPoints.some((p) => p.batteryTempC != null)
+  const hasCurrent = (session?.points ?? []).some((p) => p.currentA != null)
+  const hasVoltage = (session?.points ?? []).some((p) => p.voltageV != null)
+  const hasRange = (session?.points ?? []).some((p) => p.rangeMi != null)
+
+  return (
+    <div className="mx-auto w-full max-w-3xl px-4 py-6 sm:px-6 sm:py-8">
+      <Link
+        to="/charging"
+        className="mb-4 inline-flex items-center gap-1.5 text-sm text-slate-400 hover:text-slate-200"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        Charging
+      </Link>
+
+      {loading && (
+        <div className="flex items-center justify-center gap-2 rounded-2xl border border-white/[0.06] bg-white/[0.025] p-10 text-sm text-slate-400">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Loading session…
+        </div>
+      )}
+      {error && !loading && (
+        <div className="rounded-2xl border border-rose-400/30 bg-rose-500/5 p-6 text-sm text-rose-200">
+          Failed to load session: {error}
+        </div>
+      )}
+
+      {!loading && !error && session && (
+        <div className="space-y-6">
+          <div>
+            <h1 className="text-2xl font-semibold text-slate-100">
+              {formatDateTime(session.startMs)}
+            </h1>
+            <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-slate-500">
+              <span>{fmtDuration(session.durationSecs)}</span>
+              {session.location && (
+                <span className="inline-flex items-center gap-1">
+                  <MapPin className="h-3.5 w-3.5" />
+                  {session.location}
+                </span>
+              )}
+            </div>
+          </div>
+
+          <div className="rounded-2xl border border-white/10 bg-slate-900/40 p-5">
+            <SectionHeading>Session</SectionHeading>
+            <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+              <StatTile
+                label="Energy added"
+                value={fmtEnergy(session.energyAddedKwh)}
+                icon={<BatteryCharging className="h-4 w-4" />}
+                info="Energy added across this charging session."
+              />
+              <StatTile
+                label="Peak power"
+                value={fmtPower(session.peakPowerKw)}
+                icon={<Zap className="h-4 w-4" />}
+                info={
+                  session.avgPowerKw != null
+                    ? `Highest charging power seen this session. Average ${Math.round(session.avgPowerKw)} kW.`
+                    : "Highest charging power seen this session."
+                }
+              />
+              <StatTile
+                label="Battery"
+                value={
+                  session.startSoc != null && session.endSoc != null
+                    ? `${fmtSoc(session.startSoc)} → ${fmtSoc(session.endSoc)}`
+                    : fmtSoc(session.endSoc)
+                }
+                icon={<BatteryCharging className="h-4 w-4" />}
+                info="State of charge at start and end."
+              />
+              <StatTile
+                label="Range added"
+                value={rangeAdded != null ? fmtRange(rangeAdded) : "—"}
+                icon={<Gauge className="h-4 w-4" />}
+                info="Rated range gained this session."
+              />
+              <StatTile
+                label="Peak current"
+                value={session.peakCurrentA != null ? `${session.peakCurrentA} A` : "—"}
+                icon={<Plug className="h-4 w-4" />}
+              />
+              <StatTile
+                label="Voltage"
+                value={session.peakVoltageV != null ? `${session.peakVoltageV} V` : "—"}
+                icon={<Zap className="h-4 w-4" />}
+              />
+              <StatTile
+                label="Charge limit"
+                value={fmtSoc(session.chargeLimitSoc)}
+                icon={<BatteryCharging className="h-4 w-4" />}
+                info="Target state of charge for this session."
+              />
+            </div>
+          </div>
+
+          {session.points.length > 1 && (
+            <div className="rounded-2xl border border-white/10 bg-slate-900/40 p-5">
+              <SectionHeading>Power &amp; battery</SectionHeading>
+              <ChargePowerChart points={session.points} />
+            </div>
+          )}
+
+          {session.points.length > 1 && hasRange && (
+            <div className="rounded-2xl border border-white/10 bg-slate-900/40 p-5">
+              <SectionHeading>Range</SectionHeading>
+              <ChargingLineChart
+                points={session.points}
+                series={[{ key: "rangeMi", name: "Range", color: "#a78bfa" }]}
+                unit=" mi"
+              />
+            </div>
+          )}
+
+          {session.points.length > 1 && hasCurrent && (
+            <div className="rounded-2xl border border-white/10 bg-slate-900/40 p-5">
+              <SectionHeading>Amperage</SectionHeading>
+              <ChargingLineChart
+                points={session.points}
+                series={[{ key: "currentA", name: "Current", color: "#fbbf24" }]}
+                unit=" A"
+              />
+            </div>
+          )}
+
+          {session.points.length > 1 && hasVoltage && (
+            <div className="rounded-2xl border border-white/10 bg-slate-900/40 p-5">
+              <SectionHeading>Voltage</SectionHeading>
+              <ChargingLineChart
+                points={session.points}
+                series={[{ key: "voltageV", name: "Voltage", color: "#22d3ee" }]}
+                unit=" V"
+                yDomain={[0, "dataMax + 10"]}
+              />
+            </div>
+          )}
+
+          {session.points.length > 1 && hasTemp && (
+            <div className="rounded-2xl border border-white/10 bg-slate-900/40 p-5">
+              <SectionHeading>Battery temperature</SectionHeading>
+              <ChargingLineChart
+                points={tempPoints}
+                series={[{ key: "batteryTempC", name: "Battery temp", color: "#fb7185" }]}
+                unit="°F"
+                yDomain={["dataMin - 4", "dataMax + 4"]}
+              />
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function formatDateTime(ms: number): string {
+  const d = new Date(ms)
+  return d.toLocaleString([], {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  })
+}

--- a/web/src/pages/ChargeSessionDetail.tsx
+++ b/web/src/pages/ChargeSessionDetail.tsx
@@ -14,6 +14,7 @@ import type { ChargeSessionDetail } from "@/types/charging"
 import { SectionHeading, StatTile } from "@/components/drives/StatTile"
 import ChargePowerChart from "@/components/charging/ChargePowerChart"
 import ChargingLineChart from "@/components/charging/ChargingLineChart"
+import { MiniPinMap } from "@/components/charging/MiniPinMap"
 import type { ChargePoint } from "@/types/charging"
 import { fmtDuration, fmtEnergy, fmtPower, fmtRange, fmtSoc } from "@/lib/charge-format"
 
@@ -98,6 +99,15 @@ export default function ChargeSessionDetailPage() {
               )}
             </div>
           </div>
+
+          {session.locationLat != null && session.locationLon != null && (
+            <MiniPinMap
+              lat={session.locationLat}
+              lon={session.locationLon}
+              zoom={16}
+              className="h-44 w-full"
+            />
+          )}
 
           <div className="rounded-2xl border border-white/10 bg-slate-900/40 p-5">
             <SectionHeading>Session</SectionHeading>

--- a/web/src/pages/Charging.tsx
+++ b/web/src/pages/Charging.tsx
@@ -123,7 +123,7 @@ function ChargeRow({ session }: { session: ChargeSessionSummary }) {
   return (
     <Link
       to={`/charging/${session.id}`}
-      className="group flex items-center gap-4 rounded-2xl border border-white/[0.06] bg-white/[0.025] p-4 transition-colors hover:border-white/10 hover:bg-white/[0.04]"
+      className="group flex items-center gap-3 rounded-2xl border border-white/[0.06] bg-white/[0.025] p-3 transition-colors hover:border-white/10 hover:bg-white/[0.04] sm:gap-4 sm:p-4"
     >
       <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-emerald-500/10 text-emerald-300 ring-1 ring-inset ring-emerald-500/20">
         <BatteryCharging className="h-5 w-5" />
@@ -147,24 +147,31 @@ function ChargeRow({ session }: { session: ChargeSessionSummary }) {
           <span>·</span>
           <span>{fmtDuration(session.durationSecs)}</span>
         </div>
+        {/* Mobile: energy + SoC sit below the meta line so the title gets
+            the full row width instead of being squeezed by a side column. */}
+        <div className="mt-1.5 flex items-center gap-2.5 tabular-nums sm:hidden">
+          <span className="inline-flex items-center gap-1 text-sm font-semibold text-emerald-300">
+            <Zap className="h-3.5 w-3.5" />
+            {fmtEnergy(session.energyAddedKwh)}
+          </span>
+          <span className="text-xs text-slate-500">{socShort}</span>
+        </div>
       </div>
 
-      <div className="shrink-0 text-right">
+      {/* Desktop: energy + SoC as a right-aligned column. */}
+      <div className="hidden shrink-0 text-right sm:block">
         <div className="flex items-center justify-end gap-1 text-sm font-semibold text-emerald-300 tabular-nums">
           <Zap className="h-3.5 w-3.5" />
           {fmtEnergy(session.energyAddedKwh)}
         </div>
-        <div className="mt-0.5 text-xs text-slate-500 tabular-nums">
-          <span className="sm:hidden">{socShort}</span>
-          <span className="hidden sm:inline">{socFull}</span>
-        </div>
+        <div className="mt-0.5 text-xs text-slate-500 tabular-nums">{socFull}</div>
       </div>
 
       {session.locationLat != null && session.locationLon != null && (
         <MiniPinMap
           lat={session.locationLat}
           lon={session.locationLon}
-          className="h-16 w-24 sm:h-20 sm:w-32"
+          className="h-14 w-20 sm:h-20 sm:w-32"
         />
       )}
 

--- a/web/src/pages/Charging.tsx
+++ b/web/src/pages/Charging.tsx
@@ -126,22 +126,22 @@ function ChargeRow({ session }: { session: ChargeSessionSummary }) {
       </span>
 
       <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-2 text-sm font-medium text-slate-100">
-          {formatDate(start)}
+        <div className="flex items-center gap-1.5 text-sm font-medium text-slate-100">
+          {session.location ? (
+            <>
+              <MapPin className="h-3.5 w-3.5 shrink-0 text-emerald-300/80" />
+              <span className="truncate">{session.location}</span>
+            </>
+          ) : (
+            <span className="truncate">{formatDate(start)}</span>
+          )}
         </div>
-        <div className="mt-0.5 flex flex-wrap items-center gap-x-3 gap-y-0.5 text-xs text-slate-500">
+        <div className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-slate-500">
+          {session.location && <span>{formatDate(start)}</span>}
+          {session.location && <span>·</span>}
           <span>{formatTime(start)}</span>
           <span>·</span>
           <span>{fmtDuration(session.durationSecs)}</span>
-          {session.location && (
-            <>
-              <span>·</span>
-              <span className="inline-flex items-center gap-1 truncate">
-                <MapPin className="h-3 w-3 shrink-0" />
-                <span className="truncate">{session.location}</span>
-              </span>
-            </>
-          )}
         </div>
         <div className="mt-1 flex items-center gap-1 text-sm font-semibold text-emerald-300 tabular-nums sm:hidden">
           <Zap className="h-3.5 w-3.5" />

--- a/web/src/pages/Charging.tsx
+++ b/web/src/pages/Charging.tsx
@@ -8,6 +8,7 @@ import {
   ChargingSummaryStrip,
   type ChargingStats,
 } from "@/components/charging/ChargingSummaryStrip"
+import { MiniPinMap } from "@/components/charging/MiniPinMap"
 import { rangeBounds, type DateRange } from "@/hooks/useDrivesList"
 import { fmtDuration, fmtEnergy, fmtSoc } from "@/lib/charge-format"
 
@@ -120,7 +121,7 @@ function ChargeRow({ session }: { session: ChargeSessionSummary }) {
       to={`/charging/${session.id}`}
       className="group flex items-center gap-4 rounded-2xl border border-white/[0.06] bg-white/[0.025] p-4 transition-colors hover:border-white/10 hover:bg-white/[0.04]"
     >
-      <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-emerald-500/10 text-emerald-300 ring-1 ring-inset ring-emerald-500/20">
+      <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-emerald-500/10 text-emerald-300 ring-1 ring-inset ring-emerald-500/20">
         <BatteryCharging className="h-5 w-5" />
       </span>
 
@@ -142,6 +143,10 @@ function ChargeRow({ session }: { session: ChargeSessionSummary }) {
             </>
           )}
         </div>
+        <div className="mt-1 flex items-center gap-1 text-sm font-semibold text-emerald-300 tabular-nums sm:hidden">
+          <Zap className="h-3.5 w-3.5" />
+          {fmtEnergy(session.energyAddedKwh)}
+        </div>
       </div>
 
       <div className="hidden shrink-0 text-right sm:block">
@@ -151,6 +156,14 @@ function ChargeRow({ session }: { session: ChargeSessionSummary }) {
         </div>
         <div className="mt-0.5 text-xs text-slate-500 tabular-nums">{socDelta}</div>
       </div>
+
+      {session.locationLat != null && session.locationLon != null && (
+        <MiniPinMap
+          lat={session.locationLat}
+          lon={session.locationLon}
+          className="h-16 w-24 sm:h-20 sm:w-32"
+        />
+      )}
 
       <ChevronRight className="h-4 w-4 shrink-0 text-slate-600 transition-colors group-hover:text-slate-400" />
     </Link>

--- a/web/src/pages/Charging.tsx
+++ b/web/src/pages/Charging.tsx
@@ -100,16 +100,20 @@ export default function Charging() {
 
 function ChargeRow({ session }: { session: ChargeSessionSummary }) {
   const start = new Date(session.startMs)
-  // "19% (40 mi) → 90% (193 mi)" when range is known, else just the
-  // SoC pair.
-  const socPart = (
-    pct: number | null,
-    mi: number | null,
-  ): string => {
+  // Two forms so the SoC range degrades instead of vanishing when the
+  // row is tight: `socShort` is always shown ("62% → 79%"); the miles
+  // ("62% (132 mi) → …") only appear when there's room (sm+).
+  const socShort =
+    session.startSoc != null && session.endSoc != null
+      ? `${fmtSoc(session.startSoc)} → ${fmtSoc(session.endSoc)}`
+      : session.endSoc != null
+        ? fmtSoc(session.endSoc)
+        : "—"
+  const socPart = (pct: number | null, mi: number | null): string => {
     if (pct == null) return "—"
     return mi != null ? `${fmtSoc(pct)} (${Math.round(mi)} mi)` : fmtSoc(pct)
   }
-  const socDelta =
+  const socFull =
     session.startSoc != null && session.endSoc != null
       ? `${socPart(session.startSoc, session.startRangeMi)} → ${socPart(session.endSoc, session.endRangeMi)}`
       : session.endSoc != null
@@ -143,18 +147,17 @@ function ChargeRow({ session }: { session: ChargeSessionSummary }) {
           <span>·</span>
           <span>{fmtDuration(session.durationSecs)}</span>
         </div>
-        <div className="mt-1 flex items-center gap-1 text-sm font-semibold text-emerald-300 tabular-nums sm:hidden">
-          <Zap className="h-3.5 w-3.5" />
-          {fmtEnergy(session.energyAddedKwh)}
-        </div>
       </div>
 
-      <div className="hidden shrink-0 text-right sm:block">
+      <div className="shrink-0 text-right">
         <div className="flex items-center justify-end gap-1 text-sm font-semibold text-emerald-300 tabular-nums">
           <Zap className="h-3.5 w-3.5" />
           {fmtEnergy(session.energyAddedKwh)}
         </div>
-        <div className="mt-0.5 text-xs text-slate-500 tabular-nums">{socDelta}</div>
+        <div className="mt-0.5 text-xs text-slate-500 tabular-nums">
+          <span className="sm:hidden">{socShort}</span>
+          <span className="hidden sm:inline">{socFull}</span>
+        </div>
       </div>
 
       {session.locationLat != null && session.locationLon != null && (

--- a/web/src/pages/Charging.tsx
+++ b/web/src/pages/Charging.tsx
@@ -1,0 +1,158 @@
+import { useCallback, useEffect, useState } from "react"
+import { Link } from "react-router-dom"
+import {
+  BatteryCharging,
+  ChevronRight,
+  Loader2,
+  MapPin,
+  RefreshCw,
+  Zap,
+} from "lucide-react"
+import { fetchChargeSessions } from "@/api/charging"
+import type { ChargeSessionSummary } from "@/types/charging"
+import { fmtDuration, fmtEnergy, fmtSoc } from "@/lib/charge-format"
+
+export default function Charging() {
+  const [sessions, setSessions] = useState<ChargeSessionSummary[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const load = useCallback(() => {
+    setLoading(true)
+    setError(null)
+    fetchChargeSessions()
+      .then((s) => setSessions(s))
+      .catch((e) => setError(e instanceof Error ? e.message : String(e)))
+      .finally(() => setLoading(false))
+  }, [])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  const totalEnergy = sessions.reduce(
+    (sum, s) => sum + (s.energyAddedKwh ?? 0),
+    0,
+  )
+
+  return (
+    <div className="mx-auto w-full max-w-5xl px-4 py-6 sm:px-6 sm:py-8">
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-3 sm:mb-6">
+        <div>
+          <h1 className="text-2xl font-semibold text-slate-100 sm:text-3xl">
+            Charging
+          </h1>
+          {sessions.length > 0 && (
+            <p className="mt-1 text-sm text-slate-500">
+              {sessions.length} session{sessions.length === 1 ? "" : "s"} ·{" "}
+              {fmtEnergy(totalEnergy)} added
+            </p>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={load}
+          className="inline-flex items-center gap-1.5 rounded-lg border border-white/10 bg-white/[0.03] px-3 py-1.5 text-xs font-medium text-slate-300 hover:bg-white/[0.06]"
+        >
+          <RefreshCw className="h-3.5 w-3.5" />
+          Refresh
+        </button>
+      </div>
+
+      <div className="flex flex-col gap-3">
+        {loading && (
+          <div className="flex items-center justify-center gap-2 rounded-2xl border border-white/[0.06] bg-white/[0.025] p-10 text-sm text-slate-400">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Loading charging history…
+          </div>
+        )}
+        {error && !loading && (
+          <div className="rounded-2xl border border-rose-400/30 bg-rose-500/5 p-6 text-sm text-rose-200">
+            Failed to load charging history: {error}
+          </div>
+        )}
+        {!loading && !error && sessions.length === 0 && (
+          <div className="rounded-2xl border border-white/[0.06] bg-white/[0.025] p-10 text-center text-sm text-slate-400">
+            <BatteryCharging className="mx-auto mb-3 h-8 w-8 text-slate-600" />
+            No charging sessions recorded yet. Sessions appear here once the
+            car charges while the Pi is sampling.
+          </div>
+        )}
+        {!loading &&
+          sessions.map((s) => <ChargeRow key={s.id} session={s} />)}
+      </div>
+    </div>
+  )
+}
+
+function ChargeRow({ session }: { session: ChargeSessionSummary }) {
+  const start = new Date(session.startMs)
+  // "19% (40 mi) → 90% (193 mi)" when range is known, else just the
+  // SoC pair, matching how TeslaScope labels a session.
+  const socPart = (
+    pct: number | null,
+    mi: number | null,
+  ): string => {
+    if (pct == null) return "—"
+    return mi != null ? `${fmtSoc(pct)} (${Math.round(mi)} mi)` : fmtSoc(pct)
+  }
+  const socDelta =
+    session.startSoc != null && session.endSoc != null
+      ? `${socPart(session.startSoc, session.startRangeMi)} → ${socPart(session.endSoc, session.endRangeMi)}`
+      : session.endSoc != null
+        ? socPart(session.endSoc, session.endRangeMi)
+        : "—"
+
+  return (
+    <Link
+      to={`/charging/${session.id}`}
+      className="group flex items-center gap-4 rounded-2xl border border-white/[0.06] bg-white/[0.025] p-4 transition-colors hover:border-white/10 hover:bg-white/[0.04]"
+    >
+      <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-emerald-500/10 text-emerald-300 ring-1 ring-inset ring-emerald-500/20">
+        <BatteryCharging className="h-5 w-5" />
+      </span>
+
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2 text-sm font-medium text-slate-100">
+          {formatDate(start)}
+        </div>
+        <div className="mt-0.5 flex flex-wrap items-center gap-x-3 gap-y-0.5 text-xs text-slate-500">
+          <span>{formatTime(start)}</span>
+          <span>·</span>
+          <span>{fmtDuration(session.durationSecs)}</span>
+          {session.location && (
+            <>
+              <span>·</span>
+              <span className="inline-flex items-center gap-1 truncate">
+                <MapPin className="h-3 w-3 shrink-0" />
+                <span className="truncate">{session.location}</span>
+              </span>
+            </>
+          )}
+        </div>
+      </div>
+
+      <div className="hidden shrink-0 text-right sm:block">
+        <div className="flex items-center justify-end gap-1 text-sm font-semibold text-emerald-300 tabular-nums">
+          <Zap className="h-3.5 w-3.5" />
+          {fmtEnergy(session.energyAddedKwh)}
+        </div>
+        <div className="mt-0.5 text-xs text-slate-500 tabular-nums">{socDelta}</div>
+      </div>
+
+      <ChevronRight className="h-4 w-4 shrink-0 text-slate-600 transition-colors group-hover:text-slate-400" />
+    </Link>
+  )
+}
+
+function formatDate(d: Date): string {
+  return d.toLocaleDateString([], {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  })
+}
+
+function formatTime(d: Date): string {
+  return d.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })
+}

--- a/web/src/pages/Charging.tsx
+++ b/web/src/pages/Charging.tsx
@@ -1,62 +1,73 @@
-import { useCallback, useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { Link } from "react-router-dom"
-import {
-  BatteryCharging,
-  ChevronRight,
-  Loader2,
-  MapPin,
-  RefreshCw,
-  Zap,
-} from "lucide-react"
+import { BatteryCharging, ChevronRight, Loader2, MapPin, Zap } from "lucide-react"
 import { fetchChargeSessions } from "@/api/charging"
 import type { ChargeSessionSummary } from "@/types/charging"
+import { DatePopover } from "@/components/drives/DatePopover"
+import {
+  ChargingSummaryStrip,
+  type ChargingStats,
+} from "@/components/charging/ChargingSummaryStrip"
+import { rangeBounds, type DateRange } from "@/hooks/useDrivesList"
 import { fmtDuration, fmtEnergy, fmtSoc } from "@/lib/charge-format"
 
 export default function Charging() {
   const [sessions, setSessions] = useState<ChargeSessionSummary[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  // Charge sessions are infrequent, so default to All time rather than
+  // the Drives default of Last 7 days (which would usually be empty).
+  const [range, setRange] = useState<DateRange>({ kind: "preset", preset: "all" })
 
-  const load = useCallback(() => {
+  useEffect(() => {
+    let cancelled = false
     setLoading(true)
     setError(null)
     fetchChargeSessions()
-      .then((s) => setSessions(s))
-      .catch((e) => setError(e instanceof Error ? e.message : String(e)))
-      .finally(() => setLoading(false))
+      .then((s) => {
+        if (!cancelled) setSessions(s)
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e))
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
   }, [])
 
-  useEffect(() => {
-    load()
-  }, [load])
+  const visible = useMemo(() => {
+    const { from, to } = rangeBounds(range, new Date())
+    return sessions.filter((s) => {
+      const t = new Date(s.startMs)
+      if (from && t < from) return false
+      if (to && t >= to) return false
+      return true
+    })
+  }, [sessions, range])
 
-  const totalEnergy = sessions.reduce(
-    (sum, s) => sum + (s.energyAddedKwh ?? 0),
-    0,
+  const stats: ChargingStats = useMemo(
+    () => ({
+      count: visible.length,
+      totalEnergyKwh: visible.reduce((sum, s) => sum + (s.energyAddedKwh ?? 0), 0),
+      totalDurationSecs: visible.reduce((sum, s) => sum + s.durationSecs, 0),
+    }),
+    [visible],
   )
 
   return (
     <div className="mx-auto w-full max-w-5xl px-4 py-6 sm:px-6 sm:py-8">
       <div className="mb-4 flex flex-wrap items-center justify-between gap-3 sm:mb-6">
-        <div>
-          <h1 className="text-2xl font-semibold text-slate-100 sm:text-3xl">
-            Charging
-          </h1>
-          {sessions.length > 0 && (
-            <p className="mt-1 text-sm text-slate-500">
-              {sessions.length} session{sessions.length === 1 ? "" : "s"} ·{" "}
-              {fmtEnergy(totalEnergy)} added
-            </p>
-          )}
-        </div>
-        <button
-          type="button"
-          onClick={load}
-          className="inline-flex items-center gap-1.5 rounded-lg border border-white/10 bg-white/[0.03] px-3 py-1.5 text-xs font-medium text-slate-300 hover:bg-white/[0.06]"
-        >
-          <RefreshCw className="h-3.5 w-3.5" />
-          Refresh
-        </button>
+        <h1 className="text-2xl font-semibold text-slate-100 sm:text-3xl">
+          Charging
+        </h1>
+      </div>
+
+      <div className="mb-4 flex flex-wrap items-center gap-x-4 gap-y-3">
+        <DatePopover range={range} onChange={setRange} />
+        <ChargingSummaryStrip stats={stats} loading={loading} />
       </div>
 
       <div className="flex flex-col gap-3">
@@ -71,15 +82,16 @@ export default function Charging() {
             Failed to load charging history: {error}
           </div>
         )}
-        {!loading && !error && sessions.length === 0 && (
+        {!loading && !error && visible.length === 0 && (
           <div className="rounded-2xl border border-white/[0.06] bg-white/[0.025] p-10 text-center text-sm text-slate-400">
             <BatteryCharging className="mx-auto mb-3 h-8 w-8 text-slate-600" />
-            No charging sessions recorded yet. Sessions appear here once the
-            car charges while the Pi is sampling.
+            {sessions.length === 0
+              ? "No charging sessions recorded yet. Sessions appear here once the car charges while the Pi is sampling."
+              : "No charging sessions in this date range."}
           </div>
         )}
         {!loading &&
-          sessions.map((s) => <ChargeRow key={s.id} session={s} />)}
+          visible.map((s) => <ChargeRow key={s.id} session={s} />)}
       </div>
     </div>
   )
@@ -88,7 +100,7 @@ export default function Charging() {
 function ChargeRow({ session }: { session: ChargeSessionSummary }) {
   const start = new Date(session.startMs)
   // "19% (40 mi) → 90% (193 mi)" when range is known, else just the
-  // SoC pair, matching how TeslaScope labels a session.
+  // SoC pair.
   const socPart = (
     pct: number | null,
     mi: number | null,

--- a/web/src/pages/PreviewCharging.tsx
+++ b/web/src/pages/PreviewCharging.tsx
@@ -1,0 +1,33 @@
+import {
+  ChargingSection,
+  type ChargeDetail,
+} from "@/components/drives/ChargingSection"
+
+const MOCK: ChargeDetail = {
+  powerKw: 7,
+  currentA: 16,
+  voltageV: 240,
+  rateMph: 25,
+  energyAddedKwh: 12.4,
+  limitSoc: 80,
+  rangeMi: 263,
+}
+
+export default function PreviewCharging() {
+  return (
+    <div className="min-h-screen bg-slate-950 text-slate-100">
+      <div className="mx-auto max-w-3xl space-y-6 p-6">
+        <div>
+          <h1 className="text-2xl font-bold">Charging — preview</h1>
+          <p className="mt-1 text-sm text-slate-500">
+            Dev-only preview of the Charging section for the Driving view.
+            Values shown are mock data.
+          </p>
+        </div>
+        <div className="rounded-2xl border border-white/10 bg-slate-900/40 p-5">
+          <ChargingSection charge={MOCK} />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/types/charging.ts
+++ b/web/src/types/charging.ts
@@ -1,0 +1,45 @@
+// Charge-session shapes returned by /api/charging and
+// /api/charging/{id}. Field names are camelCase to match the backend's
+// serde serialization (crates/api/src/charging.rs). All measured values
+// are optional — any column can be NULL on a given sample.
+
+export interface ChargeSessionSummary {
+  // Session id == start timestamp in unix seconds. Also the detail key.
+  id: number
+  startMs: number
+  endMs: number
+  durationSecs: number
+  location: string | null
+  energyAddedKwh: number | null
+  peakPowerKw: number | null
+  startSoc: number | null
+  endSoc: number | null
+  startRangeMi: number | null
+  endRangeMi: number | null
+  chargeLimitSoc: number | null
+}
+
+export interface ChargePoint {
+  ts: number // unix ms
+  powerKw: number | null
+  currentA: number | null
+  voltageV: number | null
+  rateMph: number | null
+  soc: number | null
+  rangeMi: number | null
+  energyAddedKwh: number | null
+  batteryTempC: number | null
+  interiorTempC: number | null
+  exteriorTempC: number | null
+}
+
+export interface ChargeSessionDetail extends ChargeSessionSummary {
+  avgPowerKw: number | null
+  peakCurrentA: number | null
+  avgCurrentA: number | null
+  peakVoltageV: number | null
+  avgVoltageV: number | null
+  peakRateMph: number | null
+  avgBatteryTempC: number | null
+  points: ChargePoint[]
+}

--- a/web/src/types/charging.ts
+++ b/web/src/types/charging.ts
@@ -10,6 +10,8 @@ export interface ChargeSessionSummary {
   endMs: number
   durationSecs: number
   location: string | null
+  locationLat: number | null
+  locationLon: number | null
   energyAddedKwh: number | null
   peakPowerKw: number | null
   startSoc: number | null

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -49,6 +49,7 @@ export default defineConfig({
     },
   },
   server: {
+    allowedHosts: true,
     proxy: {
       '/api': 'http://localhost:8788',
       '/TeslaCam': 'http://localhost:8788',


### PR DESCRIPTION
## Slice 2 of 3 — charging history (the user-facing feature)

🔗 **Stacked on #66** — review/merge after it. Until #66 lands, the diff below includes #66's commits; it shrinks to just the charging changes once #66 is in `main`.

**What it adds**
- `/api/charging` list + `/api/charging/{id}` detail, derived on-demand from the `telemetry_samples` charge columns from #66 (30-min gap = new session; empty when the flag is off).
- A **Charging page** parallel to Drives: Battery/Range/Power/Amp/Voltage/Temp charts + a location pin map, same layout language as the Drives tab.
- Additive-nullable GPS lat/lon columns (v11→v12) for the charge-location pin.

Forward-looking: it populates once the car actually charges with the flag on (no backfill of pre-flag sessions).

**Safety:** same as #66 — flag-gated reads, additive-nullable + downgrade-safe schema.

Part of a 3-PR series: foundation (#66) → **this (charging)** → architecture consolidation.
