### PR TITLE
Add complete system backup and restore

### DIFF
--- a/crates/api/src/backup.rs
+++ b/crates/api/src/backup.rs
@@ -1,14 +1,15 @@
-//! Config backup and restore.
+//! System backup and restore.
 //!
-//! A backup is a JSON envelope containing
-//! the `sentryusb.conf` contents plus the user preferences, SSH keys, rclone
-//! config, Tesla BLE pairing keys, and notification-device credentials — the
-//! stuff the user doesn't want to re-set up after an SD-card reflash. Change
-//! detection via SHA-256 hash avoids filling the backup dir with identical
-//! copies.
+//! A backup is a JSON envelope plus an optional app-data bundle. The JSON
+//! envelope contains `sentryusb.conf`, user preferences, SSH keys, rclone
+//! config, Tesla BLE pairing keys, cloud/push credentials, and other small
+//! setup state. The app-data bundle contains the SQLite application database
+//! plus small mutable/root state that should survive an SD-card reflash. Large
+//! virtual disk images, snapshots, and dashcam/video files are deliberately not
+//! included; those continue to live in the normal archive destination.
 
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use axum::Json;
@@ -20,9 +21,16 @@ use tracing::{info, warn};
 use crate::router::AppState;
 
 const LOCAL_BACKUP_DIR: &str = "/mutable/backups";
+const LOCAL_APP_DATA_BACKUP_DIR: &str = "/backingfiles/backups";
 const ARCHIVE_BACKUP_DIR: &str = "/mnt/archive/backups";
 const LAST_HASH_FILE: &str = "/mutable/backups/.last_hash";
-const BACKUP_VERSION: u32 = 1;
+const BACKUP_VERSION: u32 = 2;
+
+const APP_DATA_EXPORT_DIR: &str = "/backingfiles/.backup-app-data";
+const APP_DATA_EXPORT_GZ: &str = "/backingfiles/.backup-app-data.tar.gz";
+const APP_DATA_RESTORE_DIR: &str = "/backingfiles/.restore-app-data";
+const PENDING_DB_RESTORE: &str = "/backingfiles/drive-data.db.restore-pending";
+const PENDING_DB_RESTORE_MARKER: &str = "/backingfiles/.restore-drive-data-pending";
 
 // Paths included in a backup.
 //
@@ -40,6 +48,40 @@ const RCLONE_CONFIG: &str = "/root/.config/rclone/rclone.conf";
 const BLE_PRIVATE_KEY: &str = "/root/.ble/key_private.pem";
 const BLE_PUBLIC_KEY: &str = "/root/.ble/key_public.pem";
 const NOTIFICATION_CREDS: &str = "/root/.sentryusb/notification-credentials.json";
+
+/// Durable state paths copied into the app-data bundle when present. Keep this
+/// tight: no virtual disk images, snapshots, TeslaCam media, logs, session
+/// cookies, or archive payloads.
+const APP_DATA_FILES: &[&str] = &[
+    "/backingfiles/drive-data.json",
+    "/mutable/.sentryusb_preferences.json",
+    "/mutable/sentryusb-prefs.json",
+    "/mutable/sentryusb-notifications.json",
+    "/mutable/.notification_history.json",
+    "/mutable/LockChime.wav",
+    "/mutable/keep_accessory_gps.json",
+    "/mutable/sentryusb_away_mode.json",
+    "/mutable/.drive-data-last-sync",
+    "/mutable/.beaconed",
+    "/root/sentryusb.conf",
+    "/root/.sentryusb_version",
+];
+
+const APP_DATA_DIRS: &[&str] = &[
+    "/mutable/LockChime",
+    "/mutable/Wraps",
+    "/mutable/.wraps_deleted",
+    "/mutable/LicensePlate",
+    "/mutable/configs",
+    "/mutable/etc",
+    "/mutable/var/lib",
+    "/mutable/varlib",
+    "/mutable/.bluetooth",
+    "/root/.sentryusb",
+    "/root/.ble",
+    "/root/.ssh",
+    "/root/.config/rclone",
+];
 
 /// Read whichever SSH keypair exists on disk. ed25519 wins when both are
 /// present (newer install ran ssh-keygen on top of an old RSA key). Returns
@@ -71,6 +113,10 @@ struct BackupData {
     preferences: HashMap<String, String>,
     #[serde(default)]
     drive_data_included: bool,
+    #[serde(default)]
+    app_data_included: bool,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    app_data_filename: String,
 
     #[serde(default, skip_serializing_if = "String::is_empty")]
     ssh_private_key: String,
@@ -93,10 +139,33 @@ struct BackupEntry {
     location: String,
     size: u64,
     filename: String,
+    app_data_included: bool,
+    app_data_size: u64,
+    app_data_filename: String,
+    total_size: u64,
+}
+
+#[derive(Serialize)]
+struct AppDataManifest {
+    version: u32,
+    date: String,
+    timestamp: String,
+    includes: Vec<String>,
+    missing: Vec<String>,
+}
+
+#[derive(Default)]
+struct AppDataRestoreResult {
+    restored_paths: Vec<String>,
+    db_restore_pending: bool,
 }
 
 fn backup_filename(date: &str) -> String {
     format!("sentryusb-backup-{}.json", date)
+}
+
+fn app_data_filename(date: &str) -> String {
+    format!("sentryusb-backup-{}.app-data.tar.gz", date)
 }
 
 fn read_file_if_exists(path: &str) -> String {
@@ -140,6 +209,8 @@ async fn build_backup_data_async() -> Result<BackupData, String> {
         config,
         preferences: prefs_as_strings(),
         drive_data_included: false,
+        app_data_included: false,
+        app_data_filename: String::new(),
         ssh_private_key,
         ssh_public_key,
         rclone_config: read_file_if_exists(RCLONE_CONFIG),
@@ -170,6 +241,9 @@ fn compute_backup_hash(data: &BackupData) -> String {
     ctx.update(data.ble_private_key.as_bytes());
     ctx.update(data.ble_public_key.as_bytes());
     ctx.update(data.notification_credentials.as_bytes());
+    ctx.update(if data.drive_data_included { b"drive:1" } else { b"drive:0" });
+    ctx.update(if data.app_data_included { b"app:1" } else { b"app:0" });
+    ctx.update(data.app_data_filename.as_bytes());
     hex::encode(ctx.finish().as_ref())
 }
 
@@ -266,6 +340,249 @@ async fn sync_backup_to_rclone(data: &BackupData) -> Result<(), String> {
     res.map(|_| ()).map_err(|e| e.to_string())
 }
 
+fn bundle_rel_path(path: &str) -> PathBuf {
+    Path::new(path.trim_start_matches('/')).to_path_buf()
+}
+
+fn copy_file_atomic(src: &str, dest: &str) -> Result<(), String> {
+    if let Some(parent) = Path::new(dest).parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("create {}: {}", parent.display(), e))?;
+    }
+    let tmp = format!("{}.tmp", dest);
+    std::fs::copy(src, &tmp)
+        .map_err(|e| { let _ = std::fs::remove_file(&tmp); format!("copy {} -> {}: {}", src, dest, e) })?;
+    std::fs::rename(&tmp, dest).map_err(|e| format!("finalize {}: {}", dest, e))
+}
+
+fn copy_path_recursive(src: &Path, dest: &Path) -> Result<(), String> {
+    let meta = match std::fs::symlink_metadata(src) {
+        Ok(m) => m,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(format!("stat {}: {}", src.display(), e)),
+    };
+    if meta.file_type().is_symlink() {
+        // Restore backups should be plain files/dirs. Symlinks are skipped so
+        // a crafted backup cannot write through an unexpected link target.
+        return Ok(());
+    }
+    if meta.is_dir() {
+        std::fs::create_dir_all(dest)
+            .map_err(|e| format!("create {}: {}", dest.display(), e))?;
+        for entry in std::fs::read_dir(src).map_err(|e| format!("read {}: {}", src.display(), e))? {
+            let entry = entry.map_err(|e| e.to_string())?;
+            let name = entry.file_name();
+            copy_path_recursive(&entry.path(), &dest.join(PathBuf::from(name)))?;
+        }
+        return Ok(());
+    }
+    if meta.is_file() {
+        if let Some(parent) = dest.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| format!("create {}: {}", parent.display(), e))?;
+        }
+        std::fs::copy(src, dest)
+            .map(|_| ())
+            .map_err(|e| format!("copy {} -> {}: {}", src.display(), dest.display(), e))?;
+    }
+    Ok(())
+}
+
+fn restore_path_recursive(src: &Path, dest: &Path) -> Result<Vec<String>, String> {
+    if !src.exists() {
+        return Ok(Vec::new());
+    }
+    let meta = std::fs::symlink_metadata(src)
+        .map_err(|e| format!("stat restored path {}: {}", src.display(), e))?;
+    if meta.file_type().is_symlink() {
+        return Err(format!("refusing to restore symlink {}", src.display()));
+    }
+    if meta.is_dir() {
+        let _ = std::fs::remove_dir_all(dest);
+    } else {
+        let _ = std::fs::remove_file(dest);
+    }
+    copy_path_recursive(src, dest)?;
+    Ok(vec![dest.display().to_string()])
+}
+
+fn export_drive_db_to(
+    store: std::sync::Arc<sentryusb_drives::DriveStore>,
+    dest: PathBuf,
+) -> Result<(), String> {
+    if let Some(parent) = dest.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("create {}: {}", parent.display(), e))?;
+    }
+    let _ = std::fs::remove_file(&dest);
+    let dest_s = dest.to_string_lossy().to_string();
+    store.with_locked_conn(|conn| {
+        conn.execute("VACUUM INTO ?1", rusqlite::params![dest_s])
+            .map(|_| ())
+    })
+    .map_err(|e| format!("VACUUM INTO failed: {}", e))
+}
+
+async fn export_app_data_bundle(
+    store: std::sync::Arc<sentryusb_drives::DriveStore>,
+    data: &BackupData,
+) -> Result<String, String> {
+    let _ = std::fs::remove_dir_all(APP_DATA_EXPORT_DIR);
+    let _ = std::fs::remove_file(APP_DATA_EXPORT_GZ);
+    std::fs::create_dir_all(APP_DATA_EXPORT_DIR)
+        .map_err(|e| format!("create app-data staging dir: {}", e))?;
+
+    let mut includes = Vec::new();
+    let mut missing = Vec::new();
+
+    let db_dest = Path::new(APP_DATA_EXPORT_DIR).join("backingfiles/drive-data.db");
+    if Path::new(DRIVE_DB_PATH).exists() {
+        let store_for_db = store.clone();
+        let db_dest_for_task = db_dest.clone();
+        tokio::task::spawn_blocking(move || export_drive_db_to(store_for_db, db_dest_for_task))
+            .await
+            .map_err(|e| format!("drive DB export task failed: {}", e))??;
+        includes.push("backingfiles/drive-data.db".to_string());
+    } else {
+        missing.push(DRIVE_DB_PATH.to_string());
+    }
+
+    for src in APP_DATA_FILES {
+        let src_path = Path::new(src);
+        if src_path.exists() {
+            let rel = bundle_rel_path(src);
+            copy_path_recursive(src_path, &Path::new(APP_DATA_EXPORT_DIR).join(&rel))?;
+            includes.push(rel.display().to_string());
+        } else {
+            missing.push((*src).to_string());
+        }
+    }
+
+    for src in APP_DATA_DIRS {
+        let src_path = Path::new(src);
+        if src_path.exists() {
+            let rel = bundle_rel_path(src);
+            copy_path_recursive(src_path, &Path::new(APP_DATA_EXPORT_DIR).join(&rel))?;
+            includes.push(format!("{}/", rel.display()));
+        } else {
+            missing.push((*src).to_string());
+        }
+    }
+
+    let manifest = AppDataManifest {
+        version: BACKUP_VERSION,
+        date: data.date.clone(),
+        timestamp: data.timestamp.clone(),
+        includes,
+        missing,
+    };
+    let manifest_json = serde_json::to_vec_pretty(&manifest)
+        .map_err(|e| format!("marshal app-data manifest: {}", e))?;
+    std::fs::write(
+        Path::new(APP_DATA_EXPORT_DIR).join("manifest.json"),
+        manifest_json,
+    )
+    .map_err(|e| format!("write app-data manifest: {}", e))?;
+
+    sentryusb_shell::run_with_timeout(
+        Duration::from_secs(300),
+        "tar",
+        &["-C", APP_DATA_EXPORT_DIR, "-czf", APP_DATA_EXPORT_GZ, "."],
+    )
+    .await
+    .map_err(|e| format!("tar app-data bundle failed: {}", e))?;
+    Ok(APP_DATA_EXPORT_GZ.to_string())
+}
+
+async fn ship_app_data(location: &str, gz_path: &str, date: &str) -> Result<(), String> {
+    let filename = app_data_filename(date);
+    let config_path = sentryusb_config::find_config_path();
+    let archive_system = sentryusb_config::parse_file(config_path)
+        .ok()
+        .and_then(|(active, _)| active.get("ARCHIVE_SYSTEM").cloned())
+        .unwrap_or_default();
+
+    match (location, archive_system.as_str()) {
+        ("ssd", _) => {
+            let dest = format!("{}/{}", LOCAL_APP_DATA_BACKUP_DIR, filename);
+            copy_file_atomic(gz_path, &dest)
+        }
+        (_, "cifs" | "nfs") => {
+            if !Path::new("/mnt/archive").exists() {
+                return Err("archive not mounted at /mnt/archive".to_string());
+            }
+            let dest = format!("{}/{}", ARCHIVE_BACKUP_DIR, filename);
+            copy_file_atomic(gz_path, &dest)
+        }
+        (_, "rsync") => {
+            let (active, _) = sentryusb_config::parse_file(config_path).map_err(|e| e.to_string())?;
+            let server = active.get("RSYNC_SERVER").cloned().unwrap_or_default();
+            let user = active.get("RSYNC_USER").cloned().unwrap_or_default();
+            let rsync_path = active.get("RSYNC_PATH").cloned().unwrap_or_default();
+            if server.is_empty() || user.is_empty() {
+                return Err("rsync not configured".to_string());
+            }
+            let user_at_server = format!("{}@{}", user, server);
+            let remote_dir = format!("{}/backups", rsync_path);
+            let _ = sentryusb_shell::run_with_timeout(
+                Duration::from_secs(10),
+                "ssh",
+                &[
+                    "-o", "ConnectTimeout=10", "-o", "StrictHostKeyChecking=no",
+                    "-o", "BatchMode=yes", &user_at_server, "mkdir", "-p", &remote_dir,
+                ],
+            ).await;
+            let dest = format!("{}@{}:{}/backups/{}", user, server, rsync_path, filename);
+            sentryusb_shell::run_with_timeout(
+                Duration::from_secs(600),
+                "rsync",
+                &["-h", "--no-perms", "--omit-dir-times", "--timeout=300", gz_path, &dest],
+            )
+            .await
+            .map(|_| ())
+            .map_err(|e| e.to_string())
+        }
+        (_, "rclone") => {
+            let (active, _) = sentryusb_config::parse_file(config_path).map_err(|e| e.to_string())?;
+            let drive = active.get("RCLONE_DRIVE").cloned().unwrap_or_default();
+            let rclone_path = active.get("RCLONE_PATH").cloned().unwrap_or_default();
+            if drive.is_empty() {
+                return Err("rclone not configured".to_string());
+            }
+            let staged = format!("/backingfiles/{}", filename);
+            std::fs::rename(gz_path, &staged).map_err(|e| format!("stage: {}", e))?;
+            let dest = format!("{}:{}/backups/", drive, rclone_path);
+            let res = sentryusb_shell::run_with_timeout(
+                Duration::from_secs(600),
+                "rclone",
+                &["--config", "/root/.config/rclone/rclone.conf", "copy", &staged, &dest],
+            )
+            .await;
+            let _ = std::fs::rename(&staged, gz_path);
+            res.map(|_| ()).map_err(|e| e.to_string())
+        }
+        _ => {
+            let dest = format!("{}/{}", LOCAL_APP_DATA_BACKUP_DIR, filename);
+            info!("[backup] No archive system configured, writing app-data bundle locally");
+            copy_file_atomic(gz_path, &dest)
+        }
+    }
+}
+
+fn app_data_path_for(dir: &str, date: &str) -> String {
+    format!("{}/{}", dir.trim_end_matches('/'), app_data_filename(date))
+}
+
+fn find_app_data_backup(date: &str) -> Option<String> {
+    for dir in [ARCHIVE_BACKUP_DIR, LOCAL_APP_DATA_BACKUP_DIR] {
+        let path = app_data_path_for(dir, date);
+        if Path::new(&path).exists() {
+            return Some(path);
+        }
+    }
+    None
+}
+
 fn list_backups_in_dir(dir: &str, location: &str) -> Vec<BackupEntry> {
     let entries = match std::fs::read_dir(dir) {
         Ok(e) => e,
@@ -287,142 +604,34 @@ fn list_backups_in_dir(dir: &str, location: &str) -> Vec<BackupEntry> {
             Ok(b) => b,
             Err(_) => continue,
         };
+        let app_data_path = if location == "ssd" {
+            app_data_path_for(LOCAL_APP_DATA_BACKUP_DIR, &bd.date)
+        } else {
+            app_data_path_for(dir, &bd.date)
+        };
+        let app_data_size = std::fs::metadata(&app_data_path).map(|m| m.len()).unwrap_or(0);
+        let app_data_filename = if app_data_size > 0 {
+            app_data_filename(&bd.date)
+        } else {
+            String::new()
+        };
         out.push(BackupEntry {
             date: bd.date,
             timestamp: bd.timestamp,
             location: location.to_string(),
             size,
             filename: name,
+            app_data_included: app_data_size > 0,
+            app_data_size,
+            app_data_filename,
+            total_size: size.saturating_add(app_data_size),
         });
     }
     out
 }
 
-/// Scratch path for the drive-DB snapshot. Lives on /backingfiles (the
-/// big data partition) — /tmp can be RAM-backed and /mutable is small,
-/// and the source DB is on the same filesystem anyway.
-const DB_EXPORT_TMP: &str = "/backingfiles/.backup-drive-data.db";
+/// Main app database path.
 const DRIVE_DB_PATH: &str = "/backingfiles/drive-data.db";
-
-fn drive_data_filename(date: &str) -> String {
-    format!("sentryusb-backup-{}.drive-data.db.gz", date)
-}
-
-/// Snapshot the drive DB (drives, charges, telemetry) into a gzipped
-/// copy ready to ship next to the JSON backup. `VACUUM INTO` takes a
-/// read transaction on the live DB so the copy is consistent even while
-/// the sampler writes; other DB users queue for the few seconds it
-/// takes, which is fine for a manual/nightly backup. Returns the .gz
-/// path.
-async fn export_drive_data_gz(
-    store: std::sync::Arc<sentryusb_drives::DriveStore>,
-) -> Result<String, String> {
-    if !Path::new(DRIVE_DB_PATH).exists() {
-        return Err("drive DB does not exist yet".to_string());
-    }
-    let gz = format!("{}.gz", DB_EXPORT_TMP);
-    // VACUUM INTO refuses to overwrite; clear leftovers from a crashed run.
-    let _ = std::fs::remove_file(DB_EXPORT_TMP);
-    let _ = std::fs::remove_file(&gz);
-
-    let vacuum = tokio::task::spawn_blocking(move || {
-        store.with_locked_conn(|conn| {
-            conn.execute("VACUUM INTO ?1", rusqlite::params![DB_EXPORT_TMP])
-                .map(|_| ())
-        })
-    })
-    .await;
-    match vacuum {
-        Ok(Ok(())) => {}
-        Ok(Err(e)) => return Err(format!("VACUUM INTO failed: {}", e)),
-        Err(e) => return Err(format!("export task failed: {}", e)),
-    }
-
-    sentryusb_shell::run_with_timeout(
-        Duration::from_secs(300),
-        "gzip",
-        &["-f", DB_EXPORT_TMP],
-    )
-    .await
-    .map_err(|e| format!("gzip failed: {}", e))?;
-    Ok(gz)
-}
-
-/// Ship the drive-DB snapshot to the same archive destination the JSON
-/// backup goes to. Deliberately NOT written to the /mutable local copy —
-/// that partition is a few hundred MB and a dated DB snapshot per backup
-/// would fill it. `location == "ssd"` therefore skips with an
-/// explanatory error the caller logs.
-async fn ship_drive_data(location: &str, gz_path: &str, date: &str) -> Result<(), String> {
-    if location == "ssd" {
-        return Err(
-            "backup_location is local SSD — drive DB snapshot is only shipped to archive \
-             destinations (/mutable is too small for dated DB copies)"
-                .to_string(),
-        );
-    }
-    let filename = drive_data_filename(date);
-    let config_path = sentryusb_config::find_config_path();
-    let (active, _) = sentryusb_config::parse_file(config_path).map_err(|e| e.to_string())?;
-    let archive_system = active.get("ARCHIVE_SYSTEM").cloned().unwrap_or_default();
-    match archive_system.as_str() {
-        "cifs" | "nfs" => {
-            if !Path::new("/mnt/archive").exists() {
-                return Err("archive not mounted at /mnt/archive".to_string());
-            }
-            let gz = gz_path.to_string();
-            let dest = format!("{}/{}", ARCHIVE_BACKUP_DIR, filename);
-            // Tens of MB onto a network mount — keep it off the runtime.
-            tokio::task::spawn_blocking(move || {
-                std::fs::create_dir_all(ARCHIVE_BACKUP_DIR)
-                    .map_err(|e| format!("create {}: {}", ARCHIVE_BACKUP_DIR, e))?;
-                let tmp = format!("{}.tmp", dest);
-                std::fs::copy(&gz, &tmp).map_err(|e| format!("copy to archive: {}", e))?;
-                std::fs::rename(&tmp, &dest).map_err(|e| format!("finalize: {}", e))
-            })
-            .await
-            .map_err(|e| format!("copy task failed: {}", e))?
-        }
-        "rsync" => {
-            let server = active.get("RSYNC_SERVER").cloned().unwrap_or_default();
-            let user = active.get("RSYNC_USER").cloned().unwrap_or_default();
-            let rsync_path = active.get("RSYNC_PATH").cloned().unwrap_or_default();
-            if server.is_empty() || user.is_empty() {
-                return Err("rsync not configured".to_string());
-            }
-            let dest = format!("{}@{}:{}/backups/{}", user, server, rsync_path, filename);
-            sentryusb_shell::run_with_timeout(
-                Duration::from_secs(600),
-                "rsync",
-                &["-h", "--no-perms", "--omit-dir-times", "--timeout=300", gz_path, &dest],
-            )
-            .await
-            .map(|_| ())
-            .map_err(|e| e.to_string())
-        }
-        "rclone" => {
-            let drive = active.get("RCLONE_DRIVE").cloned().unwrap_or_default();
-            let rclone_path = active.get("RCLONE_PATH").cloned().unwrap_or_default();
-            if drive.is_empty() {
-                return Err("rclone not configured".to_string());
-            }
-            // rclone preserves the source filename; stage under the dated
-            // name so the remote gets sentryusb-backup-<date>.drive-data.db.gz.
-            let staged = format!("/backingfiles/{}", filename);
-            std::fs::rename(gz_path, &staged).map_err(|e| format!("stage: {}", e))?;
-            let dest = format!("{}:{}/backups/", drive, rclone_path);
-            let res = sentryusb_shell::run_with_timeout(
-                Duration::from_secs(600),
-                "rclone",
-                &["--config", "/root/.config/rclone/rclone.conf", "copy", &staged, &dest],
-            )
-            .await;
-            let _ = std::fs::rename(&staged, gz_path);
-            res.map(|_| ()).map_err(|e| e.to_string())
-        }
-        _ => Err("no archive system configured".to_string()),
-    }
-}
 
 #[derive(Deserialize, Default)]
 pub struct BackupQuery {
@@ -457,26 +666,42 @@ pub async fn create_backup(
         .unwrap_or("archive")
         .to_string();
 
-    // Snapshot + ship the drive DB (drives, charges, telemetry) next to
-    // the JSON backup. Runs even when the config hash is unchanged —
-    // drive data changes every day the car is used, and a stale export
-    // is exactly how users lose drive history on a reflash. Best-effort:
-    // a DB export failure must never block the config backup.
-    let mut drive_data_shipped = false;
-    match export_drive_data_gz(s.drives.store.clone()).await {
-        Ok(gz) => {
-            match ship_drive_data(&location, &gz, &data.date).await {
-                Ok(()) => {
-                    info!("[backup] Drive DB snapshot shipped as {}", drive_data_filename(&data.date));
-                    drive_data_shipped = true;
-                }
-                Err(e) => warn!("[backup] Drive DB snapshot not shipped: {}", e),
-            }
-            let _ = std::fs::remove_file(&gz);
+    // Snapshot + ship the full app-data bundle next to the JSON backup.
+    // This includes the drive/charge/telemetry SQLite DB plus small mutable
+    // app state (notification history, lock chimes, wraps, BLE/cloud creds,
+    // rclone/SSH config). Large disk images and video remain in the normal
+    // archive flow.
+    let app_data_gz = match export_app_data_bundle(s.drives.store.clone(), &data).await {
+        Ok(gz) => gz,
+        Err(e) => {
+            return crate::json_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &format!("App-data backup failed: {}", e),
+            );
         }
-        Err(e) => warn!("[backup] Drive DB export failed: {}", e),
+    };
+    if let Err(e) = ship_app_data(&location, &app_data_gz, &data.date).await {
+        let _ = std::fs::remove_file(&app_data_gz);
+        return crate::json_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            &format!("App-data backup failed: {}", e),
+        );
     }
-    data.drive_data_included = drive_data_shipped;
+    if location != "ssd" {
+        let local_app_data = format!(
+            "{}/{}",
+            LOCAL_APP_DATA_BACKUP_DIR,
+            app_data_filename(&data.date)
+        );
+        if let Err(e) = copy_file_atomic(&app_data_gz, &local_app_data) {
+            warn!("[backup] Warning: failed to write local app-data backup copy: {}", e);
+        }
+    }
+    let _ = std::fs::remove_file(&app_data_gz);
+    let _ = std::fs::remove_dir_all(APP_DATA_EXPORT_DIR);
+    data.drive_data_included = Path::new(DRIVE_DB_PATH).exists();
+    data.app_data_included = true;
+    data.app_data_filename = app_data_filename(&data.date);
 
     let force = q.force.as_deref() == Some("1");
     let current_hash = compute_backup_hash(&data);
@@ -487,7 +712,8 @@ pub async fn create_backup(
             "success": true,
             "skipped": true,
             "reason": "no changes detected",
-            "drive_data_refreshed": drive_data_shipped,
+            "app_data_refreshed": true,
+            "drive_data_refreshed": data.drive_data_included,
             "date": data.date,
         })));
     }
@@ -536,6 +762,8 @@ pub async fn create_backup(
         "success": true,
         "date": data.date,
         "location": location,
+        "app_data_included": data.app_data_included,
+        "app_data_filename": data.app_data_filename,
     })))
 }
 
@@ -562,6 +790,10 @@ pub async fn list_backups(State(_s): State<AppState>) -> (StatusCode, Json<serde
                     location: all[i].location.clone(),
                     size: all[i].size,
                     filename: all[i].filename.clone(),
+                    app_data_included: all[i].app_data_included,
+                    app_data_size: all[i].app_data_size,
+                    app_data_filename: all[i].app_data_filename.clone(),
+                    total_size: all[i].total_size,
                 };
             }
             all[i].date.clear(); // mark for removal
@@ -583,7 +815,7 @@ pub async fn get_backup(
     AxPath(date): AxPath<String>,
 ) -> axum::response::Response {
     use axum::response::IntoResponse;
-    if date.is_empty() || date.contains("..") || date.contains('/') || date.contains('\\') {
+    if !valid_backup_date(&date) {
         return crate::json_error(StatusCode::BAD_REQUEST, "invalid date").into_response();
     }
     let filename = backup_filename(&date);
@@ -601,6 +833,169 @@ pub async fn get_backup(
         }
     }
     crate::json_error(StatusCode::NOT_FOUND, &format!("backup not found for date: {}", date)).into_response()
+}
+
+/// GET /api/system/backup/{date}/app-data
+///
+/// Returns the app-data companion bundle when present. Archive copy wins over
+/// the local `/backingfiles/backups` copy so restore/download prefers offsite
+/// data if both exist.
+pub async fn get_app_data_backup(
+    State(_s): State<AppState>,
+    AxPath(date): AxPath<String>,
+) -> axum::response::Response {
+    use axum::response::IntoResponse;
+    if !valid_backup_date(&date) {
+        return crate::json_error(StatusCode::BAD_REQUEST, "invalid date").into_response();
+    }
+    let filename = app_data_filename(&date);
+    if let Some(path) = find_app_data_backup(&date) {
+        if let Ok(data) = std::fs::read(&path) {
+            let mut r = axum::response::Response::new(axum::body::Body::from(data));
+            r.headers_mut()
+                .insert("content-type", "application/gzip".parse().unwrap());
+            r.headers_mut().insert(
+                "content-disposition",
+                format!("attachment; filename={}", filename).parse().unwrap(),
+            );
+            return r;
+        }
+    }
+    crate::json_error(
+        StatusCode::NOT_FOUND,
+        &format!("app-data backup not found for date: {}", date),
+    ).into_response()
+}
+
+fn valid_backup_date(date: &str) -> bool {
+    !date.is_empty()
+        && !date.contains("..")
+        && !date.contains('/')
+        && !date.contains('\\')
+        && date
+            .chars()
+            .all(|c| c.is_ascii_digit() || c == '-')
+}
+
+fn is_safe_tar_entry(name: &str) -> bool {
+    let clean = name.trim_start_matches("./");
+    if clean.is_empty() {
+        return true;
+    }
+    if clean.starts_with('/') || clean.contains("..") {
+        return false;
+    }
+    clean == "manifest.json"
+        || clean.starts_with("backingfiles/")
+        || clean.starts_with("mutable/")
+        || clean.starts_with("root/")
+}
+
+async fn validate_app_data_tar(path: &str) -> Result<(), String> {
+    let listing = sentryusb_shell::run_with_timeout(
+        Duration::from_secs(30),
+        "tar",
+        &["-tzf", path],
+    )
+    .await
+    .map_err(|e| format!("list app-data bundle: {}", e))?;
+    for line in listing.lines() {
+        if !is_safe_tar_entry(line) {
+            return Err(format!("unsafe path in app-data bundle: {}", line));
+        }
+    }
+    Ok(())
+}
+
+fn check_sqlite_integrity(path: &str) -> Result<(), String> {
+    let conn = rusqlite::Connection::open(path)
+        .map_err(|e| format!("open restored drive DB: {}", e))?;
+    let result: String = conn
+        .query_row("PRAGMA integrity_check", [], |row| row.get(0))
+        .map_err(|e| format!("drive DB integrity_check failed: {}", e))?;
+    if result == "ok" {
+        Ok(())
+    } else {
+        Err(format!("drive DB integrity_check returned {}", result))
+    }
+}
+
+async fn restore_app_data_bundle(path: &str) -> Result<AppDataRestoreResult, String> {
+    validate_app_data_tar(path).await?;
+
+    let _ = std::fs::remove_dir_all(APP_DATA_RESTORE_DIR);
+    std::fs::create_dir_all(APP_DATA_RESTORE_DIR)
+        .map_err(|e| format!("create restore staging dir: {}", e))?;
+    sentryusb_shell::run_with_timeout(
+        Duration::from_secs(300),
+        "tar",
+        &["-xzf", path, "-C", APP_DATA_RESTORE_DIR],
+    )
+    .await
+    .map_err(|e| format!("extract app-data bundle: {}", e))?;
+
+    let mut result = AppDataRestoreResult::default();
+    let staging = Path::new(APP_DATA_RESTORE_DIR);
+
+    // Restore small files/directories immediately. The live SQLite DB is
+    // handled separately below because the daemon already has it open.
+    for src in APP_DATA_FILES {
+        if *src == "/backingfiles/drive-data.json" {
+            let staged = staging.join(bundle_rel_path(src));
+            result.restored_paths.extend(restore_path_recursive(&staged, Path::new(src))?);
+            continue;
+        }
+        let staged = staging.join(bundle_rel_path(src));
+        result.restored_paths.extend(restore_path_recursive(&staged, Path::new(src))?);
+    }
+    for src in APP_DATA_DIRS {
+        let staged = staging.join(bundle_rel_path(src));
+        result.restored_paths.extend(restore_path_recursive(&staged, Path::new(src))?);
+    }
+
+    let staged_db = staging.join("backingfiles/drive-data.db");
+    if staged_db.exists() {
+        let staged_db_s = staged_db.to_string_lossy().to_string();
+        tokio::task::spawn_blocking(move || check_sqlite_integrity(&staged_db_s))
+            .await
+            .map_err(|e| format!("drive DB integrity task failed: {}", e))??;
+        let staged_db_s = staged_db.to_string_lossy().to_string();
+        copy_file_atomic(&staged_db_s, PENDING_DB_RESTORE)?;
+        std::fs::write(
+            PENDING_DB_RESTORE_MARKER,
+            format!("{}\n", chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true)),
+        )
+        .map_err(|e| format!("write pending DB restore marker: {}", e))?;
+        result.db_restore_pending = true;
+    }
+
+    let _ = std::fs::remove_dir_all(APP_DATA_RESTORE_DIR);
+    Ok(result)
+}
+
+/// Apply a pending app-data DB restore before the daemon opens SQLite.
+/// Called at startup from `sentryusb` main.
+pub fn apply_pending_app_data_restore_at_startup() {
+    if !Path::new(PENDING_DB_RESTORE).exists() {
+        return;
+    }
+    let stamp = chrono::Utc::now().format("%Y%m%d%H%M%S").to_string();
+    for suffix in ["", "-wal", "-shm"] {
+        let current = format!("{}{}", DRIVE_DB_PATH, suffix);
+        if Path::new(&current).exists() {
+            let backup = format!("{}.pre-restore-{}{}", DRIVE_DB_PATH, stamp, suffix);
+            if let Err(e) = std::fs::rename(&current, &backup) {
+                warn!("[backup] pending DB restore: failed to move {} to {}: {}", current, backup, e);
+                return;
+            }
+        }
+    }
+    if let Err(e) = std::fs::rename(PENDING_DB_RESTORE, DRIVE_DB_PATH) {
+        warn!("[backup] pending DB restore: failed to install restored DB: {}", e);
+        return;
+    }
+    let _ = std::fs::remove_file(PENDING_DB_RESTORE_MARKER);
+    info!("[backup] Applied pending drive-data DB restore at startup");
 }
 
 fn save_prefs_from_strings(src: &HashMap<String, String>) {
@@ -646,6 +1041,27 @@ pub async fn restore_backup(
             "Invalid backup: missing version or config data",
         );
     }
+    let app_data_path = if backup.app_data_included {
+        match find_app_data_backup(&backup.date) {
+            Some(p) => {
+                if let Err(e) = validate_app_data_tar(&p).await {
+                    return crate::json_error(
+                        StatusCode::BAD_REQUEST,
+                        &format!("Invalid app-data backup: {}", e),
+                    );
+                }
+                Some(p)
+            }
+            None => {
+                return crate::json_error(
+                    StatusCode::NOT_FOUND,
+                    &format!("App-data backup not found for date: {}", backup.date),
+                );
+            }
+        }
+    } else {
+        None
+    };
 
     // Remount filesystem read-write for the config write.
     let _ = sentryusb_shell::run("bash", &["-c", "/root/bin/remountfs_rw"]).await;
@@ -737,9 +1153,32 @@ pub async fn restore_backup(
         }
     }
 
+    let app_data_restore = if let Some(path) = app_data_path {
+        match restore_app_data_bundle(&path).await {
+            Ok(r) => Some(r),
+            Err(e) => {
+                return crate::json_error(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    &format!("Failed to restore app data: {}", e),
+                );
+            }
+        }
+    } else {
+        None
+    };
+
     // Reparse the restored config so the wizard can re-populate fields.
     let active: HashMap<String, String> = sentryusb_config::parse_file(config_path)
         .map(|(a, _)| a.into_iter().collect())
+        .unwrap_or_default();
+
+    let app_data_restored = app_data_restore.is_some();
+    let db_restore_pending = app_data_restore
+        .as_ref()
+        .map(|r| r.db_restore_pending)
+        .unwrap_or(false);
+    let restored_paths = app_data_restore
+        .map(|r| r.restored_paths)
         .unwrap_or_default();
 
     (StatusCode::OK, Json(serde_json::json!({
@@ -747,5 +1186,9 @@ pub async fn restore_backup(
         "date": backup.date,
         "hostname": backup.hostname,
         "config": active,
+        "app_data_restored": app_data_restored,
+        "db_restore_pending": db_restore_pending,
+        "restart_required": db_restore_pending,
+        "restored_paths": restored_paths,
     })))
 }

--- a/crates/api/src/router.rs
+++ b/crates/api/src/router.rs
@@ -167,6 +167,7 @@ pub fn build_router(state: AppState) -> Router {
         .route("/api/system/backup", post(crate::backup::create_backup))
         .route("/api/system/backups", get(crate::backup::list_backups))
         .route("/api/system/backup/{date}", get(crate::backup::get_backup))
+        .route("/api/system/backup/{date}/app-data", get(crate::backup::get_app_data_backup))
         .route("/api/system/restore", post(crate::backup::restore_backup))
         // Drives
         .route("/api/drives", get(crate::drives_handler::list_drives))

--- a/crates/sentryusb/src/main.rs
+++ b/crates/sentryusb/src/main.rs
@@ -172,6 +172,12 @@ async fn main() {
     // WebSocket hub
     let hub = sentryusb_ws::Hub::new();
 
+    // If a restore queued a replacement app-data DB, install it before
+    // opening SQLite. The running daemon cannot safely replace its own open
+    // DB handle during the restore request, so restore stages the DB and this
+    // startup hook completes the swap.
+    sentryusb_api::backup::apply_pending_app_data_restore_at_startup();
+
     // Drive store (SQLite)
     let db_path = sentryusb_drives::DEFAULT_DB_PATH;
     let store = match sentryusb_drives::DriveStore::open(db_path) {

--- a/web/src/components/settings/sections/ConfigBackupSection.tsx
+++ b/web/src/components/settings/sections/ConfigBackupSection.tsx
@@ -18,6 +18,10 @@ interface BackupEntry {
   location: string
   size: number
   filename: string
+  app_data_included?: boolean
+  app_data_size?: number
+  app_data_filename?: string
+  total_size?: number
 }
 
 const INLINE_CAP = 5
@@ -37,6 +41,8 @@ export function ConfigBackupSection() {
   const [restoreResult, setRestoreResult] = useState<{
     date: string
     hostname: string
+    appDataRestored: boolean
+    restartRequired: boolean
   } | null>(null)
 
   useEffect(() => {
@@ -98,6 +104,7 @@ export function ConfigBackupSection() {
       const backupRes = await fetch(`/api/system/backup/${selectedBackup.date}`)
       if (!backupRes.ok) throw new Error("Failed to fetch backup")
       const backupData = await backupRes.json()
+      backupData.app_data_included = Boolean(selectedBackup.app_data_included)
 
       const restoreRes = await fetch("/api/system/restore", {
         method: "POST",
@@ -106,7 +113,12 @@ export function ConfigBackupSection() {
       })
       if (!restoreRes.ok) throw new Error("Restore failed")
       const result = await restoreRes.json()
-      setRestoreResult({ date: result.date, hostname: result.hostname })
+      setRestoreResult({
+        date: result.date,
+        hostname: result.hostname,
+        appDataRestored: Boolean(result.app_data_restored),
+        restartRequired: Boolean(result.restart_required),
+      })
       setRestoreState("success")
     } catch {
       setRestoreState("error")
@@ -124,7 +136,7 @@ export function ConfigBackupSection() {
     <PrefCard
       icon={<Save className="h-3.5 w-3.5" />}
       halo="blue"
-      title="Config Backup"
+      title="System Backup"
     >
       {/* Location + backup trigger */}
       <div className="flex flex-wrap items-center gap-2">
@@ -190,11 +202,16 @@ export function ConfigBackupSection() {
           <div className="flex items-start gap-3">
             <CheckCircle className="mt-0.5 h-5 w-5 shrink-0 text-emerald-400" />
             <div>
-              <p className="text-sm font-medium text-emerald-300">Config Restored</p>
+              <p className="text-sm font-medium text-emerald-300">System Restored</p>
               <p className="mt-1 text-xs text-slate-400">
                 Backup from {restoreResult.date} has been restored
-                {restoreResult.hostname ? ` (${restoreResult.hostname})` : ""}. Run setup to
-                apply the restored configuration.
+                {restoreResult.hostname ? ` (${restoreResult.hostname})` : ""}.
+                {restoreResult.appDataRestored
+                  ? " App data was restored."
+                  : " Configuration was restored."}
+                {restoreResult.restartRequired
+                  ? " Reboot to load the restored drive, charge, and telemetry database."
+                  : " Run setup to apply the restored configuration."}
               </p>
               <button
                 onClick={() => {
@@ -227,8 +244,14 @@ export function ConfigBackupSection() {
                     year: "numeric",
                   })}
                 </span>
-                . SSH keys, BLE pairing, and notification credentials will also be restored. You
-                will need to run setup afterward to apply changes.
+                . Configuration, SSH keys, BLE pairing, notification credentials
+                {selectedBackup.app_data_included
+                  ? ", drive history, charge sessions, telemetry, lock chimes, wraps, network/Bluetooth state, and app state"
+                  : ", and stored credentials"}
+                {" "}will be restored.
+                {selectedBackup.app_data_included
+                  ? " A reboot is required before restored drive data is active."
+                  : " You will need to run setup afterward to apply changes."}
               </p>
               <div className="mt-3 flex gap-2">
                 <button
@@ -244,7 +267,7 @@ export function ConfigBackupSection() {
                   onClick={handleRestore}
                   className="rounded-lg bg-amber-500/20 px-3 py-1.5 text-xs font-medium text-amber-300 transition-colors hover:bg-amber-500/30"
                 >
-                  Restore Config
+                  Restore Backup
                 </button>
               </div>
             </div>
@@ -296,7 +319,9 @@ export function ConfigBackupSection() {
                   {" · "}
                   {b.location === "archive" ? "Archive server" : "Local SSD"}
                   {" · "}
-                  {(b.size / 1024).toFixed(1)} KB
+                  {((b.total_size ?? b.size) / 1024).toFixed(1)} KB
+                  {" · "}
+                  {b.app_data_included ? "App data" : "Config only"}
                 </p>
               </div>
               {restoreState === "restoring" && selectedBackup?.date === b.date ? (

--- a/web/src/components/setup/steps/ArchiveStep.tsx
+++ b/web/src/components/setup/steps/ArchiveStep.tsx
@@ -279,16 +279,16 @@ export function ArchiveStep({ data, onChange }: StepProps) {
         </div>
       )}
 
-      {/* Config backup location */}
+      {/* System backup location */}
       <div className="space-y-2 rounded-lg border border-white/5 bg-white/[0.02] p-4">
         <div className="flex items-center gap-2">
           <Save className="h-4 w-4 text-blue-400" />
           <p className="text-xs font-medium uppercase tracking-wider text-slate-500">
-            Config Backup Location
+            System Backup Location
           </p>
         </div>
         <p className="text-xs text-slate-500">
-          Your configuration is automatically backed up after each archive.
+          Your configuration and app data are automatically backed up after each archive.
           Choose where to store backups for easy recovery if the SD card fails.
         </p>
         <div className="grid grid-cols-2 gap-2">

--- a/web/src/components/setup/steps/WelcomeStep.tsx
+++ b/web/src/components/setup/steps/WelcomeStep.tsx
@@ -185,6 +185,10 @@ interface BackupEntry {
   location: string
   size: number
   filename: string
+  app_data_included?: boolean
+  app_data_size?: number
+  app_data_filename?: string
+  total_size?: number
 }
 
 export function WelcomeStep({ data: _data, onChange: _onChange, onBatchChange }: StepProps) {
@@ -281,6 +285,7 @@ export function WelcomeStep({ data: _data, onChange: _onChange, onBatchChange }:
       const backupRes = await fetch(`/api/system/backup/${backup.date}`)
       if (!backupRes.ok) throw new Error("Failed to fetch backup")
       const backupData = await backupRes.json()
+      backupData.app_data_included = Boolean(backup.app_data_included)
 
       // Send to restore endpoint
       const restoreRes = await fetch("/api/system/restore", {
@@ -321,7 +326,9 @@ export function WelcomeStep({ data: _data, onChange: _onChange, onBatchChange }:
   // yet (its credentials live inside the backup), so /api/system/backups
   // returns an empty list and the user has no way to pick a backup. POST
   // the file straight to /api/system/restore — the backend writes config,
-  // SSH keys, rclone config, BLE keys, and notification creds back.
+  // SSH keys, rclone config, BLE keys, and notification creds back. Uploaded
+  // JSON restores are config-only because the companion app-data tarball is
+  // not uploaded by this control.
   async function handleBackupFileUpload(file: File) {
     if (!file.name.endsWith(".json")) {
       setUploadError("Please select a .json backup file")
@@ -344,11 +351,12 @@ export function WelcomeStep({ data: _data, onChange: _onChange, onBatchChange }:
         setUploadError("Invalid backup file — missing version or config data")
         return
       }
+      backupData.app_data_included = false
 
       const restoreRes = await fetch("/api/system/restore", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: text,
+        body: JSON.stringify(backupData),
       })
       if (!restoreRes.ok) throw new Error("Restore failed")
       const result = await restoreRes.json()
@@ -535,7 +543,9 @@ export function WelcomeStep({ data: _data, onChange: _onChange, onBatchChange }:
                               {" · "}
                               {b.location === "archive" ? "Archive server" : "Local SSD"}
                               {" · "}
-                              {(b.size / 1024).toFixed(1)} KB
+                              {((b.total_size ?? b.size) / 1024).toFixed(1)} KB
+                              {" · "}
+                              {b.app_data_included ? "App data" : "Config only"}
                             </p>
                           </div>
                           {restoringDate === b.date ? (

--- a/web/src/pages/settings/SystemTab.tsx
+++ b/web/src/pages/settings/SystemTab.tsx
@@ -26,7 +26,7 @@ interface Props {
  * Settings → System. Consolidates what used to be three sparse, low-traffic
  * tabs — Backups, About, and Privacy — into one admin/maintenance surface:
  *
- *   - Config Backup / Export / Raw Config   (was: Backups tab)
+ *   - System Backup / Export / Raw Config   (was: Backups tab)
  *   - Setup Wizard + Resources              (was: About tab)
  *   - Analytics opt-in + disclosure         (was: Privacy tab)
  */


### PR DESCRIPTION
## Summary

- expand system backups from config-only/drive-only snapshots into a JSON envelope plus a companion app-data bundle
- include the SQLite app DB, drive/charge/telemetry data, mutable app state, wraps/chimes/license plate assets, cloud/push credentials, BLE/rclone/SSH state, and small persistent system state used for recovery
- add restore support that stages the live SQLite DB and swaps it at daemon startup, while restoring other small app-data paths immediately
- surface app-data presence and total backup size in Settings and the setup wizard restore flow

Large virtual disk images, snapshots, TeslaCam video, logs, archive payloads, and web session cookies are intentionally excluded.

## Validation

- `git diff --check`

Could not run `cargo fmt --check`, `cargo check`, or `npm run build` in this environment because `cargo`, `rustfmt`, and `npm` are not installed, and `web/node_modules` is absent.
