### PR TITLE
feat(charging): dashboard charging banner + minutes-to-full [stacked on #71]

### DIFF
--- a/crates/api/src/charging.rs
+++ b/crates/api/src/charging.rs
@@ -305,6 +305,97 @@ pub async fn single_charging(
     (StatusCode::OK, Json(serde_json::to_value(detail).unwrap()))
 }
 
+/// Live charge status for the dashboard banner. `charging` is false when
+/// the latest sample isn't an active charge or is stale (the car stopped
+/// being sampled); the other fields are present only while charging.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CurrentCharge {
+    charging: bool,
+    soc: Option<f64>,
+    limit_soc: Option<i64>,
+    power_kw: Option<i64>,
+    minutes_to_full: Option<i64>,
+    range_mi: Option<f64>,
+}
+
+impl CurrentCharge {
+    fn idle() -> Self {
+        Self {
+            charging: false,
+            soc: None,
+            limit_soc: None,
+            power_kw: None,
+            minutes_to_full: None,
+            range_mi: None,
+        }
+    }
+}
+
+/// The single most-recent telemetry row, charge-relevant columns only.
+struct LatestCharge {
+    ts: i64,
+    soc: Option<f64>,
+    limit_soc: Option<i64>,
+    power_kw: Option<i64>,
+    rate_mph: Option<f64>,
+    minutes_to_full: Option<i64>,
+    range_mi: Option<f64>,
+}
+
+/// GET /api/charging/current — is the car charging right now, with the
+/// fields the dashboard banner shows. Reads one row (latest by ts); a
+/// sample older than 10 minutes counts as "not charging" so a long-asleep
+/// car doesn't keep the banner stuck on.
+pub async fn current_charging(
+    State(state): State<AppState>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    use rusqlite::OptionalExtension;
+    let latest = state.drives.store.with_locked_conn(|conn| {
+        conn.query_row(
+            "SELECT ts, battery_pct, charge_limit_soc, charger_power_kw, \
+                    charge_rate_mph, charge_minutes_to_full, battery_range_mi \
+             FROM telemetry_samples ORDER BY ts DESC LIMIT 1",
+            [],
+            |r| {
+                Ok(LatestCharge {
+                    ts: r.get(0)?,
+                    soc: r.get(1)?,
+                    limit_soc: r.get(2)?,
+                    power_kw: r.get(3)?,
+                    rate_mph: r.get(4)?,
+                    minutes_to_full: r.get(5)?,
+                    range_mi: r.get(6)?,
+                })
+            },
+        )
+        .optional()
+    });
+
+    let cur = match latest {
+        Ok(Some(l)) => {
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs() as i64)
+                .unwrap_or(l.ts);
+            if now - l.ts <= 600 && is_charging(l.power_kw, l.rate_mph) {
+                CurrentCharge {
+                    charging: true,
+                    soc: l.soc,
+                    limit_soc: l.limit_soc,
+                    power_kw: l.power_kw,
+                    minutes_to_full: l.minutes_to_full,
+                    range_mi: l.range_mi,
+                }
+            } else {
+                CurrentCharge::idle()
+            }
+        }
+        _ => CurrentCharge::idle(),
+    };
+    (StatusCode::OK, Json(serde_json::to_value(cur).unwrap()))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/api/src/router.rs
+++ b/crates/api/src/router.rs
@@ -203,6 +203,7 @@ pub fn build_router(state: AppState) -> Router {
         // Charging — sessions derived on-demand from the per-sample
         // charge columns. Empty unless the experimental flag is on.
         .route("/api/charging", get(crate::charging::list_charging))
+        .route("/api/charging/current", get(crate::charging::current_charging))
         .route("/api/charging/{id}", get(crate::charging::single_charging))
         // Keep-awake
         .route("/api/keep-awake/start", post(crate::keep_awake::start))

--- a/crates/drives/src/schema.rs
+++ b/crates/drives/src/schema.rs
@@ -78,7 +78,7 @@ use rusqlite::{params, Connection, OptionalExtension};
 /// Also: `software_version` columns on both tables are kept for
 /// forward-compat but no longer written â€” Tesla doesn't expose
 /// `car_version` over BLE state queries.
-pub const CURRENT_SCHEMA_VERSION: i32 = 12;
+pub const CURRENT_SCHEMA_VERSION: i32 = 13;
 
 /// v1 DDL. Each statement is idempotent (`IF NOT EXISTS`) so `migrate()`
 /// is safe on every startup. Column shapes and names match Go exactly â€”
@@ -288,6 +288,14 @@ pub const V12_TELEMETRY_GPS_COLUMNS: &[(&str, &str)] = &[
     ("longitude", "REAL"),
 ];
 
+/// v13 estimated-minutes-to-full column on `telemetry_samples`. The car
+/// already reports this in its `ChargeState`; persisting it lets the
+/// dashboard "charging" banner show a live time-to-full. Additive +
+/// nullable like the rest.
+pub const V13_TELEMETRY_MINUTES_COLUMN: &[(&str, &str)] = &[
+    ("charge_minutes_to_full", "INTEGER"),
+];
+
 /// v10 per-clip location-name rollups on `routes`. Populated by
 /// the aggregator from the first / last non-null sample in the
 /// clip's 60s window.
@@ -364,6 +372,7 @@ pub fn migrate(conn: &Connection) -> Result<()> {
         .chain(V10_TELEMETRY_COLUMNS.iter())
         .chain(V11_TELEMETRY_CHARGE_COLUMNS.iter())
         .chain(V12_TELEMETRY_GPS_COLUMNS.iter())
+        .chain(V13_TELEMETRY_MINUTES_COLUMN.iter())
     {
         if existing_tele.contains(*name) {
             continue;
@@ -538,7 +547,7 @@ mod tests {
         migrate(&conn).unwrap();
         assert_eq!(
             meta_get(&conn, "schema_version").unwrap().as_deref(),
-            Some("12"),
+            Some("13"),
         );
         assert!(meta_get(&conn, "created_at").unwrap().is_some());
     }
@@ -576,7 +585,7 @@ mod tests {
         }
         assert_eq!(
             meta_get(&conn, "schema_version").unwrap().as_deref(),
-            Some("12")
+            Some("13")
         );
     }
 
@@ -608,7 +617,7 @@ mod tests {
         }
         assert_eq!(
             meta_get(&conn, "schema_version").unwrap().as_deref(),
-            Some("12")
+            Some("13")
         );
     }
 
@@ -642,7 +651,7 @@ mod tests {
         }
         assert_eq!(
             meta_get(&conn, "schema_version").unwrap().as_deref(),
-            Some("12")
+            Some("13")
         );
     }
 
@@ -749,7 +758,7 @@ mod tests {
         assert!(surviving_processed.starts_with("RecentClips/"));
         assert_eq!(
             meta_get(&conn, "schema_version").unwrap().as_deref(),
-            Some("12")
+            Some("13")
         );
     }
 
@@ -800,7 +809,7 @@ mod tests {
         assert_eq!(count_routes(&conn), 1, "fresh-DB seed must not run v5 cleanup");
         assert_eq!(
             meta_get(&conn, "schema_version").unwrap().as_deref(),
-            Some("12")
+            Some("13")
         );
     }
 
@@ -853,7 +862,7 @@ mod tests {
         assert_eq!(table_exists, 1, "v6 must create telemetry_samples");
         assert_eq!(
             meta_get(&conn, "schema_version").unwrap().as_deref(),
-            Some("12")
+            Some("13")
         );
     }
 
@@ -896,7 +905,7 @@ mod tests {
         }
         assert_eq!(
             meta_get(&conn, "schema_version").unwrap().as_deref(),
-            Some("12")
+            Some("13")
         );
     }
 

--- a/crates/tesla_telemetry/src/db.rs
+++ b/crates/tesla_telemetry/src/db.rs
@@ -41,9 +41,9 @@ pub fn insert(conn: &Connection, s: &Sample) -> Result<()> {
           charger_power_kw, charger_actual_current_a, charger_voltage_v, \
           charge_rate_mph, charge_energy_added_kwh, charge_limit_soc, battery_range_mi, \
           latitude, longitude, \
-          source) \
+          source, charge_minutes_to_full) \
          VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, \
-                 ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22)",
+                 ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23)",
         params![
             s.ts,
             s.battery_pct,
@@ -67,6 +67,7 @@ pub fn insert(conn: &Connection, s: &Sample) -> Result<()> {
             s.latitude,
             s.longitude,
             s.source,
+            s.charge_minutes_to_full,
         ],
     )?;
     Ok(())

--- a/crates/tesla_telemetry/src/main.rs
+++ b/crates/tesla_telemetry/src/main.rs
@@ -977,6 +977,7 @@ async fn tick(
                     sample.charge_energy_added_kwh = d.charge_energy_added_kwh;
                     sample.charge_limit_soc = d.charge_limit_soc;
                     sample.battery_range_mi = d.battery_range_mi;
+                    sample.charge_minutes_to_full = d.minutes_to_full_charge;
                     try_sync_clock(c.meta);
                     sample.battery_pct = c.battery_pct;
                     // Refresh the gate input on success; keep the previous

--- a/crates/tesla_telemetry/src/sample.rs
+++ b/crates/tesla_telemetry/src/sample.rs
@@ -344,6 +344,9 @@ pub struct Sample {
     pub charge_energy_added_kwh: Option<f32>,
     pub charge_limit_soc: Option<i32>,
     pub battery_range_mi: Option<f32>,
+    // Estimated minutes to full charge (v13). Drives the dashboard
+    // "charging" banner's time-to-full readout.
+    pub charge_minutes_to_full: Option<i32>,
     // Raw GPS (v12). Populated from the bundled LocationState only when
     // the experimental flag is on; None otherwise. Lets a parked-and-
     // charging sample carry the charger's location for the map pin.

--- a/web/src/api/charging.ts
+++ b/web/src/api/charging.ts
@@ -1,6 +1,7 @@
 import type {
   ChargeSessionDetail,
   ChargeSessionSummary,
+  CurrentCharge,
 } from "@/types/charging"
 
 export async function fetchChargeSessions(): Promise<ChargeSessionSummary[]> {
@@ -15,5 +16,12 @@ export async function fetchChargeSession(
 ): Promise<ChargeSessionDetail> {
   const res = await fetch(`/api/charging/${id}`)
   if (!res.ok) throw new Error(`charge session ${id}: ${res.status}`)
+  return res.json()
+}
+
+/// Live "is the car charging right now" for the dashboard banner.
+export async function fetchCurrentCharge(): Promise<CurrentCharge> {
+  const res = await fetch("/api/charging/current")
+  if (!res.ok) throw new Error(`charging/current: ${res.status}`)
   return res.json()
 }

--- a/web/src/components/charging/ChargingBanner.tsx
+++ b/web/src/components/charging/ChargingBanner.tsx
@@ -1,0 +1,70 @@
+import { useEffect, useState } from "react"
+import { BatteryCharging } from "lucide-react"
+import { fetchCurrentCharge } from "@/api/charging"
+import type { CurrentCharge } from "@/types/charging"
+
+const POLL_MS = 30_000
+
+/** "3h 45m to full" / "45m to full" — null/0 renders nothing. */
+function fmtToFull(mins: number | null): string | null {
+  if (mins == null || mins <= 0) return null
+  const h = Math.floor(mins / 60)
+  const m = mins % 60
+  if (h > 0) return `~${h}h ${m}m to full`
+  return `~${m}m to full`
+}
+
+/**
+ * Slim dashboard banner shown only while the car is actively charging.
+ * Polls /api/charging/current; renders nothing when idle, so it occupies
+ * zero space the rest of the time.
+ */
+export default function ChargingBanner() {
+  const [cur, setCur] = useState<CurrentCharge | null>(null)
+
+  useEffect(() => {
+    let alive = true
+    const tick = () =>
+      fetchCurrentCharge()
+        .then((c) => alive && setCur(c))
+        .catch(() => alive && setCur(null))
+    tick()
+    const id = setInterval(tick, POLL_MS)
+    return () => {
+      alive = false
+      clearInterval(id)
+    }
+  }, [])
+
+  if (!cur?.charging) return null
+
+  const toFull = fmtToFull(cur.minutesToFull)
+  const parts: string[] = []
+  if (cur.soc != null) {
+    parts.push(
+      cur.limitSoc != null
+        ? `${Math.round(cur.soc)}% → ${cur.limitSoc}%`
+        : `${Math.round(cur.soc)}%`,
+    )
+  }
+  if (cur.powerKw != null) parts.push(`${cur.powerKw} kW`)
+  if (toFull) parts.push(toFull)
+
+  return (
+    <div className="mb-4 flex items-center gap-2 rounded-xl border border-emerald-500/20 bg-emerald-500/10 px-4 py-2.5 text-sm text-emerald-300">
+      <BatteryCharging className="h-4 w-4 shrink-0 animate-pulse" />
+      <span className="font-medium text-emerald-200">Charging</span>
+      {parts.length > 0 && (
+        <span className="text-emerald-400/70">·</span>
+      )}
+      <span className="flex flex-wrap items-center gap-x-2 gap-y-0.5 tabular-nums">
+        {parts.map((p, i) => (
+          <span key={i} className="flex items-center gap-2">
+            {i > 0 && <span className="text-emerald-400/50">·</span>}
+            {p}
+          </span>
+        ))}
+      </span>
+    </div>
+  )
+}

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -22,6 +22,7 @@ import { api } from "@/lib/api"
 import { useKeepAwake } from "@/hooks/useKeepAwake"
 import { useAwayMode } from "@/hooks/useAwayMode"
 import { useUpdateAvailable } from "@/hooks/useUpdateAvailable"
+import ChargingBanner from "@/components/charging/ChargingBanner"
 import type { PiStatus, DriveStats, StorageBreakdown } from "@/lib/api"
 import { wsClient } from "@/lib/ws"
 import { formatUptime, formatBytes, formatTemp } from "@/lib/utils"
@@ -446,6 +447,8 @@ export default function Dashboard() {
         <h1 className="text-2xl font-bold text-slate-100">Dashboard</h1>
         <p className="mt-0.5 text-sm text-slate-500">System overview and status</p>
       </div>
+
+      <ChargingBanner />
 
       <BannerStack banners={banners} />
 

--- a/web/src/types/charging.ts
+++ b/web/src/types/charging.ts
@@ -45,3 +45,15 @@ export interface ChargeSessionDetail extends ChargeSessionSummary {
   avgBatteryTempC: number | null
   points: ChargePoint[]
 }
+
+// Live charge status for the dashboard banner (/api/charging/current).
+// `charging` is false when the car isn't actively charging; the other
+// fields are present only while charging.
+export interface CurrentCharge {
+  charging: boolean
+  soc: number | null
+  limitSoc: number | null
+  powerKw: number | null
+  minutesToFull: number | null
+  rangeMi: number | null
+}


### PR DESCRIPTION
## Dashboard charging banner + minutes-to-full

A slim banner across the top of the dashboard, shown **only while the car is actively charging** — charging icon, battery % → limit, power, and estimated time to full:

```
⚡ Charging · 55% → 80% · 4 kW · ~3h 45m to full
```

🔗 **Stacked on #71** (charging-ungate) — review/merge after it; the diff includes #71's commits until it lands.

**Backend**
- **DB (v13):** new nullable `charge_minutes_to_full` column on `telemetry_samples` (additive, downgrade-safe). The car already reports it in `ChargeState`; the sampler now persists it.
- **API:** `GET /api/charging/current` — reads the latest sample, reports whether the car is charging *right now* (power/rate nonzero **and** the sample is < 10 min old, so a long-asleep car doesn't keep the banner stuck), with soc / limit / power / minutes-to-full / range. camelCase wire shape.

**Web**
- `ChargingBanner` polls `/api/charging/current` every 30s, renders **nothing when idle** (zero footprint) and the slim emerald strip when charging. Wired into the Dashboard above the existing banners.

Backend builds clean; drives/telemetry/api tests green. Forward-looking: minutes-to-full populates on charges recorded after this lands.
