### PR TITLE
fix(patches): make EATT-disable universal + heal on OTA

### DIFF
--- a/install-pi.sh
+++ b/install-pi.sh
@@ -249,25 +249,9 @@ else
     warn "Could not fetch BLE daemon — iOS app pairing will be unavailable"
 fi
 
-# ── Step 3b2: Disable EATT (no recurring BLE pairing prompt) ────────
-# The BLE GATT is app-PIN over plain (unencrypted) ATT, but a phone's EATT
-# (PSM 0x0027) open needs an encrypted link — bluetoothd refuses it and sends an
-# SMP Security Request, popping a pair prompt on every connect. Channels=1 keeps
-# plain ATT (same GATT), so no prompt. Safe on all boards (no security change).
-MAIN_CONF=/etc/bluetooth/main.conf
-if [ -f "$MAIN_CONF" ] && ! grep -qE '^Channels[[:space:]]*=[[:space:]]*1' "$MAIN_CONF"; then
-    if grep -qE '^\[GATT\]' "$MAIN_CONF"; then
-        if grep -qiE '^[# ]*Channels' "$MAIN_CONF"; then
-            sed -i -E 's/^[# ]*Channels[ ]*=.*/Channels = 1/' "$MAIN_CONF"
-        else
-            sed -i '/^\[GATT\]/a Channels = 1' "$MAIN_CONF"
-        fi
-    else
-        printf '\n[GATT]\nChannels = 1\n' >> "$MAIN_CONF"
-    fi
-    systemctl restart bluetooth 2>/dev/null || true
-    ok "EATT disabled (no recurring BLE pairing prompt)"
-fi
+# Step 3b2 (EATT disable) moved to setup/pi/apply-runtime-patches.sh
+# so existing pre-v3.11.x installs heal automatically on OTA. Step 3d2
+# installs that helper and runs it.
 
 # ── Step 3c: archiveloop ↔ gadget shim scripts ─────────────────────
 #
@@ -345,10 +329,11 @@ if ! grep -q SENTRYUSB_TIP1 /root/.bashrc 2>/dev/null; then
 fi
 
 # ── Step 3d2: install the runtime-patches script (called by OTA updater) ──
-# Universal — runs for everyone; the script self-detects 4C+ inside. Lives
-# at a stable path the Rust binary's update.rs invokes after every binary
-# swap so install-time fixes (BLE non-fatal-adv on BCM4345C0, etc.) heal
-# automatically on update instead of silently rotting.
+# Universal — runs for everyone; each patch inside self-detects its own
+# precondition (board, file presence, etc.). Lives at a stable path the
+# Rust binary's update.rs invokes after every binary swap so install-time
+# fixes — BLE non-fatal-adv on BCM4345C0 (4C+), EATT disable on all
+# boards, etc. — heal automatically on update instead of silently rotting.
 PATCHES_URL="https://raw.githubusercontent.com/${REPO}/main/setup/pi/apply-runtime-patches.sh"
 PATCHES_DST="/usr/local/bin/sentryusb-apply-runtime-patches"
 PATCHES_LOCAL="$(dirname "${1:-/dev/null}")/setup/pi/apply-runtime-patches.sh"
@@ -359,7 +344,7 @@ elif curl -fsSL --max-time 10 "$PATCHES_URL" -o "$PATCHES_DST" 2>/dev/null; then
     chmod +x "$PATCHES_DST"
     ok "Runtime-patches script downloaded to $PATCHES_DST"
 else
-    warn "Could not fetch runtime-patches script — OTA updates won't re-apply 4C+ BLE fix"
+    warn "Could not fetch runtime-patches script — OTA updates won't re-apply BLE patches"
 fi
 # Run it once now so first-install applies patches without waiting for the
 # first OTA update. The script's per-patch detection-gates make this a

--- a/setup/pi/apply-runtime-patches.sh
+++ b/setup/pi/apply-runtime-patches.sh
@@ -112,9 +112,51 @@ PYEOF
     return 0
 }
 
+# ── EATT disable (all Pi boards) ────────────────────────────────────────
+#
+# Our BLE GATT is app-PIN over plain (unencrypted) ATT. Android (esp. 14+)
+# opens EATT (PSM 0x0027) on connect, which bluetoothd refuses without an
+# encrypted link and answers with an SMP Security Request — popping an OS
+# pair prompt on every connect (or, on some phones, a silent GATT 147 /
+# "Connection lost" tear-down loop with bond=BOND_NONE).
+#
+# Channels=1 keeps plain ATT (same GATT, same PIN), no prompt, no tear-down.
+# Safe on every Pi board — no security change vs. our existing model.
+# Universal patch (no board gate): pre-v3.11.x installs (e.g. v3.9.0 Zero 2W)
+# never ran the install-time version of this, so OTA must heal it for them.
+apply_eatt_disable() {
+    local conf=/etc/bluetooth/main.conf
+    [ -f "$conf" ] || { warn "EATT: $conf missing — skipping"; return 0; }
+
+    if grep -qE '^Channels[[:space:]]*=[[:space:]]*1' "$conf"; then
+        log "EATT disable: already applied"
+        return 0
+    fi
+
+    if grep -qE '^\[GATT\]' "$conf"; then
+        if grep -qiE '^[# ]*Channels' "$conf"; then
+            sed -i -E 's/^[# ]*Channels[ ]*=.*/Channels = 1/' "$conf"
+        else
+            sed -i '/^\[GATT\]/a Channels = 1' "$conf"
+        fi
+    else
+        printf '\n[GATT]\nChannels = 1\n' >> "$conf"
+    fi
+
+    if grep -qE '^Channels[[:space:]]*=[[:space:]]*1' "$conf"; then
+        log "EATT disable: applied to $conf"
+        systemctl restart bluetooth 2>/dev/null || true
+    else
+        err "EATT disable: write to $conf failed (read-only fs? check remountfs_rw)"
+        return 1
+    fi
+    return 0
+}
+
 # ── Run all patches ─────────────────────────────────────────────────────
 
 apply_ble_nonfatal_adv
+apply_eatt_disable
 
 # Future patches that must survive an OTA update get appended here. Each
 # one self-checks board / precondition / marker so the whole script stays


### PR DESCRIPTION
## What

Move the `[GATT] Channels = 1` (EATT-disable) patch from `install-pi.sh` step 3b2 into `setup/pi/apply-runtime-patches.sh` as a universal helper. Drop the now-redundant inline block in `install-pi.sh` — step 3d2 already installs + runs the helper at fresh-install time, so no regression there.

## Why

EATT requires an encrypted link by spec. SentryUSB's GATT is PIN-over-plain-ATT, so the phone's EATT open is doomed — BlueZ refuses, sends an SMP Security Request, and the phone either pops a recurring pair prompt or silently disconnects with `GATT 147 / bond=BOND_NONE` on a 10-second loop.

`Channels = 1` reverts to plain ATT (BlueZ default for years). Same GATT, same PIN, no prompt, no disconnect loop.

But the install-time version of this patch only landed in v3.11.x (#95). Anyone still on v3.9.0 etc. never got it, and OTA wouldn't heal them because the patch lived in `install-pi.sh` (only run on fresh install). The runtime-patches helper was built exactly for this kind of hole — moving the patch into it lets OTA users heal automatically via `update.rs` + `migrate.rs`.

## Safety

- **iOS clients:** No-op. iOS doesn't open EATT against unencrypted GATT either.
- **Android clients:** No-op for ones already working; fix for ones hitting GATT 147 / recurring pair prompt.
- **Throughput:** Theoretically a tiny dip on a client that was using EATT for parallel notifications, but our GATT exchanges short JSON commands — totally inelastic.
- **Idempotent:** First check is `grep -qE '^Channels[[:space:]]*=[[:space:]]*1'`; re-runs are no-ops.

## Repro that motivated this

Tester on Pi Zero 2W / SentryUSB v3.9.0 / Samsung S25 Ultra / Android 16:
```
BLE: found SentryUSB- @ 24:F1:FB:3B:CB:25 (-49 dBm)
BLE connecting to SentryUSB-
BLE: GATT DISCONNECTED status=147 bond=10
BLE setup error: Connection lost (code 147)
```
Repeats forever. `bond=10` = `BOND_NONE` — phone never bonded, classic EATT/SMP timeout signature.

## Test plan

- [ ] OTA a pre-v3.11 install — verify `journalctl -u sentryusb | grep "EATT disable"` shows "applied" then "already applied" on subsequent runs
- [ ] `grep -A2 "\[GATT\]" /etc/bluetooth/main.conf` shows `Channels = 1`
- [ ] BLE connect from Android stops timing out at 10s with GATT 147