### PR TITLE
fix(ota): refresh runtime-patches script body on update, don't just invoke

### DIFF
--- a/crates/api/src/update.rs
+++ b/crates/api/src/update.rs
@@ -693,44 +693,74 @@ async fn self_update(target_version: Option<String>) -> anyhow::Result<String> {
     // is idempotent + detection-gated, so it's a no-op on non-applicable
     // boards and a no-op on already-patched files.
     //
-    // Bootstrap: the script first ships in v3.11.4. Users updating from a
-    // pre-v3.11.4 release won't have it on disk yet — fetch it from the
-    // repo BEFORE running so the very first auto-heal cycle works. The
-    // script lives at a stable URL (main branch, setup/pi/) so it's
-    // fetchable as long as the repo is reachable.
+    // Always refresh the script body from the repo before running.
+    //
+    // Bootstrap-only (the old behavior) had a fatal hole: if a user already
+    // had a stale on-disk copy from an earlier release, new patches we add
+    // to apply-runtime-patches.sh would never reach them — update.rs would
+    // skip the download and invoke the rotten old script. We fix that by
+    // ALWAYS downloading; a failed download falls back to whatever is
+    // already on disk (warn-only). The script lives at a stable URL
+    // (main branch, setup/pi/) so it's fetchable as long as the repo is
+    // reachable.
     let patches_path = "/usr/local/bin/sentryusb-apply-runtime-patches";
-    if !std::path::Path::new(patches_path).exists() {
-        let patches_url = format!(
-            "https://raw.githubusercontent.com/{}/main/setup/pi/apply-runtime-patches.sh",
-            repo
-        );
-        tracing::info!(
-            "update.rs: runtime-patches script missing — bootstrapping from {}",
-            patches_url
-        );
-        match sentryusb_shell::run_with_timeout(
-            std::time::Duration::from_secs(20),
-            "curl",
-            &[
-                "-fsSL",
-                "--max-time",
-                "15",
-                "-o",
-                patches_path,
-                &patches_url,
-            ],
-        )
-        .await
-        {
-            Ok(_) => {
+    let patches_url = format!(
+        "https://raw.githubusercontent.com/{}/main/setup/pi/apply-runtime-patches.sh",
+        repo
+    );
+    let patches_tmp = "/tmp/sentryusb-apply-runtime-patches.new";
+    tracing::info!(
+        "update.rs: refreshing runtime-patches script from {}",
+        patches_url
+    );
+    match sentryusb_shell::run_with_timeout(
+        std::time::Duration::from_secs(20),
+        "curl",
+        &[
+            "-fsSL",
+            "--max-time",
+            "15",
+            "-o",
+            patches_tmp,
+            &patches_url,
+        ],
+    )
+    .await
+    {
+        Ok(_) => {
+            // Only swap the live script if the download produced a non-empty
+            // file (catches "200 OK + empty body" rare github edge cases).
+            if std::fs::metadata(patches_tmp)
+                .map(|m| m.len() > 0)
+                .unwrap_or(false)
+            {
+                let _ = std::fs::rename(patches_tmp, patches_path);
                 let _ = sentryusb_shell::run("chmod", &["+x", patches_path]).await;
-                tracing::info!("update.rs: runtime-patches script bootstrapped");
+                tracing::info!("update.rs: runtime-patches script refreshed");
+            } else {
+                let _ = std::fs::remove_file(patches_tmp);
+                if !std::path::Path::new(patches_path).exists() {
+                    install_warnings.push(
+                        "runtime-patches download empty AND no existing script: board-specific \
+                         fixes won't apply this update. Re-run install-pi.sh manually."
+                            .to_string(),
+                    );
+                }
             }
-            Err(e) => install_warnings.push(format!(
-                "runtime-patches bootstrap FAILED ({e}): board-specific fixes \
-                 (BCM4345C0 BLE on Rock 4C+, etc.) won't auto-reapply after this \
-                 update. Re-run install-pi.sh manually if BLE pairing breaks."
-            )),
+        }
+        Err(e) => {
+            let _ = std::fs::remove_file(patches_tmp);
+            if !std::path::Path::new(patches_path).exists() {
+                install_warnings.push(format!(
+                    "runtime-patches download FAILED ({e}) AND no existing script: board-specific \
+                     fixes (BCM4345C0 BLE on Rock 4C+, EATT disable, etc.) won't auto-reapply \
+                     after this update. Re-run install-pi.sh manually if BLE pairing breaks."
+                ));
+            } else {
+                tracing::warn!(
+                    "update.rs: runtime-patches refresh failed ({e}), falling back to existing on-disk script"
+                );
+            }
         }
     }
 

--- a/crates/sentryusb/src/migrate.rs
+++ b/crates/sentryusb/src/migrate.rs
@@ -316,6 +316,15 @@ if [ -f "$TMPDIR/pi-gen-sources/00-sentryusb-tweaks/files/sentryusb-pick-binary"
   install -m 755 "$TMPDIR/pi-gen-sources/00-sentryusb-tweaks/files/sentryusb-pick-binary" /usr/local/bin/sentryusb-pick-binary
 fi
 
+# ── Refresh the runtime-patches helper from the tarball ──
+# Without this, new patches we add to apply-runtime-patches.sh never reach
+# existing installs — the OTA invocation (the Rust caller after this shell
+# script exits) would re-run the OLD on-disk version. Bootstrap pre-v3.11
+# installs that never had the helper at all (the file just appears).
+if [ -f "$TMPDIR/setup/pi/apply-runtime-patches.sh" ]; then
+  install -m 755 "$TMPDIR/setup/pi/apply-runtime-patches.sh" /usr/local/bin/sentryusb-apply-runtime-patches
+fi
+
 # ── Install Tesla BLE telemetry sampler service + aux binaries ──
 # Two concerns here:
 #   1. The systemd unit ships in the source tarball — copy it into place


### PR DESCRIPTION
## Problem

\`migrate.rs\` and \`update.rs\` both INVOKED \`/usr/local/bin/sentryusb-apply-runtime-patches\` after the binary swap but neither REFRESHED its body. Any new patch added to \`setup/pi/apply-runtime-patches.sh\` would silently rot on disk — existing installs re-ran the stale on-disk copy instead of the newly-released one. \`migrate.rs\` additionally skipped invocation entirely when the script was missing (no bootstrap there, only in \`update.rs\` #101), so pre-v3.11 users couldn't auto-heal through migrate.rs alone.

Caught on a v3.11.6 OTA test: bench Pi ran the v3.11.5-era script (5574 bytes, no \`apply_eatt_disable\` function) even though the v3.11.6 release tarball shipped the new EATT helper from #104.

## Fix

### \`migrate.rs\` (shell migration)
Install \`$TMPDIR/setup/pi/apply-runtime-patches.sh\` to \`/usr/local/bin/sentryusb-apply-runtime-patches\` alongside the other tarball-sourced scripts (envsetup, sentryusb-ble.py, sentryusb-pick-binary). This both refreshes existing installs AND bootstraps missing ones.

### \`update.rs\`
Always re-download \`apply-runtime-patches.sh\` from main raw URL before invoking, instead of bootstrap-only (download-if-missing). Failed download falls back to whatever is on disk + warns; empty-body 200 OK is rejected.

## Why both

Defense in depth. Either path alone is sufficient for the common case, but covering both means a single failed network request can't strand a user on a stale script — the other path catches it.

## End-to-end walkthrough

| User on | Path |
|---|---|
| pre-v3.11 (no script) → vN | old update.rs binary swap → new binary boots → migrate.rs shell migration installs script from tarball → invokes → patches applied |
| v3.11.5/.6 (stale script) → vN | new update.rs always-refresh fetches from main → invokes → binary swap → new binary's migrate.rs re-installs from tarball (defense in depth) → invokes |
| vN → vN+1 | new update.rs always-refresh → invokes → binary swap → new binary's migrate.rs reinstalls from tarball → invokes |

## Tests / verification

- \`cargo check --workspace\` ✅
- \`cargo test -p sentryusb migration::tests::migration_script_parses\` ✅ (the shell-script template still bash-parses with the new \`install -m 755\` line)
- Manual OTA verify on hardware planned: \`stat\` mtime + \`grep -c apply_eatt_disable\` + \`journalctl -u sentryusb -b | grep "EATT\\|runtime-patches"\`. If any of the three fails on bench, will patch under the same tag rather than cutting another release.