### PR TITLE
fix(charging): capture raw GPS when experimental is on, so the charge map has a pin

### DIFF
--- a/crates/tesla_telemetry/src/main.rs
+++ b/crates/tesla_telemetry/src/main.rs
@@ -889,11 +889,15 @@ async fn tick(
             any_call_ran = true;
         }
 
-        // ── 1b. LOCATION (geofence) ── raw GPS for the keep-accessory
-        // home geofence. Not bundled in `state drive`, so it's its own
-        // round-trip; coarse cadence, and only when the feature is on.
-        // Pure geofence input (not a DB sample) — doesn't set any_call_ran.
-        if cfg.keep_accessory.enabled {
+        // ── 1b. LOCATION (raw GPS) ── `state drive` returns the
+        // locationName (address) but NOT raw coords, so lat/lon need their
+        // own `state location` round-trip. Two consumers want it: the
+        // keep-accessory home geofence, AND the experimental charging map
+        // (the charge-session pin needs lat/lon, not just the address —
+        // without this poll a charge shows its address but no map). Coarse
+        // cadence either way. Pure input (not a DB sample) — doesn't set
+        // any_call_ran.
+        if cfg.keep_accessory.enabled || cfg.experimental {
             let due = last_location_poll
                 .map(|t| tick_now.duration_since(t) >= LOCATION_POLL_INTERVAL)
                 .unwrap_or(true);


### PR DESCRIPTION
## Fix: charge-session map pin missing (raw GPS never captured)

Follow-up to the charging camelCase fix (already merged). On-vehicle testing showed a charge session correctly displaying its **address** but with **no map pin**.

### Cause
`state drive` returns `locationName` (the reverse-geocoded address) but **not** raw coordinates when parked. The raw `latitude`/`longitude` only come from a separate `state location` poll — which was gated **solely** behind `keep_accessory.enabled`. With keep-accessory off (the common case), `last_lat`/`last_lon` stay null, so charge samples carry the address but null lat/lon → the map has nothing to plot.

Confirmed in the journal: every `drive=ok` line shows `location="<address>"` and never a coordinate.

### Fix
Run the `state location` poll when keep-accessory is enabled **OR** the experimental flag is on, so the charging map gets coordinates. Coarse cadence (30s), gated; flag-off installs are unchanged.

Forward-looking: a charge recorded after this lands gets the pin (existing charge rows keep their null coords). Changes `sentryusb-tesla-telemetry` only.
