### PR TITLE
fix(update): bootstrap the runtime-patches script if missing

### DIFF
--- a/crates/api/src/update.rs
+++ b/crates/api/src/update.rs
@@ -687,17 +687,57 @@ async fn self_update(target_version: Option<String>) -> anyhow::Result<String> {
     // ── Re-apply install-time patches that must survive an OTA swap ──
     //
     // The standalone /usr/local/bin/sentryusb-apply-runtime-patches script
-    // ships with install-pi.sh and re-applies things the binary swap can't
-    // own — e.g. the BCM4345C0 non-fatal-adv patch to /root/bin/sentryusb-ble.py
-    // on Rock 4C+ which otherwise crash-loops the BLE daemon after every
-    // update. The script is idempotent + detection-gated, so it's a no-op on
-    // non-4C+ boards and a no-op on already-patched files. Best-effort: a
-    // missing script (older install that pre-dates this scheme) just yields
-    // a warning instead of failing the whole update.
-    if std::path::Path::new("/usr/local/bin/sentryusb-apply-runtime-patches").exists() {
+    // re-applies things the binary swap can't own — e.g. the BCM4345C0
+    // non-fatal-adv patch to /root/bin/sentryusb-ble.py on Rock 4C+ which
+    // otherwise crash-loops the BLE daemon after every update. The script
+    // is idempotent + detection-gated, so it's a no-op on non-applicable
+    // boards and a no-op on already-patched files.
+    //
+    // Bootstrap: the script first ships in v3.11.4. Users updating from a
+    // pre-v3.11.4 release won't have it on disk yet — fetch it from the
+    // repo BEFORE running so the very first auto-heal cycle works. The
+    // script lives at a stable URL (main branch, setup/pi/) so it's
+    // fetchable as long as the repo is reachable.
+    let patches_path = "/usr/local/bin/sentryusb-apply-runtime-patches";
+    if !std::path::Path::new(patches_path).exists() {
+        let patches_url = format!(
+            "https://raw.githubusercontent.com/{}/main/setup/pi/apply-runtime-patches.sh",
+            repo
+        );
+        tracing::info!(
+            "update.rs: runtime-patches script missing — bootstrapping from {}",
+            patches_url
+        );
+        match sentryusb_shell::run_with_timeout(
+            std::time::Duration::from_secs(20),
+            "curl",
+            &[
+                "-fsSL",
+                "--max-time",
+                "15",
+                "-o",
+                patches_path,
+                &patches_url,
+            ],
+        )
+        .await
+        {
+            Ok(_) => {
+                let _ = sentryusb_shell::run("chmod", &["+x", patches_path]).await;
+                tracing::info!("update.rs: runtime-patches script bootstrapped");
+            }
+            Err(e) => install_warnings.push(format!(
+                "runtime-patches bootstrap FAILED ({e}): board-specific fixes \
+                 (BCM4345C0 BLE on Rock 4C+, etc.) won't auto-reapply after this \
+                 update. Re-run install-pi.sh manually if BLE pairing breaks."
+            )),
+        }
+    }
+
+    if std::path::Path::new(patches_path).exists() {
         match sentryusb_shell::run_with_timeout(
             std::time::Duration::from_secs(30),
-            "/usr/local/bin/sentryusb-apply-runtime-patches",
+            patches_path,
             &[],
         )
         .await
@@ -709,15 +749,6 @@ async fn self_update(target_version: Option<String>) -> anyhow::Result<String> {
                  if BLE pairing is broken after this update, re-run install-pi.sh"
             )),
         }
-    } else {
-        // Pre-v3.11.3 installs don't have the runtime-patches script. Surface
-        // as a warning so 4C+ owners know to re-run install-pi.sh once to
-        // pick up the new auto-heal scheme.
-        install_warnings.push(
-            "runtime-patches script missing — install-time fixes won't auto-reapply on future \
-             updates. Re-run install-pi.sh once to land the new auto-heal scheme."
-                .to_string(),
-        );
     }
 
     if install_warnings.is_empty() {


### PR DESCRIPTION
## Problem

The runtime-patches script (added in #100, intended to re-apply install-time fixes after every OTA) was only installed by `install-pi.sh` — never by the OTA path. So when a Pi updated from v3.11.2 → v3.11.3 via the web UI, the new Rust binary tried to invoke the heal script, didn't find it, and silently no-op'd.

Meanwhile the same OTA refreshed `/root/bin/sentryusb-ble.py` (which the binary pulls along) and wiped the BCM4345C0 non-fatal-adv patch. Net result on Rock 4C+: v3.11.3 OTA landed in the exact crash loop v3.11.3 was supposed to prevent.

## Fix

When the runtime-patches script is missing locally, fetch it from `https://raw.githubusercontent.com/$REPO/main/setup/pi/apply-runtime-patches.sh` before invoking it. Bootstrap-once: only the first OTA after upgrading from a pre-v3.11.4 release actually downloads. Idempotent for everyone else.

## Test

Deleted the bootstrapped script from a working 4C+ post-v3.11.3 to simulate a pre-v3.11.4 install. Forced re-update via `POST /api/system/update`. Watched journalctl: update.rs fetched the script + immediately re-applied the BLE patch in the same cycle. `sentryusb-ble` came back stable, NRestarts=0.