### PR TITLE
fix(update): re-apply install-time patches after OTA binary swap

### DIFF
--- a/crates/api/src/update.rs
+++ b/crates/api/src/update.rs
@@ -684,6 +684,42 @@ async fn self_update(target_version: Option<String>) -> anyhow::Result<String> {
     // confusion we hit on the Rock Pi 4C+ tester. Surface failures
     // here so the user knows to investigate (usually: read-only
     // rootfs needs a remount, or a release missing one of the assets).
+    // ── Re-apply install-time patches that must survive an OTA swap ──
+    //
+    // The standalone /usr/local/bin/sentryusb-apply-runtime-patches script
+    // ships with install-pi.sh and re-applies things the binary swap can't
+    // own — e.g. the BCM4345C0 non-fatal-adv patch to /root/bin/sentryusb-ble.py
+    // on Rock 4C+ which otherwise crash-loops the BLE daemon after every
+    // update. The script is idempotent + detection-gated, so it's a no-op on
+    // non-4C+ boards and a no-op on already-patched files. Best-effort: a
+    // missing script (older install that pre-dates this scheme) just yields
+    // a warning instead of failing the whole update.
+    if std::path::Path::new("/usr/local/bin/sentryusb-apply-runtime-patches").exists() {
+        match sentryusb_shell::run_with_timeout(
+            std::time::Duration::from_secs(30),
+            "/usr/local/bin/sentryusb-apply-runtime-patches",
+            &[],
+        )
+        .await
+        {
+            Ok(_) => tracing::info!("update.rs: runtime-patches re-applied successfully"),
+            Err(e) => install_warnings.push(format!(
+                "runtime-patches re-apply FAILED: {e} — board-specific fixes \
+                 (BCM4345C0 BLE on Rock 4C+, etc.) may not survive this update; \
+                 if BLE pairing is broken after this update, re-run install-pi.sh"
+            )),
+        }
+    } else {
+        // Pre-v3.11.3 installs don't have the runtime-patches script. Surface
+        // as a warning so 4C+ owners know to re-run install-pi.sh once to
+        // pick up the new auto-heal scheme.
+        install_warnings.push(
+            "runtime-patches script missing — install-time fixes won't auto-reapply on future \
+             updates. Re-run install-pi.sh once to land the new auto-heal scheme."
+                .to_string(),
+        );
+    }
+
     if install_warnings.is_empty() {
         Ok(format!(
             "Updated to {}.",

--- a/install-pi.sh
+++ b/install-pi.sh
@@ -344,6 +344,30 @@ if ! grep -q SENTRYUSB_TIP1 /root/.bashrc 2>/dev/null; then
     ok "Added remountfs_rw reminder to /root/.bashrc"
 fi
 
+# ── Step 3d2: install the runtime-patches script (called by OTA updater) ──
+# Universal — runs for everyone; the script self-detects 4C+ inside. Lives
+# at a stable path the Rust binary's update.rs invokes after every binary
+# swap so install-time fixes (BLE non-fatal-adv on BCM4345C0, etc.) heal
+# automatically on update instead of silently rotting.
+PATCHES_URL="https://raw.githubusercontent.com/${REPO}/main/setup/pi/apply-runtime-patches.sh"
+PATCHES_DST="/usr/local/bin/sentryusb-apply-runtime-patches"
+PATCHES_LOCAL="$(dirname "${1:-/dev/null}")/setup/pi/apply-runtime-patches.sh"
+if [ -f "$PATCHES_LOCAL" ]; then
+    install -m 755 "$PATCHES_LOCAL" "$PATCHES_DST"
+    ok "Runtime-patches script installed from local path"
+elif curl -fsSL --max-time 10 "$PATCHES_URL" -o "$PATCHES_DST" 2>/dev/null; then
+    chmod +x "$PATCHES_DST"
+    ok "Runtime-patches script downloaded to $PATCHES_DST"
+else
+    warn "Could not fetch runtime-patches script — OTA updates won't re-apply 4C+ BLE fix"
+fi
+# Run it once now so first-install applies patches without waiting for the
+# first OTA update. The script's per-patch detection-gates make this a
+# no-op on non-applicable boards.
+if [ -x "$PATCHES_DST" ]; then
+    "$PATCHES_DST" || warn "runtime-patches first-run reported issues — see output above"
+fi
+
 # ── Step 3e: ifupdown AP resurrector (away_mode + archiveloop coexistence) ──
 # archiveloop's wifi_cycle() tears down ap0 every ~5 min to free the radio for
 # wlan0 to scan/reconnect (single-radio chipset — STA scans need exclusive
@@ -523,54 +547,12 @@ DTS
     #     BlueZ adv failure; (ii) a helper programs legacy ADV_IND @ 100ms directly
     #     over raw HCI (SC then connects to the real MAC + authenticates); (iii) start
     #     event-driven when hci0 appears (UART BT attaches late on cold boot).
-    BLE_PY=/root/bin/sentryusb-ble.py
-    if [ -f "$BLE_PY" ] && ! grep -q 'legacy btmgmt advertising' "$BLE_PY"; then
-        # Capture the patcher's stdout so we can tell "patched" from
-        # "anchor-not-found" — the previous version printed an unconditional
-        # OK after the heredoc and silently shipped images where the patch
-        # never applied (observed on the v3.11.1 bench install: GATT crashed
-        # 320+ times in a row because register_ad_error_cb still sys.exit'd
-        # on the BCM4345C0's Invalid Params 0x0d adv rejection).
-        PATCH_RESULT="$(python3 - "$BLE_PY" 2>&1 <<'PYEOF'
-import sys
-p = sys.argv[1]; s = open(p).read()
-a = s.find('def register_ad_error_cb(error):'); b = s.find('\ndef register_app_cb', a)
-if a >= 0 and b >= 0:
-    cb = ("def register_ad_error_cb(error):\n"
-          "    # BCM4345C0 (Rock 4C+): BlueZ uses EXTENDED advertising which this chip\n"
-          "    # rejects ('Invalid Parameters 0x0d'). Do NOT exit (that tears down GATT\n"
-          "    # and loops forever); keep GATT up. Legacy btmgmt advertising is enabled\n"
-          "    # out-of-band by sentryusb-ble-adv.service.\n"
-          "    log.warning(f'BlueZ advertisement registration failed ({error}); '\n"
-          "                'using legacy btmgmt advertising instead; GATT stays up.')\n")
-    open(p, 'w').write(s[:a] + cb + s[b+1:]); print('patched')
-else:
-    print('anchor-not-found')
-PYEOF
-)" || PATCH_RESULT="python-error"
-        # Verify the file actually contains the patch marker post-run. The
-        # patcher's stdout AND a content check both have to agree, otherwise
-        # SC discovery + BLE pairing silently break on every 4C+ install.
-        if [ "$PATCH_RESULT" = "patched" ] && grep -q 'legacy btmgmt advertising' "$BLE_PY"; then
-            ok "Patched sentryusb-ble.py: BlueZ adv failure no longer kills the GATT server"
-        else
-            warn "sentryusb-ble.py patch did NOT apply ($PATCH_RESULT) — falling back to sed"
-            # sed fallback: replace the whole register_ad_error_cb body line by
-            # line. Less surgical than the AST-aware Python path, but it lands
-            # the same marker so SC can be sure the patch is live.
-            sed -i '/^def register_ad_error_cb(error):$/,/^def register_app_cb/{
-                /^def register_ad_error_cb(error):$/!{
-                    /^def register_app_cb/!d
-                }
-            }' "$BLE_PY"
-            sed -i '/^def register_ad_error_cb(error):$/a\    log.warning(f"BlueZ advertisement registration failed ({error}); using legacy btmgmt advertising instead; GATT stays up.")\n' "$BLE_PY"
-            if grep -q 'legacy btmgmt advertising' "$BLE_PY"; then
-                ok "Patched sentryusb-ble.py via sed fallback"
-            else
-                warn "BOTH patch paths failed — SC discovery may be broken on this 4C+ install"
-            fi
-        fi
-    fi
+    # The actual BLE non-fatal-adv patch lives in a standalone script
+    # (sentryusb-apply-runtime-patches.sh) that is ALSO invoked by the
+    # Rust binary's in-app updater after every OTA swap — so existing
+    # users heal automatically on update instead of needing a re-install.
+    # Installed below in the universal section; the call here just primes
+    # the patch state for first-install.
     cat > /usr/local/bin/sentryusb-ble-adv.sh <<'ADVSH'
 #!/bin/bash
 # Legacy ADV_IND advertiser for BCM4345C0. BlueZ's mgmt path is unreliable on

--- a/setup/pi/apply-runtime-patches.sh
+++ b/setup/pi/apply-runtime-patches.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+# sentryusb-apply-runtime-patches.sh
+#
+# Idempotent re-application of all install-time patches that must survive
+# a binary OTA update. Called by:
+#   - install-pi.sh        — initial install / re-install via curl
+#   - crates/api/src/update.rs — after every in-app binary swap
+#
+# Why this exists: the in-app updater (Settings → System → Check for
+# Updates) only swaps the Rust binary. It does NOT re-run install-pi.sh.
+# So install-time fixes (BLE non-fatal-adv on BCM4345C0, etc.) that are
+# applied to shipped scripts on disk silently rot the moment a release
+# replaces those scripts — leaving every existing 4C+ user with a
+# crash-looped Bluetooth stack after their first update.
+#
+# This script is the bridge: it re-applies the patches every time the
+# updater runs, so existing installs heal automatically on update without
+# needing a re-install.
+#
+# Detection-gated: each patch's apply-block self-checks for the board /
+# precondition it cares about, so running on a Pi 4 or Pi 5 (or amd64
+# dev box) is a no-op.
+#
+# Safe to re-run anytime: every patch first checks if the marker is
+# already present in the target file.
+
+set -u
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NC='\033[0m'
+
+log()  { echo -e "${GREEN}[patches]${NC} $1"; }
+warn() { echo -e "${YELLOW}[patches]${NC} $1" >&2; }
+err()  { echo -e "${RED}[patches]${NC} $1" >&2; }
+
+# ── Detection helpers ────────────────────────────────────────────────────
+
+is_rock_4cplus() {
+    grep -qai 'rock-4c-plus\|rockpi4c-plus\|ROCK 4C+' \
+        /proc/device-tree/model /proc/device-tree/compatible 2>/dev/null
+}
+
+# ── BLE non-fatal-adv patch (Rock 4C+ / BCM4345C0) ──────────────────────
+#
+# The BCM4345C0 firmware rejects BlueZ extended advertising with "Invalid
+# Parameters (0x0d)". The shipped sentryusb-ble.py calls sys.exit(1) on
+# that error, which tears down GATT and lets systemd re-spawn the daemon
+# in a fast crash loop. The Pi's actual advertising is handled out-of-band
+# by sentryusb-ble-adv.service via raw HCI, so the BlueZ failure is
+# legitimately non-fatal for our use case — we just need the GATT server
+# to stay up. Patch swallows the BlueZ adv error and logs it instead.
+apply_ble_nonfatal_adv() {
+    is_rock_4cplus || return 0
+    local f=/root/bin/sentryusb-ble.py
+    [ -f "$f" ] || { warn "BLE: $f missing — skipping non-fatal-adv patch"; return 0; }
+
+    if grep -q 'legacy btmgmt advertising' "$f"; then
+        log "BLE non-fatal-adv: already patched"
+        return 0
+    fi
+
+    # Make root RW for the write (no-op if already RW). Shipped by
+    # install-pi.sh; safe to call here.
+    [ -x /root/bin/remountfs_rw ] && /root/bin/remountfs_rw >/dev/null 2>&1 || true
+
+    # AST-aware Python patcher: surgically replaces register_ad_error_cb.
+    local result
+    result="$(python3 - "$f" 2>&1 <<'PYEOF'
+import sys
+p = sys.argv[1]; s = open(p).read()
+a = s.find('def register_ad_error_cb(error):'); b = s.find('\ndef register_app_cb', a)
+if a >= 0 and b >= 0:
+    cb = ("def register_ad_error_cb(error):\n"
+          "    # BCM4345C0 (Rock 4C+): BlueZ uses EXTENDED advertising which this chip\n"
+          "    # rejects ('Invalid Parameters 0x0d'). Do NOT exit (that tears down GATT\n"
+          "    # and loops forever); keep GATT up. Legacy btmgmt advertising is enabled\n"
+          "    # out-of-band by sentryusb-ble-adv.service.\n"
+          "    log.warning(f'BlueZ advertisement registration failed ({error}); '\n"
+          "                'using legacy btmgmt advertising instead; GATT stays up.')\n")
+    open(p, 'w').write(s[:a] + cb + s[b+1:]); print('patched')
+else:
+    print('anchor-not-found')
+PYEOF
+)" || result="python-error"
+
+    if [ "$result" = "patched" ] && grep -q 'legacy btmgmt advertising' "$f"; then
+        log "BLE non-fatal-adv: applied via Python patcher"
+    else
+        warn "BLE non-fatal-adv: Python path failed ($result), trying sed fallback"
+        # sed fallback rewrites register_ad_error_cb body line by line
+        sed -i '/^def register_ad_error_cb(error):$/,/^def register_app_cb/{
+            /^def register_ad_error_cb(error):$/!{
+                /^def register_app_cb/!d
+            }
+        }' "$f"
+        sed -i '/^def register_ad_error_cb(error):$/a\    log.warning(f"BlueZ advertisement registration failed ({error}); using legacy btmgmt advertising instead; GATT stays up.")\n' "$f"
+        if grep -q 'legacy btmgmt advertising' "$f"; then
+            log "BLE non-fatal-adv: applied via sed fallback"
+        else
+            err  "BLE non-fatal-adv: BOTH patch paths failed — SC discovery may be broken on this 4C+ install"
+            return 1
+        fi
+    fi
+
+    # Restart the daemon so the patched version takes effect immediately
+    # rather than waiting for the next reboot. reset-failed clears any
+    # crash-loop backoff from the broken pre-patch state.
+    systemctl reset-failed sentryusb-ble.service 2>/dev/null || true
+    systemctl restart sentryusb-ble.service 2>/dev/null || true
+    return 0
+}
+
+# ── Run all patches ─────────────────────────────────────────────────────
+
+apply_ble_nonfatal_adv
+
+# Future patches that must survive an OTA update get appended here. Each
+# one self-checks board / precondition / marker so the whole script stays
+# a safe no-op on non-applicable systems.


### PR DESCRIPTION
## Problem

The in-app Software Update flow only swaps the Rust binary; it never re-runs the install-time patches that live in shipped scripts on disk. So whenever a release ships a new `server/ble/sentryusb-ble.py` (which the binary swap pulls along with the release), patches like the BCM4345C0 non-fatal-adv patch on Rock 4C+ silently rot, and every existing 4C+ user wakes up to a crash-looped BLE daemon after their first Software Update.

Observed live: v3.11.1 → v3.11.2 OTA upgrade on a Rock 4C+ left `sentryusb-ble.service` in a permanent crash loop, SC could never hold a BLE connection, the dashboard "Bluetooth Control" sheet froze on "Reading device status…" forever.

## Fix

Lift the patch logic into a standalone idempotent script:
- New file: `setup/pi/apply-runtime-patches.sh`
- Installed to `/usr/local/bin/sentryusb-apply-runtime-patches` by `install-pi.sh`
- Each patch self-detects board / precondition / marker — safe no-op on non-applicable systems and already-patched files
- Called by both `install-pi.sh` and `update.rs` after every binary swap

Existing installs heal automatically on next update. Future patches just append to the script.

If the script is missing (pre-v3.11.3 installs), `update.rs` surfaces a warning telling the user to re-run install-pi.sh once to pick up the new auto-heal scheme.