### PR TITLE
fix(charging): minimalist banner — battery + range only, units honour DRIVE_MAP_UNIT

### DIFF
--- a/web/src/components/charging/ChargingBanner.tsx
+++ b/web/src/components/charging/ChargingBanner.tsx
@@ -5,24 +5,23 @@ import type { CurrentCharge } from "@/types/charging"
 
 const POLL_MS = 30_000
 
-/** "3h 45m to full" / "45m to full" — null/0 renders nothing. */
-function fmtToFull(mins: number | null): string | null {
-  if (mins == null || mins <= 0) return null
-  const h = Math.floor(mins / 60)
-  const m = mins % 60
-  if (h > 0) return `~${h}h ${m}m to full`
-  return `~${m}m to full`
-}
-
 /**
  * Persistent dashboard car-status banner. Polls /api/charging/current and
- * stays visible whenever there's recent battery data: a green "charging"
- * strip with time-to-full while charging, and a subdued battery readout
- * when idle (so it doesn't vanish the moment a charge ends). Renders
- * nothing only when there's no recent telemetry at all.
+ * stays visible whenever there's recent battery data.
+ *
+ * Charging vs idle is conveyed by color + icon — green pulsing
+ * `BatteryCharging` for active charging, subdued `Battery` when not.
+ * The content is the same in both states (battery % · range) so the
+ * banner reads as a steady "this is your car's battery right now" strip
+ * rather than two visually different cards. Same pattern as drive-detail:
+ * the unit comes from `DRIVE_MAP_UNIT` in setup config (default imperial).
  */
 export default function ChargingBanner() {
   const [cur, setCur] = useState<CurrentCharge | null>(null)
+  // Distance unit, sourced from setup config (DRIVE_MAP_UNIT). Default
+  // imperial — same default as the wizard and the other dashboard
+  // surfaces, so the first paint never shows an unintended unit.
+  const [metric, setMetric] = useState(false)
 
   useEffect(() => {
     let alive = true
@@ -30,7 +29,7 @@ export default function ChargingBanner() {
       fetchCurrentCharge()
         .then((c) => alive && setCur(c))
         // Keep the last good state on a transient fetch error (a single
-        // 30s-poll timeout shouldn't collapse a live charging banner).
+        // 30s-poll timeout shouldn't collapse a live banner).
         .catch(() => {})
     tick()
     const id = setInterval(tick, POLL_MS)
@@ -40,46 +39,65 @@ export default function ChargingBanner() {
     }
   }, [])
 
+  useEffect(() => {
+    let cancelled = false
+    fetch("/api/setup/config")
+      .then((r) => r.json())
+      .then((cfg) => {
+        if (cancelled) return
+        const entry = cfg?.DRIVE_MAP_UNIT
+        if (!entry) return
+        const val =
+          typeof entry === "object" ? (entry.active ? entry.value : null) : entry
+        if (val !== null && val !== undefined) setMetric(val === "km")
+      })
+      .catch(() => {
+        /* non-critical — fall back to default unit */
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
   // No recent battery data → nothing to show.
   if (!cur || cur.soc == null) return null
 
   const soc = Math.round(cur.soc)
+  const range =
+    cur.rangeMi != null
+      ? metric
+        ? `${Math.round(cur.rangeMi * 1.609344)} km`
+        : `${Math.round(cur.rangeMi)} mi`
+      : null
 
   if (cur.charging) {
-    const parts: string[] = [
-      cur.limitSoc != null ? `${soc}% → ${cur.limitSoc}%` : `${soc}%`,
-    ]
-    if (cur.powerKw != null) parts.push(`${cur.powerKw} kW`)
-    const toFull = fmtToFull(cur.minutesToFull)
-    if (toFull) parts.push(toFull)
-
+    // Active charging — green strip, pulsing icon. Color carries the
+    // "this is charging" signal so the text doesn't have to.
     return (
       <div className="mb-4 flex flex-wrap items-center gap-x-2 gap-y-0.5 rounded-xl border border-emerald-500/20 bg-emerald-500/10 px-4 py-2.5 text-sm text-emerald-300 tabular-nums">
         <BatteryCharging className="h-4 w-4 shrink-0 animate-pulse" />
-        <span className="font-medium text-emerald-200">Charging</span>
-        {parts.map((p, i) => (
-          <span key={i} className="flex items-center gap-2">
+        <span className="font-medium text-emerald-200">{soc}%</span>
+        {range && (
+          <span className="flex items-center gap-2">
             <span className="text-emerald-400/50">·</span>
-            {p}
+            {range}
           </span>
-        ))}
+        )}
       </div>
     )
   }
 
-  // Idle — persistent battery readout so the banner stays put.
+  // Idle — subdued strip. Same content; color + icon tell the story.
   return (
     <div className="mb-4 flex flex-wrap items-center gap-x-2 gap-y-0.5 rounded-xl border border-white/10 bg-slate-800/40 px-4 py-2.5 text-sm text-slate-300 tabular-nums">
       <Battery className="h-4 w-4 shrink-0 text-slate-400" />
       <span className="font-medium text-slate-200">{soc}%</span>
-      {cur.rangeMi != null && (
+      {range && (
         <span className="flex items-center gap-2">
           <span className="text-slate-500">·</span>
-          {Math.round(cur.rangeMi)} mi
+          {range}
         </span>
       )}
-      <span className="text-slate-500">·</span>
-      <span className="text-slate-400">Not charging</span>
     </div>
   )
 }


### PR DESCRIPTION
## What changes

The dashboard banner currently repeats the state in text:

- Charging: "⚡ **Charging** · 74% → 80% · 4 kW · ~3h 45m to full"
- Idle: "🔋 74% · 235 mi · **Not charging**"

The color and icon already convey "charging vs not" (green pulsing \`BatteryCharging\` vs subdued \`Battery\`). The text is redundant. This PR strips both states down to just **battery % · range**, with the distance unit honouring the user's \`DRIVE_MAP_UNIT\` preference.

After:

- Charging (green strip): "⚡ 74% · 235 mi"
- Idle (subdued strip): "🔋 74% · 235 mi"

(\"235 mi\" becomes \"378 km\" when the user has the metric toggle on in Settings → Display & Units.)

## Why drop the kW + time-to-full readouts

The dedicated Charging page already shows the full detail (current, voltage, power chart, minutes-to-full, charge limit). The banner's job is the at-a-glance "where's my battery right now" strip — same in both states, just colored to mark "and is it filling up." Per Chad's call after on-vehicle review.

## Unit handling

Mirrors the existing pattern in \`DriveDetail.tsx\` exactly — fetch \`/api/setup/config\`, read \`DRIVE_MAP_UNIT\`, default to imperial when missing. No new shared hook (yet); when a \`useDistanceUnit\` extraction lands, this consumer will move over with the rest.

## Scope

Frontend-only — \`web/src/components/charging/ChargingBanner.tsx\`. No API change, no schema change.