### PR TITLE
fix(charging): mobile layout — rates popover, TOU editor, status-card chip

### DIFF
--- a/web/src/components/charging/ChargingRatesButton.tsx
+++ b/web/src/components/charging/ChargingRatesButton.tsx
@@ -127,7 +127,7 @@ export function ChargingRatesButton({
         Rates
       </button>
       {open && (
-        <div className="absolute right-0 top-full z-50 mt-2 max-h-[80vh] w-80 overflow-y-auto rounded-xl border border-white/10 bg-slate-900/95 p-3 shadow-2xl backdrop-blur">
+        <div className="absolute right-0 top-full z-50 mt-2 max-h-[80vh] w-80 max-w-[calc(100vw-1.5rem)] overflow-y-auto rounded-xl border border-white/10 bg-slate-900/95 p-3 shadow-2xl backdrop-blur">
           <div className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-400">
             Electricity rates
           </div>
@@ -237,7 +237,7 @@ export function ChargingRatesButton({
                         <X className="h-3.5 w-3.5" />
                       </button>
                     </div>
-                    <div className="mt-1.5 flex items-center gap-1.5">
+                    <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
                       <input
                         type="time"
                         value={p.start}

--- a/web/src/components/dashboard/CarStatusCard.tsx
+++ b/web/src/components/dashboard/CarStatusCard.tsx
@@ -171,7 +171,7 @@ export function CarStatusCard({
         <Link
           to="/community?view=chimes"
           title={`Active lock chime: ${lockChimeName}`}
-          className="absolute right-3 top-3 inline-flex max-w-[180px] items-center gap-1.5 rounded-full border border-emerald-400/25 bg-emerald-500/10 px-2.5 py-1 text-[11px] font-medium text-emerald-300 transition-colors hover:bg-emerald-500/15"
+          className="absolute right-3 top-3 inline-flex max-w-[120px] items-center gap-1.5 rounded-full border border-emerald-400/25 bg-emerald-500/10 px-2.5 py-1 text-[11px] font-medium text-emerald-300 transition-colors hover:bg-emerald-500/15 sm:max-w-[180px]"
         >
           <Music2 className="h-3 w-3 shrink-0" />
           <span className="truncate">{lockChimeName}</span>
@@ -182,7 +182,7 @@ export function CarStatusCard({
       {/* Top row — car state + duration. Right padding reserves room
           for the absolutely-positioned chime chip when present so
           long durations / labels can't slide under it. */}
-      <div className={"flex items-center gap-3 " + (lockChimeName ? "pr-32 sm:pr-40" : "")}>
+      <div className={"flex items-center gap-3 " + (lockChimeName ? "pr-32 sm:pr-48" : "")}>
         <span className="tile-icon halo-accent">
           <Car className="h-4 w-4" />
         </span>


### PR DESCRIPTION
Follow-up to the v3.6.2 summary-strip fix (`order-last w-full`). That handled one spot; these are the remaining **high-severity** mobile-layout issues in the charging UI, all from the cost/TOU additions.

## Fixes
- **Rates popover overflow** — `ChargingRatesButton` opened a fixed `w-80` (320px) popover that could run off a narrow viewport. Capped with `max-w-[calc(100vw-1.5rem)]` so it always fits.
- **TOU editor unusable on phones** — the time-of-use period row packed 4 inputs (start / "to" / end / rate) into a single **non-wrapping** flex row that overflowed offscreen <400px. Added `flex-wrap` so the rate input drops to a second line.
- **Status-card chime chip overlap** — the chime chip is `absolute … max-w-[180px]`, but the row only reserved `pr-32 sm:pr-40` (128/160px) — *less* than the chip's extent — so the "Parked" label/duration could slide under it. Shrunk the chip to `max-w-[120px]` on mobile and bumped the reservation to `sm:pr-48` so chip width and padding line up at every breakpoint.

## Notes
- Left the `ChargeSessionDetail` stat grid at `grid-cols-2` on mobile — 2 columns is right for short numeric stat tiles; single-column would just waste vertical space.
- Pure Tailwind className changes, no logic touched. `vite build` clean (the only `tsc` hit is the pre-existing `vite.config.ts` env mismatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)