### PR TITLE
Correlate BLE responses to requests to stop mid-archive aead errors

### DIFF
--- a/crates/tesla_ble/src/body_controller.rs
+++ b/crates/tesla_ble/src/body_controller.rs
@@ -13,7 +13,7 @@ use tracing::{debug, info};
 
 use crate::gatt::Connection;
 use crate::proto::universal_message::{
-    Destination, RoutableMessage, destination, routable_message,
+    Destination, Domain, RoutableMessage, destination, routable_message,
 };
 use crate::proto::vcsec::{
     FromVcsecMessage, InformationRequest, InformationRequestType, UnsignedMessage,
@@ -25,13 +25,17 @@ use crate::proto::vcsec::{
 pub async fn query(conn: &mut Connection) -> Result<VehicleStatus> {
     let payload = build_request();
     info!("body-controller-state: TX {} bytes", payload.len());
-    // Validator: must decode as a RoutableMessage. Same rationale
-    // as the manager.rs signed-query path — discards desynced
-    // frames at the transport layer so the response parser only
-    // sees frames that survived a proto-level smoke test.
+    // Correlate the response to our request: it must originate from the
+    // VEHICLE_SECURITY domain we addressed (and echo our request_uuid if
+    // present). Without this, a late Infotainment straggler on the
+    // shared session could be parsed as a VCSEC reply. See
+    // `crate::correlate`.
+    let our_uuid = RoutableMessage::decode(payload.as_slice())
+        .map(|m| m.uuid)
+        .unwrap_or_default();
     let response_bytes = conn
         .round_trip(&payload, Duration::from_secs(10), |b| {
-            RoutableMessage::decode(b).is_ok()
+            crate::correlate::is_response_to(b, &our_uuid, Domain::VehicleSecurity)
         })
         .await
         .context("BLE round-trip")?;

--- a/crates/tesla_ble/src/correlate.rs
+++ b/crates/tesla_ble/src/correlate.rs
@@ -1,0 +1,142 @@
+//! Response/request correlation for the shared persistent BLE session.
+//!
+//! All command, query, and keep-awake traffic to a parked car rides ONE
+//! long-lived GATT connection, and a dozing car answers slowly. A query
+//! that times out can have its real response arrive late and land in the
+//! RX path of the *next* operation. `gatt::Connection::round_trip`'s
+//! frame validator historically only checked that bytes decode as a
+//! `RoutableMessage`, so such a straggler was accepted as "the
+//! response" — producing a misleading `aead::Error` (a stale *signed*
+//! reply decrypted with the new request's REQUEST_HASH) or a
+//! "no sub_sig_data" error (an unsigned VCSEC reply — e.g. a
+//! body-controller `VehicleStatus` — consumed by the signed path).
+//!
+//! `is_response_to` supplies the missing correlation, using two signals
+//! the car already provides: it echoes our request `uuid` (field 51)
+//! into the response `request_uuid` (field 50), and a response carries
+//! `from_destination` = the domain that produced it.
+
+use prost::Message;
+
+use crate::proto::universal_message::{Domain, RoutableMessage, destination};
+
+/// Returns `true` if `frame` is plausibly the response to a request we
+/// sent to `target_domain` carrying request id `our_uuid`.
+///
+/// Correlation is deliberately *conservative*: it rejects a frame only
+/// when the frame carries positive evidence of belonging to a different
+/// request —
+///   * a `from_destination` domain that differs from the one we
+///     addressed (kills cross-domain VCSEC <-> Infotainment straggler
+///     pickup — the "no sub_sig_data" failure), or
+///   * a non-empty `request_uuid` that differs from ours (kills
+///     same-domain stale-response pickup — the `aead::Error` failure).
+///
+/// Frames that omit both signals (some SessionInfo refreshes, unsigned
+/// replies that don't echo a uuid) are *not* rejected here; they fall
+/// through to the caller's own shape check, preserving the existing
+/// refresh/recovery paths. This guarantees the change can only *remove*
+/// false acceptances — it never rejects a reply the old validator would
+/// have accepted on a quiet link.
+pub fn is_response_to(frame: &[u8], our_uuid: &[u8], target_domain: Domain) -> bool {
+    let Ok(rm) = RoutableMessage::decode(frame) else {
+        return false;
+    };
+
+    // Cross-domain guard. A *response* stamps `from_destination` with
+    // the domain that produced it (a *request* stamps it with the
+    // sender's routing address). So whenever `from_destination` names a
+    // domain, it must be the domain we queried.
+    if let Some(from_domain) = rm
+        .from_destination
+        .as_ref()
+        .and_then(|d| d.sub_destination.as_ref())
+        .and_then(|sd| match sd {
+            destination::SubDestination::Domain(d) => Some(*d),
+            _ => None,
+        })
+    {
+        if from_domain != target_domain as i32 {
+            return false;
+        }
+    }
+
+    // request_uuid correlation. The car echoes our request `uuid` here.
+    // Reject only on a *present* mismatch — an absent request_uuid
+    // cannot be correlated and is left to the caller's shape check.
+    if !rm.request_uuid.is_empty() && rm.request_uuid.as_slice() != our_uuid {
+        return false;
+    }
+
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::proto::universal_message::Destination;
+
+    fn response(from_domain: Domain, request_uuid: &[u8]) -> Vec<u8> {
+        RoutableMessage {
+            from_destination: Some(Destination {
+                sub_destination: Some(destination::SubDestination::Domain(
+                    from_domain as i32,
+                )),
+            }),
+            request_uuid: request_uuid.to_vec(),
+            ..Default::default()
+        }
+        .encode_to_vec()
+    }
+
+    /// A reply from the queried domain echoing our uuid is accepted.
+    #[test]
+    fn accepts_matching_domain_and_uuid() {
+        let uuid = [0xaa; 16];
+        let frame = response(Domain::Infotainment, &uuid);
+        assert!(is_response_to(&frame, &uuid, Domain::Infotainment));
+    }
+
+    /// A reply whose request_uuid is a *different* request's id (a stale
+    /// same-domain straggler) is rejected — this is the `aead::Error`
+    /// case.
+    #[test]
+    fn rejects_mismatched_request_uuid() {
+        let frame = response(Domain::Infotainment, &[0x11; 16]);
+        assert!(!is_response_to(&frame, &[0x22; 16], Domain::Infotainment));
+    }
+
+    /// A reply from a *different domain* is rejected even with no uuid —
+    /// this is the cross-talk that produced "no sub_sig_data".
+    #[test]
+    fn rejects_cross_domain_reply() {
+        // A VCSEC reply must not satisfy an Infotainment query.
+        let frame = response(Domain::VehicleSecurity, &[]);
+        assert!(!is_response_to(&frame, &[0x22; 16], Domain::Infotainment));
+    }
+
+    /// The exact bytes captured on the wire when the bug fired: a real
+    /// body-controller `VehicleStatus` reply (from VEHICLE_SECURITY, no
+    /// request_uuid). It must be REJECTED for an Infotainment query (the
+    /// source of the "no sub_sig_data" log line) yet ACCEPTED for the
+    /// VEHICLE_SECURITY query it actually answers.
+    #[test]
+    fn captured_vcsec_reply_is_domain_separated() {
+        let frame = hex::decode(
+            "32121210696efe0b9d93a8284f908951281d56413a020802520c0a0a10011801200142020802",
+        )
+        .unwrap();
+        // Wrong path (signed Infotainment query) -> reject.
+        assert!(!is_response_to(&frame, &[0x22; 16], Domain::Infotainment));
+        // Right path (body-controller VCSEC query) -> accept.
+        assert!(is_response_to(&frame, &[0x22; 16], Domain::VehicleSecurity));
+    }
+
+    /// A reply that omits both signals still passes (left to the caller's
+    /// shape validator) — guarantees no regression on the refresh path.
+    #[test]
+    fn passes_reply_with_no_correlation_fields() {
+        let frame = RoutableMessage::default().encode_to_vec();
+        assert!(is_response_to(&frame, &[0x22; 16], Domain::Infotainment));
+    }
+}

--- a/crates/tesla_ble/src/lib.rs
+++ b/crates/tesla_ble/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod actions;
 pub mod auth;
 pub mod body_controller;
+pub mod correlate;
 pub mod crypto;
 pub mod gatt;
 pub mod keys;

--- a/crates/tesla_ble/src/manager.rs
+++ b/crates/tesla_ble/src/manager.rs
@@ -797,13 +797,21 @@ async fn try_signed_request_once(
         inner.len(),
         counter
     );
-    // round_trip validator: require the frame to decode as a
-    // RoutableMessage. Discards mid-frame garbage from late
-    // notifications (seen on bluez 5.82 post-reconnect) at the
-    // transport layer.
+    // Correlate the response to THIS request before accepting it. The
+    // car echoes our request `uuid` into the response `request_uuid`,
+    // and a real reply originates from the domain we addressed. The old
+    // shape-only validator accepted ANY decodable RoutableMessage, so a
+    // late straggler from a prior or cross-domain query on the shared
+    // persistent session was taken as our response — the root cause of
+    // the spurious `aead::Error` (a stale *signed* reply decrypted with
+    // this request's REQUEST_HASH) and "no sub_sig_data" (a VCSEC
+    // body-controller reply) failures. See `crate::correlate`.
+    let our_uuid = RoutableMessage::decode(envelope.as_slice())
+        .map(|m| m.uuid)
+        .unwrap_or_default();
     let resp_bytes = conn
         .round_trip(&envelope, QUERY_TIMEOUT, |b| {
-            RoutableMessage::decode(b).is_ok()
+            crate::correlate::is_response_to(b, &our_uuid, domain)
         })
         .await?;
 

--- a/crates/tesla_ble/src/session.rs
+++ b/crates/tesla_ble/src/session.rs
@@ -72,13 +72,15 @@ pub async fn request_session_info(
         payload.len(),
         domain,
     );
-    // Validator: must decode as a RoutableMessage. Same rationale
-    // as the other round_trip callers; the session-info handshake
-    // runs right after a fresh connect when stale notifications
-    // are most likely to be in the BLE pipeline.
+    // Correlate the response to our request (echoed request_uuid +
+    // originating domain) so a stale straggler on the shared session
+    // can't be mistaken for the handshake reply. See `crate::correlate`.
+    let our_uuid = RoutableMessage::decode(payload.as_slice())
+        .map(|m| m.uuid)
+        .unwrap_or_default();
     let response = conn
         .round_trip(&payload, Duration::from_secs(10), |b| {
-            RoutableMessage::decode(b).is_ok()
+            crate::correlate::is_response_to(b, &our_uuid, domain)
         })
         .await
         .context("session-info round-trip")?;


### PR DESCRIPTION
All command/query/keep-awake traffic shares one persistent GATT connection. round_trip's frame validator only checked that bytes decode as a RoutableMessage, with no correlation to the request that was sent. When a dozing car answers slowly, a timed-out query's late reply lands on the next operation's round_trip and is accepted as the wrong query's response -- producing `aead::Error` (a stale signed reply decrypted with the new request's REQUEST_HASH) or "no sub_sig_data" (an unsigned VCSEC reply consumed by the signed path). The false success drops the session and lets the car sleep mid-archive.

Add `correlate::is_response_to(frame, our_uuid, target_domain)`, wired into all three round_trip callers (signed query, session handshake, body-controller query). It rejects a frame whose from_destination domain != the queried domain, or whose non-empty request_uuid != ours, and keeps listening for the real reply. Conservative: frames lacking both signals fall through to the caller's shape check, so it can only remove false acceptances, never reject a reply the old validator accepted.

Includes regression tests pinning the captured cross-talk bytes.

## What does this PR do?

<!-- Describe the change and why it's needed. Link any related issue. -->

## Checklist

- [ ] I ran `cargo fmt --all` and `cargo clippy`
- [ ] I have read and agree to the [Contributor License Agreement](../blob/main/CLA.md) (the CLA Assistant bot will prompt me to sign)
- [ ] If this PR touches MIT-derived scripts listed in [NOTICE](../blob/main/NOTICE), I noted it above so the license boundary is preserved

<!--
Note: this project is source-available under the PolyForm Noncommercial
License 1.0.0. By contributing you agree your contribution may be licensed
under that license and, per the CLA, relicensed commercially by the Maintainers.
-->
