### PR TITLE
feat(charging): make the dashboard banner persistent (battery when idle)

### DIFF
--- a/crates/api/src/charging.rs
+++ b/crates/api/src/charging.rs
@@ -378,17 +378,20 @@ pub async fn current_charging(
                 .duration_since(std::time::UNIX_EPOCH)
                 .map(|d| d.as_secs() as i64)
                 .unwrap_or(l.ts);
-            if now - l.ts <= 600 && is_charging(l.power_kw, l.rate_mph) {
-                CurrentCharge {
-                    charging: true,
-                    soc: l.soc,
-                    limit_soc: l.limit_soc,
-                    power_kw: l.power_kw,
-                    minutes_to_full: l.minutes_to_full,
-                    range_mi: l.range_mi,
-                }
-            } else {
-                CurrentCharge::idle()
+            let age = now - l.ts;
+            let charging = age <= 600 && is_charging(l.power_kw, l.rate_mph);
+            // Battery % is shown for the persistent car-status banner as long
+            // as the data is reasonably fresh (<= 24h), so the banner doesn't
+            // vanish the moment a charge ends. The charging-only fields are
+            // present only while actively charging.
+            let soc = if age <= 86_400 { l.soc } else { None };
+            CurrentCharge {
+                charging,
+                soc,
+                limit_soc: if charging { l.limit_soc } else { None },
+                power_kw: if charging { l.power_kw } else { None },
+                minutes_to_full: if charging { l.minutes_to_full } else { None },
+                range_mi: if charging { l.range_mi } else { l.range_mi.filter(|_| soc.is_some()) },
             }
         }
         _ => CurrentCharge::idle(),

--- a/web/src/components/charging/ChargingBanner.tsx
+++ b/web/src/components/charging/ChargingBanner.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react"
-import { BatteryCharging } from "lucide-react"
+import { Battery, BatteryCharging } from "lucide-react"
 import { fetchCurrentCharge } from "@/api/charging"
 import type { CurrentCharge } from "@/types/charging"
 
@@ -15,9 +15,11 @@ function fmtToFull(mins: number | null): string | null {
 }
 
 /**
- * Slim dashboard banner shown only while the car is actively charging.
- * Polls /api/charging/current; renders nothing when idle, so it occupies
- * zero space the rest of the time.
+ * Persistent dashboard car-status banner. Polls /api/charging/current and
+ * stays visible whenever there's recent battery data: a green "charging"
+ * strip with time-to-full while charging, and a subdued battery readout
+ * when idle (so it doesn't vanish the moment a charge ends). Renders
+ * nothing only when there's no recent telemetry at all.
  */
 export default function ChargingBanner() {
   const [cur, setCur] = useState<CurrentCharge | null>(null)
@@ -36,35 +38,46 @@ export default function ChargingBanner() {
     }
   }, [])
 
-  if (!cur?.charging) return null
+  // No recent battery data → nothing to show.
+  if (!cur || cur.soc == null) return null
 
-  const toFull = fmtToFull(cur.minutesToFull)
-  const parts: string[] = []
-  if (cur.soc != null) {
-    parts.push(
-      cur.limitSoc != null
-        ? `${Math.round(cur.soc)}% → ${cur.limitSoc}%`
-        : `${Math.round(cur.soc)}%`,
-    )
-  }
-  if (cur.powerKw != null) parts.push(`${cur.powerKw} kW`)
-  if (toFull) parts.push(toFull)
+  const soc = Math.round(cur.soc)
 
-  return (
-    <div className="mb-4 flex items-center gap-2 rounded-xl border border-emerald-500/20 bg-emerald-500/10 px-4 py-2.5 text-sm text-emerald-300">
-      <BatteryCharging className="h-4 w-4 shrink-0 animate-pulse" />
-      <span className="font-medium text-emerald-200">Charging</span>
-      {parts.length > 0 && (
-        <span className="text-emerald-400/70">·</span>
-      )}
-      <span className="flex flex-wrap items-center gap-x-2 gap-y-0.5 tabular-nums">
+  if (cur.charging) {
+    const parts: string[] = [
+      cur.limitSoc != null ? `${soc}% → ${cur.limitSoc}%` : `${soc}%`,
+    ]
+    if (cur.powerKw != null) parts.push(`${cur.powerKw} kW`)
+    const toFull = fmtToFull(cur.minutesToFull)
+    if (toFull) parts.push(toFull)
+
+    return (
+      <div className="mb-4 flex flex-wrap items-center gap-x-2 gap-y-0.5 rounded-xl border border-emerald-500/20 bg-emerald-500/10 px-4 py-2.5 text-sm text-emerald-300 tabular-nums">
+        <BatteryCharging className="h-4 w-4 shrink-0 animate-pulse" />
+        <span className="font-medium text-emerald-200">Charging</span>
         {parts.map((p, i) => (
           <span key={i} className="flex items-center gap-2">
-            {i > 0 && <span className="text-emerald-400/50">·</span>}
+            <span className="text-emerald-400/50">·</span>
             {p}
           </span>
         ))}
-      </span>
+      </div>
+    )
+  }
+
+  // Idle — persistent battery readout so the banner stays put.
+  return (
+    <div className="mb-4 flex flex-wrap items-center gap-x-2 gap-y-0.5 rounded-xl border border-white/10 bg-slate-800/40 px-4 py-2.5 text-sm text-slate-300 tabular-nums">
+      <Battery className="h-4 w-4 shrink-0 text-slate-400" />
+      <span className="font-medium text-slate-200">{soc}%</span>
+      {cur.rangeMi != null && (
+        <span className="flex items-center gap-2">
+          <span className="text-slate-500">·</span>
+          {Math.round(cur.rangeMi)} mi
+        </span>
+      )}
+      <span className="text-slate-500">·</span>
+      <span className="text-slate-400">Not charging</span>
     </div>
   )
 }


### PR DESCRIPTION
Chad: the dashboard charging banner vanished the moment charging stopped — it should stay visible. Reworked it into a persistent car-status strip.

- `/api/charging/current` now returns the latest battery % as long as the telemetry is fresh (<= 24h), with the charging-only fields (limit / power / minutes-to-full) present only while actively charging.
- `ChargingBanner` renders the green "Charging … ~Xh Ym to full" strip while charging, and a subdued "🔋 63% · 199 mi · Not charging" strip when idle. It only disappears when there's no recent telemetry at all.

Follow-up to #72 (which introduced the banner + `/api/charging/current`). Stacked logically on #72 but the diff is independent — applies cleanly on current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)