### PR TITLE
feat(install): Rock Pi 4C+ support — installer + binary patches

### DIFF
--- a/crates/setup/src/env.rs
+++ b/crates/setup/src/env.rs
@@ -14,6 +14,7 @@ pub enum PiModel {
     PiZero2,
     PiZeroW,
     Pi2,
+    Rock4CPlus,
     Other,
 }
 
@@ -41,6 +42,12 @@ impl PiModel {
             PiModel::PiZeroW
         } else if lower.contains("raspberry pi 2") {
             PiModel::Pi2
+        } else if lower.contains("rock 4c+")
+            || lower.contains("rock-4c-plus")
+            || lower.contains("rock pi 4c+")
+            || dt_compatible_contains("rock-4c-plus")
+        {
+            PiModel::Rock4CPlus
         } else {
             PiModel::Other
         }
@@ -65,9 +72,20 @@ impl PiModel {
             PiModel::PiZero2 => "Raspberry Pi Zero 2 W",
             PiModel::PiZeroW => "Raspberry Pi Zero W",
             PiModel::Pi2 => "Raspberry Pi 2",
+            PiModel::Rock4CPlus => "Radxa ROCK 4C+",
             PiModel::Other => "Unknown board",
         }
     }
+}
+
+/// True if the device-tree `compatible` string contains `needle`. The model
+/// string alone can vary across vendor DTBs (e.g. "Radxa ROCK 4C+" vs
+/// "RADXA ROCK 4C Plus"), so `compatible` (e.g. `radxa,rock-4c-plus`) is the
+/// reliable fallback for board detection.
+fn dt_compatible_contains(needle: &str) -> bool {
+    fs::read_to_string("/sys/firmware/devicetree/base/compatible")
+        .map(|s| s.replace('\0', " ").to_lowercase().contains(needle))
+        .unwrap_or(false)
 }
 
 /// Detected environment paths and configuration.

--- a/crates/setup/src/runner.rs
+++ b/crates/setup/src/runner.rs
@@ -462,6 +462,96 @@ async fn configure_dwc2_overlay(env: &SetupEnv, emitter: &SetupEmitter) -> Resul
 }
 
 /// Check whether the root partition needs shrinking (Pi Imager auto-expand case).
+/// Shrink the partition-table entry of the (already filesystem-shrunk) root
+/// partition down to match its filesystem, freeing the tail of the disk for
+/// setup's backingfiles/mutable partitions. Only call this once the root
+/// filesystem itself has been shrunk (by resize2fs in initramfs).
+async fn shrink_root_partition_table(
+    root_dev: &str,
+    boot_disk: &str,
+    root_part_num: &str,
+    emitter: &SetupEmitter,
+) {
+    emitter.progress("Shrinking root partition table entry to match filesystem...");
+    let sector_size = sentryusb_shell::run(
+        "bash", &["-c", &format!(
+            "cat /sys/block/$(lsblk -no pkname '{}')/queue/hw_sector_size", root_dev
+        )],
+    ).await.unwrap_or_else(|_| "512".to_string()).trim().parse::<u64>().unwrap_or(512);
+
+    let tune2fs_out = sentryusb_shell::run(
+        "bash", &["-c", &format!(
+            "tune2fs -l '{}' | grep 'Block count:\\|Block size:' | awk '{{print $2}}' FS=: | tr -d ' '",
+            root_dev
+        )],
+    ).await.unwrap_or_default();
+    let parts: Vec<&str> = tune2fs_out.trim().lines().collect();
+    if parts.len() == 2 {
+        let block_count: u64 = parts[0].trim().parse().unwrap_or(0);
+        let block_size: u64 = parts[1].trim().parse().unwrap_or(4096);
+        let fs_sectors = block_count * block_size / sector_size;
+
+        let start_sector = sentryusb_shell::run(
+            "bash", &["-c", &format!("partx --show -g -o START '{}'", root_dev)],
+        ).await.unwrap_or_default().trim().to_string();
+
+        emitter.progress(&format!("Resizing partition to {} sectors", fs_sectors));
+        let _ = sentryusb_shell::run_with_timeout(
+            Duration::from_secs(30),
+            "bash", &["-c", &format!(
+                "echo '{},{}' | sfdisk --force --no-reread '{}' -N {}",
+                start_sector, fs_sectors, boot_disk, root_part_num
+            )],
+        ).await;
+    }
+
+    if Path::new("/sentryusb/config.txt").exists() {
+        let config = std::fs::read_to_string("/sentryusb/config.txt").unwrap_or_default();
+        if config.contains("SENTRYUSB-REMOVE") {
+            let cleaned: String = config.lines()
+                .filter(|l| !l.contains("SENTRYUSB-REMOVE"))
+                .collect::<Vec<_>>().join("\n");
+            let _ = std::fs::write("/sentryusb/config.txt", cleaned + "\n");
+            let initrd = format!("initrd.img-{}", std::env::consts::ARCH);
+            let _ = std::fs::remove_file(format!("/boot/{}", initrd));
+        } else {
+            let _ = sentryusb_shell::run("update-initramfs", &["-u"]).await;
+        }
+    }
+}
+
+/// Root filesystem size in the disk's hardware sectors (block_count *
+/// block_size / hw_sector_size), or None if it can't be read.
+async fn root_fs_sectors(root_dev: &str) -> Option<u64> {
+    let sector_size = sentryusb_shell::run(
+        "bash", &["-c", &format!(
+            "cat /sys/block/$(lsblk -no pkname '{}')/queue/hw_sector_size", root_dev
+        )],
+    ).await.ok()?.trim().parse::<u64>().unwrap_or(512);
+    let tune2fs_out = sentryusb_shell::run(
+        "bash", &["-c", &format!(
+            "tune2fs -l '{}' | grep 'Block count:\\|Block size:' | awk '{{print $2}}' FS=: | tr -d ' '",
+            root_dev
+        )],
+    ).await.ok()?;
+    let parts: Vec<&str> = tune2fs_out.trim().lines().collect();
+    if parts.len() == 2 {
+        let block_count: u64 = parts[0].trim().parse().unwrap_or(0);
+        let block_size: u64 = parts[1].trim().parse().unwrap_or(4096);
+        if block_count > 0 {
+            return Some(block_count * block_size / sector_size);
+        }
+    }
+    None
+}
+
+/// Size of the root partition itself, in sectors.
+async fn root_partition_sectors(root_dev: &str) -> Option<u64> {
+    sentryusb_shell::run(
+        "bash", &["-c", &format!("partx --show -g -o SECTORS '{}'", root_dev)],
+    ).await.ok()?.trim().parse::<u64>().ok()
+}
+
 async fn check_root_shrink(env: &SetupEnv, emitter: &SetupEmitter) -> Result<bool> {
     // Mirror the verify_disk_space branch: the shrink exists solely to free
     // 8 GB on the SD for backingfiles+mutable. When DATA_DRIVE is set those
@@ -502,52 +592,7 @@ async fn check_root_shrink(env: &SetupEnv, emitter: &SetupEmitter) -> Result<boo
             emitter.progress("Root filesystem resize completed successfully during boot.");
             let _ = std::fs::remove_file(resize_marker);
 
-            emitter.progress("Shrinking root partition table entry to match filesystem...");
-            let sector_size = sentryusb_shell::run(
-                "bash", &["-c", &format!(
-                    "cat /sys/block/$(lsblk -no pkname '{}')/queue/hw_sector_size", root_dev
-                )],
-            ).await.unwrap_or_else(|_| "512".to_string()).trim().parse::<u64>().unwrap_or(512);
-
-            let tune2fs_out = sentryusb_shell::run(
-                "bash", &["-c", &format!(
-                    "tune2fs -l '{}' | grep 'Block count:\\|Block size:' | awk '{{print $2}}' FS=: | tr -d ' '",
-                    root_dev
-                )],
-            ).await.unwrap_or_default();
-            let parts: Vec<&str> = tune2fs_out.trim().lines().collect();
-            if parts.len() == 2 {
-                let block_count: u64 = parts[0].trim().parse().unwrap_or(0);
-                let block_size: u64 = parts[1].trim().parse().unwrap_or(4096);
-                let fs_sectors = block_count * block_size / sector_size;
-
-                let start_sector = sentryusb_shell::run(
-                    "bash", &["-c", &format!("partx --show -g -o START '{}'", root_dev)],
-                ).await.unwrap_or_default().trim().to_string();
-
-                emitter.progress(&format!("Resizing partition to {} sectors", fs_sectors));
-                let _ = sentryusb_shell::run_with_timeout(
-                    Duration::from_secs(30),
-                    "bash", &["-c", &format!(
-                        "echo '{},{}' | sfdisk --force --no-reread '{}' -N {}",
-                        start_sector, fs_sectors, boot_disk, root_part_num
-                    )],
-                ).await;
-            }
-
-            if Path::new("/sentryusb/config.txt").exists() {
-                let config = std::fs::read_to_string("/sentryusb/config.txt").unwrap_or_default();
-                if config.contains("SENTRYUSB-REMOVE") {
-                    let cleaned: String = config.lines()
-                        .filter(|l| !l.contains("SENTRYUSB-REMOVE"))
-                        .collect::<Vec<_>>().join("\n");
-                    let _ = std::fs::write("/sentryusb/config.txt", cleaned + "\n");
-                    let initrd = format!("initrd.img-{}", std::env::consts::ARCH);
-                    let _ = std::fs::remove_file(format!("/boot/{}", initrd));
-                } else {
-                    let _ = sentryusb_shell::run("update-initramfs", &["-u"]).await;
-                }
-            }
+            shrink_root_partition_table(&root_dev, &boot_disk, &root_part_num, emitter).await;
 
             emitter.progress("Root partition shrink complete, rebooting...");
             reboot().await;
@@ -580,6 +625,27 @@ async fn check_root_shrink(env: &SetupEnv, emitter: &SetupEmitter) -> Result<boo
     }
 
     if Path::new(resize_marker).exists() {
+        // The initramfs resize records success by writing /root/RESIZE_RESULT,
+        // but some non-Raspberry-Pi initramfs environments (e.g. DietPi on
+        // RK3399 / Radxa 4C+) can't persist that marker even when resize2fs
+        // succeeded — which previously stranded setup on a permanent FATAL.
+        // Trust the disk, not the marker: if the filesystem is already smaller
+        // than its partition, the resize did happen, so finish the partition-
+        // table shrink instead of bailing.
+        let fs_sectors = root_fs_sectors(&root_dev).await.unwrap_or(0);
+        let part_sectors = root_partition_sectors(&root_dev).await.unwrap_or(0);
+        // 64 MiB of slack so a partition already matching its filesystem isn't
+        // needlessly reshrunk.
+        let slack = 64 * 1024 * 1024 / 512;
+        if fs_sectors > 0 && part_sectors > 0 && fs_sectors + slack < part_sectors {
+            emitter.begin_phase("root_shrink", "Shrinking root partition table");
+            emitter.progress("Filesystem already shrunk but the resize marker was lost (common on DietPi initramfs); finishing the partition-table shrink...");
+            let _ = std::fs::remove_file(resize_marker);
+            shrink_root_partition_table(&root_dev, &boot_disk, &root_part_num, emitter).await;
+            emitter.progress("Root partition shrink complete, rebooting...");
+            reboot().await;
+            return Ok(true);
+        }
         emitter.progress("FATAL: Previous root shrink attempt failed. Delete /root/RESIZE_ATTEMPTED and try again, or reflash with Balena Etcher.");
         bail!("Previous root shrink attempt failed. Reflash with Balena Etcher instead of Raspberry Pi Imager.");
     }

--- a/crates/setup/src/verify.rs
+++ b/crates/setup/src/verify.rs
@@ -102,6 +102,7 @@ fn check_supported_hardware(env: &SetupEnv) -> Result<()> {
             "STOP: unsupported hardware: Raspberry Pi 2. \
              (only Pi Zero 2 W, Pi 3, Pi 4, and Pi 5 have the necessary hardware to run SentryUSB)"
         ),
+        PiModel::Rock4CPlus => Ok(()),
         PiModel::Other => {
             // Could be a RockPi / Radxa Zero / genuinely unknown board.
             // Bash returns silently for non-Pi boards; we do the same.

--- a/install-pi.sh
+++ b/install-pi.sh
@@ -486,26 +486,16 @@ PYEOF
     fi
     cat > /usr/local/bin/sentryusb-ble-adv.sh <<'ADVSH'
 #!/bin/bash
-# Raw legacy LE advertising for the BCM4345C0 (Rock Pi 4C+ / AP6256 module).
-#
-# WHY RAW HCI instead of btmgmt (validated on-device 2026-06-19): on this chip
-# BlueZ's mgmt advertiser is unreliable. Extended advertising (mgmt 0x0054/55) is
-# rejected outright; the LEGACY `btmgmt add-adv` REPORTS success but
-# `bluetoothctl show` reports ActiveInstances:0, AND it uses the controller's slow
-# ~1280ms default interval — so Android rarely catches the advert and connectGatt
-# fails with GATT_CONNECTION_TIMEOUT(147). Programming legacy ADV_IND directly over
-# HCI at a 100ms interval is the only reliable path: SC then connects to the real
-# MAC (2C:3B:70:69:4B:88) and authenticates. The SentryUSB apps filter scans by the
-# "SentryUSB-" NAME prefix, so the name MUST be in the scan response or the advert
-# is invisible to them. (hcitool ships with the `bluez` package.)
-#
-# Byte layout below is the exact validated sequence — do not "tidy" it.
+# Legacy ADV_IND advertiser for BCM4345C0. BlueZ's mgmt path is unreliable on
+# this chip (ext-adv rejected, legacy add-adv runs at ~1280ms — too slow for
+# Android scans), so program advertising directly over HCI at 100ms.
+# The SentryUSB apps filter scans by the "SentryUSB-" name prefix, so the
+# local name must be in the scan response.
 UUID_LE="9e ca dc 24 0e e5 a9 e0 93 f3 a3 b5 01 00 40 6e"   # 6e400001-b5a3-f393-e0a9-e50e24dcca9e, little-endian
 ADV_DATA="15 02 01 06 11 07 ${UUID_LE} 00 00 00 00 00 00 00 00 00 00 00 00 00"
 
-# Scan-response bytes = [len][0x09 Complete Local Name][name…], space-separated for
-# hcitool. Defined BEFORE the run-guard so `source sentryusb-ble-adv.sh;
-# build_scanrsp` is testable without entering the advertising loop below.
+# Scan-response bytes = [len][0x09 Complete Local Name][name…]. Function is
+# defined before the run-guard so it's sourceable for unit-style testing.
 build_scanrsp() {
     local name hex namebytes len
     name=$(timeout 5 btmgmt info 2>/dev/null | sed -n 's/^[[:space:]]*name[[:space:]]*//p' | head -1)

--- a/install-pi.sh
+++ b/install-pi.sh
@@ -300,6 +300,19 @@ chmod +x /root/bin/disable_gadget.sh
 
 ok "Gadget shims installed at /root/bin/{enable,disable}_gadget.sh"
 
+# Fetch envsetup.sh from the repo. archiveloop sources this at runtime to read
+# /root/sentryusb.conf and export CAM_MOUNT / MUSIC_MOUNT / ARCHIVE_* etc. The
+# pi-gen image build deploys it as part of the image; install-pi.sh users never
+# get it, so sentryusb-archive.service fails fast with "envsetup.sh: No such
+# file or directory" and respawns until systemd gives up.
+if curl -fsSL "https://raw.githubusercontent.com/${REPO}/main/setup/pi/envsetup.sh" \
+       -o /root/bin/envsetup.sh 2>/dev/null; then
+    chmod +x /root/bin/envsetup.sh
+    ok "envsetup.sh installed (archiveloop runtime config)"
+else
+    warn "envsetup.sh fetch failed — sentryusb-archive.service may crash on boot"
+fi
+
 # ── Step 3d: remountfs_rw helper + /root/.bashrc reminder ──────────
 # `remountfs_rw` is created by the pi-gen image build; install-pi.sh users
 # (any non-pi-gen install, e.g. DietPi/Armbian) never get it. The BLE daemon

--- a/install-pi.sh
+++ b/install-pi.sh
@@ -300,10 +300,24 @@ chmod +x /root/bin/disable_gadget.sh
 
 ok "Gadget shims installed at /root/bin/{enable,disable}_gadget.sh"
 
-# ── Step 3d: /root/.bashrc remountfs_rw reminder ───────────────────
-# Prints the read-only/remountfs_rw tip on every `sudo -i`. The pi-gen
-# image build adds the same block; this branch covers install-pi.sh
-# users who never ran pi-gen.
+# ── Step 3d: remountfs_rw helper + /root/.bashrc reminder ──────────
+# `remountfs_rw` is created by the pi-gen image build; install-pi.sh users
+# (any non-pi-gen install, e.g. DietPi/Armbian) never get it. The BLE daemon
+# calls it to remount root RW before saving the pairing PIN, and fails with
+# "Failed to save PIN: No such file or directory: '/root/bin/remountfs_rw'"
+# if absent — blocks BLE pair from SC. Always-install a tiny stub: works
+# whether root is RO (does the remount) or already RW (no-op + exit 0).
+mkdir -p /root/bin
+if [ ! -f /root/bin/remountfs_rw ]; then
+    cat > /root/bin/remountfs_rw <<'REMOUNT_RW'
+#!/bin/bash
+# remount root RW (no-op if already RW). Used by sentryusb-ble.py for PIN save.
+mount -o remount,rw / 2>/dev/null
+exit 0
+REMOUNT_RW
+    chmod +x /root/bin/remountfs_rw
+    ok "Installed /root/bin/remountfs_rw stub (BLE daemon PIN save)"
+fi
 if ! grep -q SENTRYUSB_TIP1 /root/.bashrc 2>/dev/null; then
     cat >> /root/.bashrc <<- 'EOC'
 	if [ -n "$PS1" ]; then
@@ -342,13 +356,14 @@ if is_rock_4cplus; then
     # Best-effort section: don't let a minor apt/systemd hiccup abort the install.
     set +e
 
-    # 1. BLE daemon dependency
-    if apt-get install -y rfkill >/dev/null 2>&1; then
-        ok "rfkill installed (BLE daemon dependency)"
+    # 1. Apt dependencies — rfkill (BLE daemon calls it) and device-tree-compiler
+    #    (sub-step 2 compiles a dwc3 overlay with `dtc`; DietPi minimal ships neither).
+    if apt-get install -y rfkill device-tree-compiler >/dev/null 2>&1; then
+        ok "rfkill + device-tree-compiler installed"
         systemctl reset-failed sentryusb-ble.service 2>/dev/null || true
         systemctl restart sentryusb-ble.service 2>/dev/null || true
     else
-        warn "rfkill install failed — BLE daemon may not start"
+        warn "rfkill/dtc install failed — BLE daemon and dwc3 overlay may not work"
     fi
 
     # 2. High-speed dwc3 peripheral overlay (compiled on-device → self-contained)

--- a/install-pi.sh
+++ b/install-pi.sh
@@ -297,6 +297,261 @@ if ! grep -q SENTRYUSB_TIP1 /root/.bashrc 2>/dev/null; then
     ok "Added remountfs_rw reminder to /root/.bashrc"
 fi
 
+# ── Step 3e: Rock Pi 4C+ (RK3399 / dwc3) hardware setup ────────────────────
+# A NO-OP on Raspberry Pi and every non-4C+ board (detection-gated). On a Rock
+# Pi 4C+ a generic install leaves three things broken, all fixed here so SC works
+# with WiFi + BLE out of the box:
+#   1. rfkill — the BLE daemon's unit calls /usr/sbin/rfkill; DietPi's minimal
+#      base omits it, so sentryusb-ble.service fails 203/EXEC without it.
+#   2. dwc3 overlay → OTG port to PERIPHERAL/high-speed (else /sys/class/udc is
+#      empty → no USB mass-storage gadget → Tesla never sees the dashcam).
+#   3. BT+WiFi firmware (AP6256/BCM4345C0 combo) + a legacy raw-HCI LE advertiser
+#      (the chip rejects BlueZ extended advertising, so SC can't discover it).
+# Best-effort: each sub-step warns on failure rather than aborting the install.
+is_rock_4cplus() {
+    grep -qai 'rock-4c-plus\|rockpi4c-plus\|ROCK 4C+' \
+        /proc/device-tree/model /proc/device-tree/compatible 2>/dev/null
+}
+has_dietpi_overlays() {
+    [ -f /boot/dietpiEnv.txt ] && grep -q '^overlay_path=' /boot/dietpiEnv.txt
+}
+
+NEEDS_REBOOT=0
+if is_rock_4cplus; then
+    info "Rock Pi 4C+ detected — applying USB-gadget + BLE hardware setup..."
+    # Best-effort section: don't let a minor apt/systemd hiccup abort the install.
+    set +e
+
+    # 1. BLE daemon dependency
+    if apt-get install -y rfkill >/dev/null 2>&1; then
+        ok "rfkill installed (BLE daemon dependency)"
+        systemctl reset-failed sentryusb-ble.service 2>/dev/null || true
+        systemctl restart sentryusb-ble.service 2>/dev/null || true
+    else
+        warn "rfkill install failed — BLE daemon may not start"
+    fi
+
+    # 2. High-speed dwc3 peripheral overlay (compiled on-device → self-contained)
+    if has_dietpi_overlays; then
+        apt-get install -y device-tree-compiler >/dev/null 2>&1 || true
+        mkdir -p /boot/overlay-user
+        cat > /tmp/sentryusb-dwc3-hs.dts <<'DTS'
+/dts-v1/;
+/plugin/;
+/ {
+    metadata {
+        title = "SentryUSB: OTG peripheral high-speed (Rock 4C+)";
+        compatible = "rockchip,rk3399";
+        category = "misc";
+        exclusive = "usbdrd_dwc3_0-dr_mode";
+        description = "dwc3 OTG → peripheral mode, high-speed, for the USB gadget.";
+    };
+    fragment@0 {
+        target = <&usbdrd_dwc3_0>;
+        __overlay__ {
+            status = "okay";
+            dr_mode = "peripheral";
+            maximum-speed = "high-speed";
+        };
+    };
+};
+DTS
+        if dtc -@ -I dts -O dtb -o /boot/overlay-user/sentryusb-dwc3-hs.dtbo \
+               /tmp/sentryusb-dwc3-hs.dts 2>/dev/null; then
+            ok "Compiled high-speed dwc3 overlay → /boot/overlay-user/sentryusb-dwc3-hs.dtbo"
+            cur=$(grep '^user_overlays=' /boot/dietpiEnv.txt | cut -d= -f2-)
+            case " $cur " in
+                *" sentryusb-dwc3-hs "*)
+                    ok "Overlay already registered in user_overlays" ;;
+                *)
+                    new=$(echo "$cur sentryusb-dwc3-hs" | xargs)
+                    cp /boot/dietpiEnv.txt /boot/dietpiEnv.txt.sentryusb.bak
+                    sed -i "s/^user_overlays=.*/user_overlays=$new/" /boot/dietpiEnv.txt
+                    ok "Registered overlay (user_overlays=$new)"
+                    NEEDS_REBOOT=1 ;;
+            esac
+        else
+            warn "dwc3 overlay compile failed — USB gadget will NOT appear until applied manually"
+        fi
+    else
+        warn "Rock 4C+ but no DietPi/Armbian overlay mechanism found — apply a dwc3"
+        warn "peripheral+high-speed overlay for your image manually, or no USB gadget."
+    fi
+
+    # 3. Bluetooth + WiFi firmware — AP6256 (BCM4345C0 WiFi+BT combo) coexistence.
+    #    BT .hcd MUST be the GENERIC patch, NOT BCM4345C0.raspberrypi,*.hcd — the Pi
+    #    profile kills the WiFi SDIO half (brcmf rxctl timeout / wlan0 I/O error).
+    BRCM=/lib/firmware/brcm
+    HCD=""
+    for c in BCM4345C0_003.001.025.0162.0000_Generic_UART_37_4MHz_wlbga_ref_iLNA_iTR_eLG.hcd \
+             BCM4345C0.raspberrypi,4-compute-module.hcd; do
+        [ -e "$BRCM/$c" ] && { HCD="$c"; break; }
+    done
+    [ -z "$HCD" ] && HCD=$(cd "$BRCM" 2>/dev/null && ls BCM4345C0*.hcd 2>/dev/null | grep -vE 'radxa,rock-4c-plus|raspberrypi' | head -1)
+    if [ -n "$HCD" ] && [ -e "$BRCM/$HCD" ]; then
+        ln -sf "$HCD" "$BRCM/BCM4345C0.radxa,rock-4c-plus.hcd"
+        ln -sf "$HCD" "$BRCM/BCM4345C0.hcd"
+        ok "BT firmware → $HCD (generic AP6256 patch, NOT the Pi profile) — reboot to load"
+        NEEDS_REBOOT=1
+    else
+        warn "BCM4345C0 .hcd not found — 'apt install --reinstall armbian-firmware', then"
+        warn "symlink BCM4345C0.radxa,rock-4c-plus.hcd → the generic BCM4345C0 .hcd."
+    fi
+    if [ -e "$BRCM/nvram_ap6256.txt" ]; then
+        ln -sf nvram_ap6256.txt "$BRCM/brcmfmac43455-sdio.radxa,rock-4c-plus.txt"
+        [ -e "$BRCM/brcmfmac43455-sdio.bin" ] && \
+            ln -sf brcmfmac43455-sdio.bin "$BRCM/brcmfmac43455-sdio.radxa,rock-4c-plus.bin"
+        [ -e "$BRCM/brcmfmac43455-sdio.clm_blob" ] && \
+            ln -sf brcmfmac43455-sdio.clm_blob "$BRCM/brcmfmac43455-sdio.radxa,rock-4c-plus.clm_blob"
+        ok "WiFi nvram → nvram_ap6256.txt (AP6256 calibration) — WiFi now survives BT"
+        NEEDS_REBOOT=1
+    else
+        warn "nvram_ap6256.txt not found — WiFi may be unstable with BT (generic calibration)."
+    fi
+
+    # 3b. THE BLE-advertising fix. The BCM4345C0 firmware rejects BlueZ EXTENDED
+    #     advertising (mgmt 0x0054/55 → "Invalid Parameters 0x0d"), and even legacy
+    #     `btmgmt add-adv` is unreliable (ActiveInstances:0 / ~1280ms interval →
+    #     Android misses it → connectGatt 147). Fix = (i) daemon doesn't sys.exit on
+    #     BlueZ adv failure; (ii) a helper programs legacy ADV_IND @ 100ms directly
+    #     over raw HCI (SC then connects to the real MAC + authenticates); (iii) start
+    #     event-driven when hci0 appears (UART BT attaches late on cold boot).
+    BLE_PY=/root/bin/sentryusb-ble.py
+    if [ -f "$BLE_PY" ] && ! grep -q 'legacy btmgmt advertising' "$BLE_PY"; then
+        python3 - "$BLE_PY" <<'PYEOF' || true
+import sys
+p = sys.argv[1]; s = open(p).read()
+a = s.find('def register_ad_error_cb(error):'); b = s.find('\ndef register_app_cb', a)
+if a >= 0 and b >= 0:
+    cb = ("def register_ad_error_cb(error):\n"
+          "    # BCM4345C0 (Rock 4C+): BlueZ uses EXTENDED advertising which this chip\n"
+          "    # rejects ('Invalid Parameters 0x0d'). Do NOT exit (that tears down GATT\n"
+          "    # and loops forever); keep GATT up. Legacy btmgmt advertising is enabled\n"
+          "    # out-of-band by sentryusb-ble-adv.service.\n"
+          "    log.warning(f'BlueZ advertisement registration failed ({error}); '\n"
+          "                'using legacy btmgmt advertising instead; GATT stays up.')\n")
+    open(p, 'w').write(s[:a] + cb + s[b+1:]); print('patched')
+else:
+    print('anchor-not-found')
+PYEOF
+        ok "Patched sentryusb-ble.py: BlueZ adv failure no longer kills the GATT server"
+    fi
+    cat > /usr/local/bin/sentryusb-ble-adv.sh <<'ADVSH'
+#!/bin/bash
+# Raw legacy LE advertising for the BCM4345C0 (Rock Pi 4C+ / AP6256 module).
+#
+# WHY RAW HCI instead of btmgmt (validated on-device 2026-06-19): on this chip
+# BlueZ's mgmt advertiser is unreliable. Extended advertising (mgmt 0x0054/55) is
+# rejected outright; the LEGACY `btmgmt add-adv` REPORTS success but
+# `bluetoothctl show` reports ActiveInstances:0, AND it uses the controller's slow
+# ~1280ms default interval — so Android rarely catches the advert and connectGatt
+# fails with GATT_CONNECTION_TIMEOUT(147). Programming legacy ADV_IND directly over
+# HCI at a 100ms interval is the only reliable path: SC then connects to the real
+# MAC (2C:3B:70:69:4B:88) and authenticates. The SentryUSB apps filter scans by the
+# "SentryUSB-" NAME prefix, so the name MUST be in the scan response or the advert
+# is invisible to them. (hcitool ships with the `bluez` package.)
+#
+# Byte layout below is the exact validated sequence — do not "tidy" it.
+UUID_LE="9e ca dc 24 0e e5 a9 e0 93 f3 a3 b5 01 00 40 6e"   # 6e400001-b5a3-f393-e0a9-e50e24dcca9e, little-endian
+ADV_DATA="15 02 01 06 11 07 ${UUID_LE} 00 00 00 00 00 00 00 00 00 00 00 00 00"
+
+# Scan-response bytes = [len][0x09 Complete Local Name][name…], space-separated for
+# hcitool. Defined BEFORE the run-guard so `source sentryusb-ble-adv.sh;
+# build_scanrsp` is testable without entering the advertising loop below.
+build_scanrsp() {
+    local name hex namebytes len
+    name=$(timeout 5 btmgmt info 2>/dev/null | sed -n 's/^[[:space:]]*name[[:space:]]*//p' | head -1)
+    [ -z "$name" ] && name=$(hostname)
+    name=${name:0:29}                                   # scan-rsp budget: 31 - 2 (len+type)
+    hex=$(printf '%s' "$name" | od -An -tx1 | tr -d ' \n')
+    namebytes=$(( ${#hex} / 2 ))
+    len=$(( namebytes + 1 ))                             # +1 for the AD type byte
+    printf '%02x 09 %s' "$len" "$(echo "$hex" | sed 's/../& /g')"
+}
+
+# Program legacy ADV_IND directly via HCI (bypasses BlueZ mgmt):
+#   disable → set adv data → set scan-rsp (name, zero-padded to 31) →
+#   adv params (100ms min/max ADV_IND connectable undirected, public addr, all 3 chans) → enable
+assert_raw_adv() {
+    local scanrsp; scanrsp=$(build_scanrsp)
+    hcitool -i hci0 cmd 0x08 0x000a 00 >/dev/null 2>&1 || true
+    hcitool -i hci0 cmd 0x08 0x0008 $ADV_DATA >/dev/null 2>&1 || true
+    hcitool -i hci0 cmd 0x08 0x0009 $scanrsp 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 >/dev/null 2>&1 || true
+    hcitool -i hci0 cmd 0x08 0x0006 a0 00 a0 00 00 00 00 00 00 00 00 00 00 07 00 >/dev/null 2>&1 || true
+    hcitool -i hci0 cmd 0x08 0x000a 01 >/dev/null 2>&1 || true
+}
+
+# Run the advertising loop ONLY when executed directly (the systemd ExecStart),
+# never when sourced — otherwise testing build_scanrsp() would loop forever.
+if [ "${BASH_SOURCE[0]}" != "${0}" ]; then
+    return 0 2>/dev/null || exit 0
+fi
+
+for i in $(seq 1 30); do busctl status org.bluez >/dev/null 2>&1 && break; sleep 1; done
+sleep 3   # let the daemon's (failing) ext-adv RegisterAdvertisement settle first
+timeout 5 btmgmt le on >/dev/null 2>&1 || true
+timeout 5 btmgmt connectable on >/dev/null 2>&1 || true
+while true; do
+    # Re-assert only while IDLE — reprogramming advertising while a phone is
+    # connected can disturb Broadcom controllers and isn't needed for a live link.
+    if ! timeout 3 btmgmt con 2>/dev/null | grep -q 'type LE'; then
+        assert_raw_adv
+    fi
+    sleep 5
+done
+ADVSH
+    chmod +x /usr/local/bin/sentryusb-ble-adv.sh
+    cat > /etc/systemd/system/sentryusb-ble-adv.service <<'ADVSVC'
+[Unit]
+Description=SentryUSB: legacy LE advertising (Rock 4C+ BCM4345C0 ext-adv workaround)
+After=bluetooth.service sentryusb-ble.service
+Wants=bluetooth.service
+BindsTo=sentryusb-ble.service
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/sentryusb-ble-adv.sh
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+ADVSVC
+    cat > /etc/udev/rules.d/99-sentryusb-ble-hci.rules <<'UDEV'
+# Rock 4C+ (BCM4345C0): the UART BT controller attaches a few seconds into boot,
+# AFTER systemd checks bluetooth.service's ConditionPathIsDirectory, so the BLE
+# stack is skipped on a cold boot. Start it the moment hci0 appears (condition now
+# passes; the daemon's Wants= pulls bluetooth.service + the advertising helper).
+ACTION=="add", SUBSYSTEM=="bluetooth", KERNEL=="hci0", TAG+="systemd", ENV{SYSTEMD_WANTS}+="sentryusb-ble.service"
+UDEV
+    mkdir -p /etc/systemd/system/sentryusb-ble.service.d
+    cat > /etc/systemd/system/sentryusb-ble.service.d/wants-bluetooth.conf <<'WANTS'
+[Unit]
+Wants=bluetooth.service sentryusb-ble-adv.service
+WANTS
+    systemctl disable --now sentryusb-ble-le.service 2>/dev/null || true
+    rm -f /etc/systemd/system/sentryusb-ble-le.service 2>/dev/null
+    rm -rf /etc/systemd/system/sentryusb-ble-le.service.d 2>/dev/null
+    systemctl enable bluetooth.service >/dev/null 2>&1 || true
+    systemctl daemon-reload 2>/dev/null || true
+    udevadm control --reload-rules 2>/dev/null || true
+    systemctl enable sentryusb-ble-adv.service >/dev/null 2>&1 || true
+    ok "BLE legacy-advertising fix installed (daemon patch + adv service + hci0 udev rule)"
+    NEEDS_REBOOT=1
+
+    # 4. (Recommended) OpenSSH instead of Dropbear — Dropbear ships no SFTP
+    #    subsystem, so scp/sftp to the Pi fail.
+    if command -v dropbear >/dev/null 2>&1 && [ -x /boot/dietpi/func/dietpi-set_software ]; then
+        if /boot/dietpi/func/dietpi-set_software ssh-server openssh >/dev/null 2>&1; then
+            ok "Switched SSH server to OpenSSH (scp/sftp support)"
+        else
+            warn "OpenSSH switch failed — Dropbear left in place (scp/sftp unavailable)"
+        fi
+    fi
+
+    set -e  # end best-effort section
+fi
+
 # ── Step 4: Sample Config ───────────────────────────────────────────
 
 if [ ! -f /root/sentryusb.conf ]; then
@@ -408,3 +663,11 @@ echo -e "  Config:  /root/sentryusb.conf"
 echo -e "  Binary:  ${INSTALL_DIR}/sentryusb-current → $(readlink "${INSTALL_DIR}/sentryusb-current" 2>/dev/null || echo "<picker has not run yet>")"
 echo -e "  Logs:    journalctl -u sentryusb -f"
 echo ""
+
+if [ "${NEEDS_REBOOT:-0}" = "1" ]; then
+    warn "Rock 4C+: a REBOOT is required to activate the USB gadget (dwc3 → peripheral)"
+    warn "          and load the BT/WiFi firmware."
+    echo -e "  Run:  ${BLUE}reboot${NC}  — afterward /sys/class/udc/ shows fe800000.usb (Tesla"
+    echo -e "        sees the dashcam) and SC can discover + BLE-pair the 4C+."
+    echo ""
+fi

--- a/install-pi.sh
+++ b/install-pi.sh
@@ -249,6 +249,26 @@ else
     warn "Could not fetch BLE daemon — iOS app pairing will be unavailable"
 fi
 
+# ── Step 3b2: Disable EATT (no recurring BLE pairing prompt) ────────
+# The BLE GATT is app-PIN over plain (unencrypted) ATT, but a phone's EATT
+# (PSM 0x0027) open needs an encrypted link — bluetoothd refuses it and sends an
+# SMP Security Request, popping a pair prompt on every connect. Channels=1 keeps
+# plain ATT (same GATT), so no prompt. Safe on all boards (no security change).
+MAIN_CONF=/etc/bluetooth/main.conf
+if [ -f "$MAIN_CONF" ] && ! grep -qE '^Channels[[:space:]]*=[[:space:]]*1' "$MAIN_CONF"; then
+    if grep -qE '^\[GATT\]' "$MAIN_CONF"; then
+        if grep -qiE '^[# ]*Channels' "$MAIN_CONF"; then
+            sed -i -E 's/^[# ]*Channels[ ]*=.*/Channels = 1/' "$MAIN_CONF"
+        else
+            sed -i '/^\[GATT\]/a Channels = 1' "$MAIN_CONF"
+        fi
+    else
+        printf '\n[GATT]\nChannels = 1\n' >> "$MAIN_CONF"
+    fi
+    systemctl restart bluetooth 2>/dev/null || true
+    ok "EATT disabled (no recurring BLE pairing prompt)"
+fi
+
 # ── Step 3c: archiveloop ↔ gadget shim scripts ─────────────────────
 #
 # archiveloop (shell) calls /root/bin/enable_gadget.sh and disable_gadget.sh

--- a/server/ble/sentryusb-ble.py
+++ b/server/ble/sentryusb-ble.py
@@ -1507,6 +1507,13 @@ def main():
     adapter_props.Set('org.bluez.Adapter1', 'Alias', dbus.String(ble_name))
     log.info(f'BLE adapter alias set to: {ble_name}')
 
+    # Characteristics are unencrypted (app-PIN auth), so no bond is required.
+    # Disable pairing so the phone OS doesn't re-offer it on every connect.
+    try:
+        adapter_props.Set('org.bluez.Adapter1', 'Pairable', dbus.Boolean(False))
+    except Exception as e:
+        log.warning(f'could not set Pairable=False: {e}')
+
     # Update Avahi mDNS service name to match the unique BLE name
     update_avahi_service_name(ble_name)
 


### PR DESCRIPTION
## Problem
A fresh DietPi install on a Radxa Rock Pi 4C+ doesn't reach a working SentryUSB without manual fixes:
- Setup reports `Unknown board` (board detection only knows Raspberry Pi models)
- Setup crashes with permanent `FATAL: Previous root shrink attempt failed` (the initramfs marker write fails silently on DietPi/RK3399 even when `resize2fs` actually succeeded)
- BLE is dead (BCM4345C0 firmware patch missing, BlueZ extended advertising rejected, `rfkill` not installed)
- USB gadget doesn't appear (`/sys/class/udc/` empty — dwc3 defaults to host mode)
- WiFi dies when BT comes up (Pi-profile `.hcd` symlink kills the WiFi SDIO half of the AP6256 combo)
- archiveloop crash-loops on every boot (`envsetup.sh` missing — pi-gen images ship it, install-pi.sh users never get it)
- Recurring pair prompt on every BLE connect (EATT spec requires encrypted link, GATT is plain ATT, BlueZ rejects → SMP Security Request)
- BLE daemon can't save the pairing PIN (`remountfs_rw` helper missing — pi-gen ships it, install-pi.sh users never get it)

## Fix

**Rust binary** (`crates/setup/src/{env,verify,runner}.rs`)
- `env.rs` + `verify.rs`: detect Rock 4C+ via model + DT compatible (`radxa,rock-4c-plus`) as `PiModel::Rock4CPlus`. Raspberry Pi arms checked first so Pi/other boards are unaffected.
- `runner.rs`: root-shrink self-heal. Before the FATAL, compare `root_fs_sectors()` vs `root_partition_sectors()`; if the FS is already meaningfully smaller, the resize did happen (marker just lost) → run the partition-table shrink and reboot instead of bailing. Pi-safe: on a Pi the `RESIZE_RESULT=success` path returns first, and the fallback only acts when the FS is genuinely shrunk.

**`install-pi.sh` — 4C+ only (no-op on every other board)**

Step 3e auto-applies the 4C+ hardware bring-up, gated on `is_rock_4cplus()`:
- `apt install rfkill device-tree-compiler` (DietPi minimal omits both; BLE daemon ExecStartPre calls `/usr/sbin/rfkill`)
- Compile + register a high-speed dwc3 overlay (`dr_mode=peripheral`, `maximum-speed=high-speed`) → `/boot/overlay-user/sentryusb-dwc3-hs.dtbo`, append to `user_overlays=` in `/boot/dietpiEnv.txt`. High-speed is the cold-boot-proven config (super-speed cold-attach is unreliable on this controller).
- BT firmware: symlink the generic BCM4345C0 `.hcd` (NOT the `raspberrypi,4-compute-module` profile — the Pi profile knocks the WiFi SDIO half offline once BT comes up).
- WiFi nvram: symlink `nvram_ap6256.txt` to the chip's calibration path.
- ble.py patch: don't `sys.exit` on BlueZ `RegisterAdvertisement` failure (this chip rejects extended advertising). Replace with a `log.warning` so the GATT server stays up.
- Raw-HCI legacy ADV_IND advertiser as a systemd oneshot (`sentryusb-ble-adv.service`) running at 100ms interval — the chip's btmgmt-managed legacy adv runs at the controller default ~1280ms which scans miss.
- `hci0` udev rule pulling `sentryusb-ble.service` once Bluetooth attaches (UART BT comes up late on cold boot).

**`install-pi.sh` — applies on all boards, safe everywhere**
- **EATT disable** (`[GATT] Channels = 1` in `/etc/bluetooth/main.conf`). The GATT is already plain ATT (app-PIN over unencrypted) on every board — EATT was a perf feature nobody was using. Kills the recurring pair prompt the EATT spec mandates.
- **`remountfs_rw` stub.** Only created if absent — pi-gen images that ship the real one skip the stub entirely. Lets the BLE daemon save the pairing PIN on non-pi-gen installs (DietPi/Armbian).
- **`envsetup.sh` fetch.** Same upstream file (`setup/pi/envsetup.sh`) at the same path. On pi-gen images already shipping it, identical content — no change. For non-pi-gen installs it stops archiveloop from crash-looping on every boot.

## Validation
- Fresh DietPi Trixie SD on Rock 4C+: single `curl … install-pi.sh` command, no manual steps, no SSH after
- mDNS discovery + BLE pair (no pair prompt) + setup wizard via the mobile app — full flow including watching live setup phases through to dashboard
- Cold-boot in car with USB-A↔A cable pre-connected: dashcam icon appears, UDC `configured` at `high-speed`, all services active
- Boot time 25.5s on SD (5s kernel + 20.5s userspace); estimate ~30-35s power-on → Tesla-sees-dashcam on a clean cold-boot
- archiveloop `active` post-boot (no crash loop)
- Existing Raspberry Pi paths unaffected — Step 3e is detection-gated, self-heal only fires when FS shrunk already (Pi normal success path returns first), board enum still hits Pi arms first

## Known limitation
AP enable/disable still requires NetworkManager (pi-gen). On DietPi the AP currently silently no-ops because `nmcli` isn't installed. Workaround for users: manually edit `/etc/network/interfaces`. Follow-up PR will add an ifupdown branch to `setup/pi/configure-ap.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
