### PR TITLE
fix(charging): drop redundant Range row from the Power & battery tooltip

### DIFF
--- a/web/src/components/charging/ChargePowerChart.tsx
+++ b/web/src/components/charging/ChargePowerChart.tsx
@@ -81,9 +81,8 @@ export default function ChargePowerChart({ points }: { points: ChargePoint[] }) 
                   {p.soc != null && (
                     <Row color={SOC_COLOR} label="Battery" value={`${Math.round(p.soc)}%`} />
                   )}
-                  {p.rangeMi != null && (
-                    <Row color="#94a3b8" label="Range" value={`${Math.round(p.rangeMi)} mi`} />
-                  )}
+                  {/* Range intentionally omitted here — it has its own chart
+                      below and just duplicates the battery curve in miles. */}
                 </div>
               )
             }}


### PR DESCRIPTION
## Drop the redundant Range row from the Power & battery tooltip

The charge-detail **Power & battery** chart's tooltip showed three rows — Power, Battery, and **Range** — but Range already has its own chart directly below it, and rated range just tracks the battery % curve in miles (same shape). So the Range row was redundant clutter in that tooltip.

This removes only that one tooltip row. The Power + Battery lines and the standalone Range chart are untouched. Frontend-only, no data change.
