### PR TITLE
feat(charging): graduate off the experimental flag (charging is standard now)

### DIFF
--- a/crates/api/src/charging.rs
+++ b/crates/api/src/charging.rs
@@ -102,23 +102,6 @@ struct ChargeSessionDetail {
     points: Vec<ChargePoint>,
 }
 
-/// Whether the master experimental opt-in is set. Mirrors how the
-/// telemetry sampler reads the same key, so both sides agree on what
-/// "on" means. Read fresh per request — config changes without a
-/// daemon restart and these endpoints are low-traffic.
-fn experimental_enabled() -> bool {
-    let path = sentryusb_config::find_config_path();
-    match sentryusb_config::parse_file(path) {
-        Ok((active, commented)) => {
-            match sentryusb_config::get_config_value(&active, &commented, "SENTRYUSB_EXPERIMENTAL") {
-                Some(v) => matches!(v.trim().to_ascii_lowercase().as_str(), "yes" | "true" | "1"),
-                None => false,
-            }
-        }
-        Err(_) => false,
-    }
-}
-
 /// Mean of an iterator of values, or None when it yields nothing. Used
 /// for the detail view's average power / current / voltage / temp stats.
 fn avg(it: impl Iterator<Item = f64>) -> Option<f64> {
@@ -234,15 +217,10 @@ fn summarize(rows: &[ChargeRow]) -> ChargeSessionSummary {
 
 /// GET /api/charging
 ///
-/// Charge sessions newest-first. Empty when the experimental flag is off
-/// or no charging has been sampled.
+/// Charge sessions newest-first. Empty when no charging has been sampled.
 pub async fn list_charging(
     State(state): State<AppState>,
 ) -> (StatusCode, Json<serde_json::Value>) {
-    if !experimental_enabled() {
-        return (StatusCode::OK, Json(serde_json::json!({ "sessions": [] })));
-    }
-
     let result = state
         .drives
         .store
@@ -272,10 +250,6 @@ pub async fn single_charging(
     State(state): State<AppState>,
     Path(id): Path<i64>,
 ) -> (StatusCode, Json<serde_json::Value>) {
-    if !experimental_enabled() {
-        return crate::json_error(StatusCode::NOT_FOUND, "charging history not enabled");
-    }
-
     // Bound the scan so a session that never closes can't read the whole
     // table. One plug-in can't plausibly exceed this; the gap split ends
     // the session well before the bound in practice.

--- a/crates/tesla_telemetry/src/main.rs
+++ b/crates/tesla_telemetry/src/main.rs
@@ -889,11 +889,19 @@ async fn tick(
             any_call_ran = true;
         }
 
-        // ── 1b. LOCATION (geofence) ── raw GPS for the keep-accessory
-        // home geofence. Not bundled in `state drive`, so it's its own
-        // round-trip; coarse cadence, and only when the feature is on.
-        // Pure geofence input (not a DB sample) — doesn't set any_call_ran.
-        if cfg.keep_accessory.enabled {
+        // ── 1b. LOCATION (raw GPS) ── `state drive` returns the address
+        // name but NOT raw coords when parked, so lat/lon need their own
+        // `state location` round-trip. Two consumers: the keep-accessory
+        // home geofence, and the charging-map pin (which needs coords, not
+        // just the address). Run it when keep-accessory is on OR the car is
+        // actively charging — so a charge gets a map pin without polling
+        // GPS on every idle parked car. Coarse cadence; pure input (not a
+        // DB sample) — doesn't set any_call_ran.
+        let charging_now = last_charging_state
+            .as_ref()
+            .map(|s| s.is_active_charging())
+            .unwrap_or(false);
+        if cfg.keep_accessory.enabled || charging_now {
             let due = last_location_poll
                 .map(|t| tick_now.duration_since(t) >= LOCATION_POLL_INTERVAL)
                 .unwrap_or(true);
@@ -956,18 +964,19 @@ async fn tick(
                 Ok(c) => {
                     if cfg.experimental {
                         sample_ble::log_charge_detail(&c);
-                        // Persist the expanded charging detail (v11 columns).
-                        // Gated by the flag so a normal install writes the
-                        // same rows it always has (these stay NULL).
-                        let d = &c.detail;
-                        sample.charger_power_kw = d.charger_power_kw;
-                        sample.charger_actual_current_a = d.charger_actual_current_a;
-                        sample.charger_voltage_v = d.charger_voltage_v;
-                        sample.charge_rate_mph = d.charge_rate_mph;
-                        sample.charge_energy_added_kwh = d.charge_energy_added_kwh;
-                        sample.charge_limit_soc = d.charge_limit_soc;
-                        sample.battery_range_mi = d.battery_range_mi;
                     }
+                    // Persist the charging detail (v11 columns). Charging is a
+                    // standard feature now (graduated off the experimental
+                    // flag), so these are always written — NULL only when the
+                    // car isn't reporting charge data.
+                    let d = &c.detail;
+                    sample.charger_power_kw = d.charger_power_kw;
+                    sample.charger_actual_current_a = d.charger_actual_current_a;
+                    sample.charger_voltage_v = d.charger_voltage_v;
+                    sample.charge_rate_mph = d.charge_rate_mph;
+                    sample.charge_energy_added_kwh = d.charge_energy_added_kwh;
+                    sample.charge_limit_soc = d.charge_limit_soc;
+                    sample.battery_range_mi = d.battery_range_mi;
                     try_sync_clock(c.meta);
                     sample.battery_pct = c.battery_pct;
                     // Refresh the gate input on success; keep the previous
@@ -1081,15 +1090,14 @@ async fn tick(
         // Persist whatever this tick collected; sparse rows (e.g.
         // drive-only) are handled downstream.
         if any_call_ran {
-            // Stamp the held last-known GPS onto the row (experimental
-            // only) so a parked-and-charging sample carries the
-            // charger's location for the charging-view map pin. Parked
-            // polls omit fresh coords, so `*last_lat`/`*last_lon` (held
-            // across ticks) is the right source.
-            if cfg.experimental {
-                sample.latitude = *last_lat;
-                sample.longitude = *last_lon;
-            }
+            // Stamp the held last-known GPS onto the row so a parked-and-
+            // charging sample carries the charger's location for the
+            // charging-view map pin. Parked polls omit fresh coords, so
+            // `*last_lat`/`*last_lon` (held across ticks) is the right
+            // source. Always written now (charging graduated off the flag);
+            // NULL until a location poll has supplied coords.
+            sample.latitude = *last_lat;
+            sample.longitude = *last_lon;
             persist(conn, sample);
         }
 

--- a/web/src/components/layout/MobileNav.tsx
+++ b/web/src/components/layout/MobileNav.tsx
@@ -29,7 +29,6 @@ import { useUpdateAvailable } from "@/hooks/useUpdateAvailable"
 import { useConnectionStatus } from "@/hooks/useConnectionStatus"
 import { useAuth } from "@/hooks/useAuth"
 import { useCommunityPrefs } from "@/hooks/useCommunityPrefs"
-import { useExperimental } from "@/hooks/useExperimental"
 
 interface MobileNavProps {
   open: boolean
@@ -50,15 +49,13 @@ const baseNavItems = [
 
 function buildNavItems(
   mode: ReturnType<typeof useCommunityPrefs>["mode"],
-  experimental: boolean,
 ) {
-  const items = experimental
-    ? baseNavItems.flatMap((item) =>
-        item.to === "/drives"
-          ? [item, { to: "/charging", icon: BatteryCharging, label: "Charging" }]
-          : [item],
-      )
-    : baseNavItems
+  // Charging history is a standard view now — slot it right after Drives.
+  const items = baseNavItems.flatMap((item) =>
+    item.to === "/drives"
+      ? [item, { to: "/charging", icon: BatteryCharging, label: "Charging" }]
+      : [item],
+  )
   return items
     .filter((item) => item.to !== "/community" || mode !== "none")
     .map((item) => {
@@ -77,9 +74,8 @@ export function MobileNav({ open, onClose }: MobileNavProps) {
   const { state: connState } = useConnectionStatus()
   const { authRequired, logout } = useAuth()
   const { mode: communityMode } = useCommunityPrefs()
-  const experimental = useExperimental()
   const [version, setVersion] = useState<string | null>(null)
-  const navItems = buildNavItems(communityMode, experimental === true)
+  const navItems = buildNavItems(communityMode)
 
   useEffect(() => {
     fetch("/api/system/version")

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -30,7 +30,6 @@ import { useUpdateAvailable } from "@/hooks/useUpdateAvailable"
 import { useConnectionStatus } from "@/hooks/useConnectionStatus"
 import { useAuth } from "@/hooks/useAuth"
 import { useCommunityPrefs } from "@/hooks/useCommunityPrefs"
-import { useExperimental } from "@/hooks/useExperimental"
 
 interface SidebarProps {
   collapsed: boolean
@@ -51,18 +50,14 @@ const baseNavItems = [
 
 function buildNavItems(
   mode: ReturnType<typeof useCommunityPrefs>["mode"],
-  experimental: boolean,
 ) {
-  // Charging history is gated behind the experimental opt-in (the
-  // sampler only writes charge columns when it's on). Slot it right
-  // after Drives so the two telemetry views sit together.
-  const items = experimental
-    ? baseNavItems.flatMap((item) =>
-        item.to === "/drives"
-          ? [item, { to: "/charging", icon: BatteryCharging, label: "Charging" }]
-          : [item],
-      )
-    : baseNavItems
+  // Charging history is a standard view now — slot it right after Drives
+  // so the two telemetry views sit together.
+  const items = baseNavItems.flatMap((item) =>
+    item.to === "/drives"
+      ? [item, { to: "/charging", icon: BatteryCharging, label: "Charging" }]
+      : [item],
+  )
   return items
     .filter((item) => item.to !== "/community" || mode !== "none")
     .map((item) => {
@@ -81,9 +76,8 @@ export function Sidebar({ collapsed, onToggle }: SidebarProps) {
   const { state: connState } = useConnectionStatus()
   const { authRequired, logout } = useAuth()
   const { mode: communityMode } = useCommunityPrefs()
-  const experimental = useExperimental()
   const [version, setVersion] = useState<string | null>(null)
-  const navItems = buildNavItems(communityMode, experimental === true)
+  const navItems = buildNavItems(communityMode)
 
   useEffect(() => {
     fetch("/api/system/version")


### PR DESCRIPTION
## Graduate Charging off the experimental flag

Charging history has been validated on-vehicle (real charge sessions render correctly), so it should be a standard feature rather than an opt-in. This removes `SENTRYUSB_EXPERIMENTAL` gating from the **charging paths only**:

- **API** — `/api/charging` + `/api/charging/{id}` always serve; dropped the experimental guard + the now-unused `experimental_enabled()` helper.
- **Sampler** — the v11 charge columns and the held-GPS stamp are always persisted (NULL only when the car isn't reporting charge data). The raw `state location` poll now runs when **keep-accessory is enabled OR the car is actively charging**, so a charge gets a map pin without polling GPS on every idle parked car. **Keep-accessory behavior is unchanged** — the new condition is purely additive.
- **Web nav** — the Charging item always appears.

The experimental flag **stays** for the genuinely-risky, still-parked BLE/gadget consolidation (it was never really about charging). The expanded **drive/climate/closures** decode stays behind the flag (no UI yet) — only charging is ungated here.

DB note: schema columns were already additive/unconditional; no schema change.
