### PR TITLE
fix(install): ifupdown AP path for DietPi

### DIFF
--- a/crates/api/src/away_mode.rs
+++ b/crates/api/src/away_mode.rs
@@ -24,6 +24,79 @@ use crate::router::AppState;
 
 const FLAG_FILE: &str = "/mutable/sentryusb_away_mode.json";
 const AP_PROFILE: &str = "SENTRYUSB_AP";
+const HOSTAPD_CONF: &str = "/etc/hostapd/hostapd.conf";
+const IFUPDOWN_AP_FILE: &str = "/etc/network/interfaces.d/sentryusb-ap";
+/// Default AP channel + hw_mode when wlan0 isn't associated — prefer 5GHz
+/// channel 36 (UNII-1, universal). Faster than 2.4 for clip serving.
+const DEFAULT_AP_CHANNEL: u32 = 36;
+const DEFAULT_AP_HW_MODE: &str = "a";
+
+/// Detect whether NetworkManager owns wifi (default on Pi OS / pi-gen) or
+/// whether we're on an ifupdown image (DietPi/Armbian). The AP enable/disable
+/// path is completely different between the two.
+fn use_networkmanager() -> bool {
+    std::process::Command::new("systemctl")
+        .args(["--quiet", "is-active", "NetworkManager.service"])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Parse `iw wlan0 info` for the current STA channel + band. On
+/// BCM43455-family chipsets (Pi 4/5, Pi Zero 2 W, Rock 4C+) STA and AP are
+/// constrained to the same channel — the AP must match wlan0's channel or
+/// the chip refuses one of them. When STA isn't associated, returns None
+/// and the caller falls back to the 5GHz default.
+async fn detect_sta_channel() -> Option<(u32, &'static str)> {
+    let out = sentryusb_shell::run("iw", &["wlan0", "info"]).await.ok()?;
+    for line in out.lines() {
+        let l = line.trim();
+        let Some(rest) = l.strip_prefix("channel ") else { continue };
+        let mut parts = rest.split_whitespace();
+        let ch: u32 = parts.next()?.parse().ok()?;
+        let freq_token = parts.next()?.trim_start_matches('(');
+        let freq: u32 = freq_token.parse().ok()?;
+        let hw_mode = if freq >= 5000 { "a" } else { "g" };
+        return Some((ch, hw_mode));
+    }
+    None
+}
+
+/// Rewrite the `channel=` and `hw_mode=` lines in /etc/hostapd/hostapd.conf
+/// so the AP matches wlan0's current channel. Called immediately before
+/// `ifup ap0` so hostapd starts on the right frequency.
+fn update_hostapd_channel(channel: u32, hw_mode: &str) -> Result<(), String> {
+    // Make root writable for the duration of the write — the install
+    // ships a `remountfs_rw` stub that is safe to call even when root is
+    // already RW (no-op + exit 0).
+    let _ = std::process::Command::new("/root/bin/remountfs_rw").status();
+    let content = std::fs::read_to_string(HOSTAPD_CONF)
+        .map_err(|e| format!("read {}: {}", HOSTAPD_CONF, e))?;
+    let mut new = String::new();
+    let mut saw_channel = false;
+    let mut saw_mode = false;
+    for line in content.lines() {
+        if line.starts_with("channel=") {
+            new.push_str(&format!("channel={}", channel));
+            saw_channel = true;
+        } else if line.starts_with("hw_mode=") {
+            new.push_str(&format!("hw_mode={}", hw_mode));
+            saw_mode = true;
+        } else {
+            new.push_str(line);
+        }
+        new.push('\n');
+    }
+    if !saw_channel {
+        new.push_str(&format!("channel={}\n", channel));
+    }
+    if !saw_mode {
+        new.push_str(&format!("hw_mode={}\n", hw_mode));
+    }
+    std::fs::write(HOSTAPD_CONF, new)
+        .map_err(|e| format!("write {}: {}", HOSTAPD_CONF, e))?;
+    Ok(())
+}
 const POLL_INTERVAL: Duration = Duration::from_secs(30);
 const MAX_DURATION_MIN: u64 = 24 * 60;
 
@@ -436,18 +509,50 @@ async fn ensure_ap0() -> Result<(), String> {
 
 fn start_ap_bg() {
     tokio::spawn(async {
-        if let Err(e) = ensure_ap0().await {
-            away_mode_log(&format!("Failed to create ap0: {}", e));
-            warn!("[away-mode] Failed to create ap0: {}", e);
-        }
-        match sentryusb_shell::run("nmcli", &["con", "up", AP_PROFILE]).await {
-            Ok(_) => {
-                away_mode_log("AP started");
-                info!("[away-mode] AP started");
+        if use_networkmanager() {
+            // NetworkManager path (Pi OS / pi-gen).
+            if let Err(e) = ensure_ap0().await {
+                away_mode_log(&format!("Failed to create ap0: {}", e));
+                warn!("[away-mode] Failed to create ap0: {}", e);
             }
-            Err(e) => {
-                away_mode_log(&format!("Failed to bring up AP: {}", e));
-                warn!("[away-mode] Failed to bring up AP: {}", e);
+            match sentryusb_shell::run("nmcli", &["con", "up", AP_PROFILE]).await {
+                Ok(_) => {
+                    away_mode_log("AP started");
+                    info!("[away-mode] AP started");
+                }
+                Err(e) => {
+                    away_mode_log(&format!("Failed to bring up AP: {}", e));
+                    warn!("[away-mode] Failed to bring up AP: {}", e);
+                }
+            }
+        } else {
+            // ifupdown path (DietPi/Armbian — no NetworkManager).
+            // Match STA's channel if associated (BCM43455 family chips can't
+            // host AP+STA on different channels), else fall back to 5GHz ch
+            // 36 — fast enough to serve clips through the AP without dropping
+            // to 2.4GHz.
+            let (channel, hw_mode) = detect_sta_channel()
+                .await
+                .unwrap_or((DEFAULT_AP_CHANNEL, DEFAULT_AP_HW_MODE));
+            if let Err(e) = update_hostapd_channel(channel, hw_mode) {
+                away_mode_log(&format!("Failed to set hostapd channel: {}", e));
+                warn!("[away-mode] update_hostapd_channel: {}", e);
+            }
+            match sentryusb_shell::run("ifup", &["ap0"]).await {
+                Ok(_) => {
+                    away_mode_log(&format!(
+                        "AP started (ifupdown, channel {} {})",
+                        channel, hw_mode
+                    ));
+                    info!(
+                        "[away-mode] AP started via ifupdown channel={} hw_mode={}",
+                        channel, hw_mode
+                    );
+                }
+                Err(e) => {
+                    away_mode_log(&format!("ifup ap0 failed: {}", e));
+                    warn!("[away-mode] ifup ap0 failed: {}", e);
+                }
             }
         }
     });
@@ -455,17 +560,36 @@ fn start_ap_bg() {
 
 fn stop_ap_bg() {
     tokio::spawn(async {
-        match sentryusb_shell::run("nmcli", &["con", "down", AP_PROFILE]).await {
-            Ok(_) => {
-                away_mode_log("AP stopped");
-                info!("[away-mode] AP stopped");
+        if use_networkmanager() {
+            match sentryusb_shell::run("nmcli", &["con", "down", AP_PROFILE]).await {
+                Ok(_) => {
+                    away_mode_log("AP stopped");
+                    info!("[away-mode] AP stopped");
+                }
+                Err(e) => {
+                    // Not fatal: `con down` also fails when the AP was already
+                    // down (e.g. expiry cleanup after a reboot).
+                    away_mode_log(&format!("nmcli con down failed (AP may already be down): {}", e));
+                    warn!("[away-mode] nmcli con down failed: {}", e);
+                }
             }
-            Err(e) => {
-                // Not fatal: `con down` also fails when the AP was already
-                // down (e.g. expiry cleanup after a reboot).
-                away_mode_log(&format!("nmcli con down failed (AP may already be down): {}", e));
-                warn!("[away-mode] nmcli con down failed: {}", e);
+        } else {
+            // ifupdown path. `ifdown ap0` runs the post-down hooks in
+            // /etc/network/interfaces.d/sentryusb-ap which stop hostapd +
+            // dnsmasq. Belt-and-suspenders stops follow in case the hooks
+            // are missing (e.g. setup didn't install the interfaces.d file).
+            match sentryusb_shell::run("ifdown", &["ap0"]).await {
+                Ok(_) => {
+                    away_mode_log("AP stopped (ifupdown)");
+                    info!("[away-mode] AP stopped via ifupdown");
+                }
+                Err(e) => {
+                    away_mode_log(&format!("ifdown ap0 failed (AP may already be down): {}", e));
+                    warn!("[away-mode] ifdown ap0 failed: {}", e);
+                }
             }
+            let _ = sentryusb_shell::run("systemctl", &["stop", "hostapd"]).await;
+            let _ = sentryusb_shell::run("systemctl", &["stop", "dnsmasq"]).await;
         }
         // Always remove ap0: it locks the shared radio to the AP channel
         // (blocking wlan0 scans), and a leftover ap0 is what used to make
@@ -474,40 +598,73 @@ fn stop_ap_bg() {
     });
 }
 
-/// Whether the SENTRYUSB_AP connection profile exists. Setup creates it
-/// (AP enabled in the wizard) and deletes it (AP unchecked) — the UI uses
-/// this to grey out the Away Mode card when the feature is unconfigured.
+/// Whether the SENTRYUSB_AP profile exists. Setup creates it (AP enabled
+/// in the wizard) and deletes it (AP unchecked) — the UI uses this to grey
+/// out the Away Mode card when the feature is unconfigured. On ifupdown
+/// systems we look for both the hostapd config AND the interfaces.d stanza
+/// so a half-installed AP doesn't read as "configured".
 async fn ap_profile_exists() -> bool {
-    sentryusb_shell::run("nmcli", &["-t", "con", "show", AP_PROFILE])
-        .await
-        .map(|o| !o.trim().is_empty())
-        .unwrap_or(false)
+    if use_networkmanager() {
+        sentryusb_shell::run("nmcli", &["-t", "con", "show", AP_PROFILE])
+            .await
+            .map(|o| !o.trim().is_empty())
+            .unwrap_or(false)
+    } else {
+        std::path::Path::new(HOSTAPD_CONF).exists()
+            && std::path::Path::new(IFUPDOWN_AP_FILE).exists()
+    }
 }
 
 async fn get_ap_info() -> (String, String) {
-    let out = match sentryusb_shell::run(
-        "nmcli",
-        &["-t", "-f", "802-11-wireless.ssid,ipv4.addresses", "con", "show", AP_PROFILE],
-    )
-    .await
-    {
-        Ok(o) => o,
-        Err(_) => return (String::new(), String::new()),
-    };
-    let mut ssid = String::new();
-    let mut ip = String::new();
-    for line in out.lines() {
-        let line = line.trim();
-        if let Some(rest) = line.strip_prefix("802-11-wireless.ssid:") {
-            ssid = rest.to_string();
-        } else if let Some(rest) = line.strip_prefix("ipv4.addresses:") {
-            ip = rest.to_string();
-            if let Some(idx) = ip.find('/') {
-                ip.truncate(idx);
+    if use_networkmanager() {
+        let out = match sentryusb_shell::run(
+            "nmcli",
+            &["-t", "-f", "802-11-wireless.ssid,ipv4.addresses", "con", "show", AP_PROFILE],
+        )
+        .await
+        {
+            Ok(o) => o,
+            Err(_) => return (String::new(), String::new()),
+        };
+        let mut ssid = String::new();
+        let mut ip = String::new();
+        for line in out.lines() {
+            let line = line.trim();
+            if let Some(rest) = line.strip_prefix("802-11-wireless.ssid:") {
+                ssid = rest.to_string();
+            } else if let Some(rest) = line.strip_prefix("ipv4.addresses:") {
+                ip = rest.to_string();
+                if let Some(idx) = ip.find('/') {
+                    ip.truncate(idx);
+                }
             }
         }
+        (ssid, ip)
+    } else {
+        // ifupdown path: SSID from hostapd.conf, IP from the interfaces.d
+        // stanza. Reading files directly avoids spawning subprocesses on
+        // hot paths (status poll runs every 30s).
+        let mut ssid = String::new();
+        let mut ip = String::new();
+        if let Ok(content) = std::fs::read_to_string(HOSTAPD_CONF) {
+            for line in content.lines() {
+                if let Some(rest) = line.strip_prefix("ssid=") {
+                    ssid = rest.trim().to_string();
+                    break;
+                }
+            }
+        }
+        if let Ok(content) = std::fs::read_to_string(IFUPDOWN_AP_FILE) {
+            for line in content.lines() {
+                let l = line.trim();
+                if let Some(rest) = l.strip_prefix("address ") {
+                    ip = rest.trim().to_string();
+                    break;
+                }
+            }
+        }
+        (ssid, ip)
     }
-    (ssid, ip)
 }
 
 fn spawn_watcher(stop: std::sync::Arc<Notify>, my_epoch: u64) {

--- a/install-pi.sh
+++ b/install-pi.sh
@@ -344,7 +344,66 @@ if ! grep -q SENTRYUSB_TIP1 /root/.bashrc 2>/dev/null; then
     ok "Added remountfs_rw reminder to /root/.bashrc"
 fi
 
-# ── Step 3e: Rock Pi 4C+ (RK3399 / dwc3) hardware setup ────────────────────
+# ── Step 3e: ifupdown AP resurrector (away_mode + archiveloop coexistence) ──
+# archiveloop's wifi_cycle() tears down ap0 every ~5 min to free the radio for
+# wlan0 to scan/reconnect (single-radio chipset — STA scans need exclusive
+# channel access). On NetworkManager systems, /etc/NetworkManager/dispatcher.d/
+# 10-sentryusb-ap re-runs `nmcli con up SENTRYUSB_AP` when wlan0 comes back.
+# On ifupdown systems (DietPi/Armbian) there's no equivalent hook, so once
+# archiveloop deletes ap0 the AP stays dead until reboot. This watcher is the
+# ifupdown counterpart: re-up via `ifup ap0` when ap0 is missing OR exists
+# but hostapd died. Self-gates on /mutable/sentryusb_away_mode.json (Away Mode
+# active) and on the /etc/network/interfaces.d/sentryusb-ap config existing,
+# so the unit is a no-op on NM systems and when Away Mode is off.
+cat > /usr/local/bin/sentryusb-ap-resurrect <<'RESURRECT'
+#!/bin/bash
+# ifupdown counterpart to /etc/NetworkManager/dispatcher.d/10-sentryusb-ap:
+# bring ap0 back when archiveloop's wifi_cycle tears it down mid-session.
+while true; do
+  if systemctl is-active --quiet NetworkManager.service; then
+    sleep 30; continue
+  fi
+  if [ ! -f /etc/network/interfaces.d/sentryusb-ap ]; then
+    sleep 30; continue
+  fi
+  if [ -f /mutable/sentryusb_away_mode.json ] \
+     && ip link show wlan0 2>/dev/null | grep -q 'state UP'; then
+    if ! ip -o link show ap0 >/dev/null 2>&1; then
+      logger -t sentryusb-ap-resurrect "ap0 missing — ifup ap0"
+      ifdown ap0 2>/dev/null
+      ifup ap0 2>&1 | logger -t sentryusb-ap-resurrect
+    elif ! pgrep -f hostapd.conf >/dev/null 2>&1; then
+      logger -t sentryusb-ap-resurrect "ap0 up but hostapd dead — bounce"
+      ifdown ap0 2>/dev/null
+      iw dev ap0 del 2>/dev/null
+      ifup ap0 2>&1 | logger -t sentryusb-ap-resurrect
+    fi
+  fi
+  sleep 5
+done
+RESURRECT
+chmod +x /usr/local/bin/sentryusb-ap-resurrect
+
+cat > /etc/systemd/system/sentryusb-ap-resurrect.service <<'UNIT'
+[Unit]
+Description=SentryUSB: re-up ap0 after archiveloop wifi_cycle (ifupdown only)
+After=network.target sentryusb.service
+Wants=sentryusb.service
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/sentryusb-ap-resurrect
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+systemctl daemon-reload >/dev/null 2>&1 || true
+systemctl enable --now sentryusb-ap-resurrect.service >/dev/null 2>&1 || true
+ok "Installed sentryusb-ap-resurrect.service (ifupdown AP wifi_cycle resilience)"
+
+# ── Step 3f: Rock Pi 4C+ (RK3399 / dwc3) hardware setup ────────────────────
 # A NO-OP on Raspberry Pi and every non-4C+ board (detection-gated). On a Rock
 # Pi 4C+ a generic install leaves three things broken, all fixed here so SC works
 # with WiFi + BLE out of the box:

--- a/install-pi.sh
+++ b/install-pi.sh
@@ -13,7 +13,7 @@
 # Or with a local binary:
 #   bash install-pi.sh /path/to/sentryusb-binary
 
-REPO="Sentry-Six/Sentry-USB-Rusty"
+REPO="${REPO:-Sentry-Six/Sentry-USB-Rusty}"
 INSTALL_DIR="/opt/sentryusb"
 BINARY_NAME="sentryusb"
 


### PR DESCRIPTION
## Problem
Away Mode's AP enable/disable code shells out to `nmcli`. On any image that runs ifupdown instead of NetworkManager (DietPi, Armbian, …) `nmcli` isn't installed, the calls silently fail, and the user is stuck with whatever AP state they were in. It's the long-standing "Unable to disable AP" problem from marcone/teslausb#826 — it's been around since the Pi Zero 2 W days.

There's a related class of bug: BCM43455-family chips (Raspberry Pi 4 / 5 / Zero 2 W / CM4, plus the Rock Pi 4C+'s BCM4345C0/AP6256) can only host the AP and the STA on the **same channel**. NetworkManager doesn't enforce that, which is what marcone/teslausb#921 reports — when NM picks 2.4 for AP while STA is on 5 (or vice versa) the chip silently drops one of them and the upstream WiFi dies. The hostapd path lets us pick the channel explicitly, which sidesteps the whole class of bugs.

There's also an archiveloop interaction on the ifupdown path: `wifi_cycle()` tears down ap0 every ~5 min to free the radio for wlan0 to scan/reconnect. On NetworkManager systems, `/etc/NetworkManager/dispatcher.d/10-sentryusb-ap` re-runs `nmcli con up SENTRYUSB_AP` when wlan0 reassociates. There's no equivalent ifupdown hook, so once wifi_cycle deletes ap0 the AP stays dead until reboot.

## Fix
Three pieces:

1. **away_mode.rs runtime branch.** Detect which backend is in charge with `systemctl --quiet is-active NetworkManager.service` and branch the four AP-touching functions. NM path is 100% byte-identical to before. ifupdown path reads `iw wlan0 info` for the STA's current channel/band, rewrites `channel=`/`hw_mode=` in `/etc/hostapd/hostapd.conf`, then runs `ifup ap0` (or `ifdown ap0` to stop). Defaults to 5GHz channel 36 when wlan0 isn't associated.

2. **`sentryusb-ap-resurrect` service** (installer step 3e). Polls every 5s; when Away Mode is active and wlan0 is up but ap0 is missing (or exists but hostapd died), runs `ifup ap0` to restore. Self-gates on NetworkManager being inactive AND the `/etc/network/interfaces.d/sentryusb-ap` config existing — no-op on NM systems and when Away Mode is off.

3. **`REPO` env override** (installer line 16). One-line change so fork pre-releases can pipe install-pi.sh: `REPO=user/fork curl -fsSL .../install-pi.sh | bash` now pulls the fork's binaries + writes the matching version stamp.

## Validation
Tested end-to-end on a fresh DietPi Trixie SD on a Rock Pi 4C+ (BCM4345C0). Test rig has `hostapd`, `dnsmasq` and `iw` installed, with `/etc/hostapd/hostapd.conf`, `/etc/dnsmasq.d/sentryusb-ap.conf`, and `/etc/network/interfaces.d/sentryusb-ap` staged.

**Runtime AP toggle:**
- `POST /api/away-mode/enable` → ap0 up at 192.168.66.1, type AP channel 153 (5GHz, matched STA's channel automatically). hostapd + dnsmasq active. STA stayed up; signal unchanged.
- `POST /api/away-mode/disable` → ap0 cleanly torn down, hostapd/dnsmasq inactive, STA still connected.
- Safety `at` job armed before each test as fallback; both passed without it firing.

**wifi_cycle resilience:**
- Case A (`iw dev ap0 del`) → resurrector log `case A: ap0 missing — ifup` → ap0 back + hostapd respawned.
- Case B (`killall hostapd`) → resurrector log `case B: ap0 up but hostapd dead — bounce` → ap0 back + hostapd respawned.

## Note on this PR's lineage
This replaces #96 — same code, same testing, fresh PR opened to ensure no stale revision data hangs around. The original #96 was scrubbed but GitHub PR edit history is permanent, so a fresh PR was the cleaner path.

## Known gap (follow-up PR)
This patch covers the runtime toggle. `setup/pi/configure-ap.sh`'s wpa_supplicant fallback still writes destructively to `/etc/network/interfaces` and `/etc/wpa_supplicant/wpa_supplicant.conf` — a separate PR will land a non-destructive setup path that writes a drop-in to `/etc/network/interfaces.d/sentryusb-ap` and hostapd.conf with channel-detection-aware defaults.