### PR TITLE
fix(migrate): re-apply runtime patches after startup migration

### DIFF
--- a/crates/sentryusb/src/migrate.rs
+++ b/crates/sentryusb/src/migrate.rs
@@ -71,6 +71,35 @@ pub async fn run_startup_migration() {
         .await
         {
             Ok(_) => {
+                // Re-apply runtime patches AFTER the migration. The migration
+                // script unconditionally rewrites /root/bin/sentryusb-ble.py
+                // from the upstream tarball — which silently undoes board-
+                // specific fixes the OTA updater already applied (BCM4345C0
+                // non-fatal-adv on Rock 4C+ is the headline case: OTA patches
+                // ble.py → reboot → this migration unpatches it → BLE crash
+                // loop on next start). Invoke the standalone runtime-patches
+                // script (idempotent + detection-gated) so the patches survive
+                // every migration. Best-effort: a missing script just yields
+                // an info log — the OTA flow's bootstrap path will populate
+                // it on the next update.
+                if std::path::Path::new("/usr/local/bin/sentryusb-apply-runtime-patches").exists() {
+                    match sentryusb_shell::run_with_timeout(
+                        Duration::from_secs(30),
+                        "/usr/local/bin/sentryusb-apply-runtime-patches",
+                        &[],
+                    )
+                    .await
+                    {
+                        Ok(_) => info!("[migrate] runtime-patches re-applied post-migration"),
+                        Err(e) => warn!(
+                            "[migrate] runtime-patches post-migration run failed: {} — BLE pairing may be broken on Rock 4C+",
+                            e
+                        ),
+                    }
+                } else {
+                    info!("[migrate] runtime-patches script not present (pre-bootstrap install) — skipping; OTA path will populate it");
+                }
+
                 let _ = tokio::fs::create_dir_all(MIGRATE_DIR).await;
                 if let Err(e) = tokio::fs::write(&marker_file, b"migrated\n").await {
                     warn!("[migrate] Failed to write marker {}: {}", marker_file, e);


### PR DESCRIPTION
## Problem

`run_startup_migration()` (called on every binary startup) downloads the GitHub repo tarball for the current version and **unconditionally rewrites** `/root/bin/sentryusb-ble.py` from that tarball. This silently undoes any board-specific patches the OTA updater applied just before reboot.

On Rock 4C+ the timing is exactly:
1. OTA `self_update` swaps the Rust binary + invokes `/usr/local/bin/sentryusb-apply-runtime-patches` → patches `ble.py` ✓
2. OTA reboots the Pi
3. New binary boots, calls `run_startup_migration()` → re-fetches tarball → overwrites `ble.py` with unpatched upstream
4. BLE service starts, hits `sys.exit(1)` on every BlueZ advertisement rejection → crash loop

That's the loop v3.11.3 + v3.11.4 was supposed to prevent. Caught via `strings -a` on the live v3.11.4 binary (confirmed it has the bootstrap+invocation code) cross-referenced with the journal showing no patches log entry.

## Fix

Invoke `/usr/local/bin/sentryusb-apply-runtime-patches` immediately after the migration's tarball write succeeds (line 73-80 region). The script is:

- **Idempotent** — re-applying on an already-patched file is a no-op
- **Detection-gated** — non-4C+ boards return immediately
- **Best-effort** — a missing script (pre-bootstrap install) logs an info and continues; the OTA flow's bootstrap path populates it on the next update

Closes the patch-survival loop end-to-end.