### PR TITLE
fix(ble): widen BLE advertising helper to all known-affected Pi BT chips

### DIFF
--- a/install-pi.sh
+++ b/install-pi.sh
@@ -525,112 +525,6 @@ DTS
         warn "nvram_ap6256.txt not found — WiFi may be unstable with BT (generic calibration)."
     fi
 
-    # 3b. THE BLE-advertising fix. The BCM4345C0 firmware rejects BlueZ EXTENDED
-    #     advertising (mgmt 0x0054/55 → "Invalid Parameters 0x0d"), and even legacy
-    #     `btmgmt add-adv` is unreliable (ActiveInstances:0 / ~1280ms interval →
-    #     Android misses it → connectGatt 147). Fix = (i) daemon doesn't sys.exit on
-    #     BlueZ adv failure; (ii) a helper programs legacy ADV_IND @ 100ms directly
-    #     over raw HCI (SC then connects to the real MAC + authenticates); (iii) start
-    #     event-driven when hci0 appears (UART BT attaches late on cold boot).
-    # The actual BLE non-fatal-adv patch lives in a standalone script
-    # (sentryusb-apply-runtime-patches.sh) that is ALSO invoked by the
-    # Rust binary's in-app updater after every OTA swap — so existing
-    # users heal automatically on update instead of needing a re-install.
-    # Installed below in the universal section; the call here just primes
-    # the patch state for first-install.
-    cat > /usr/local/bin/sentryusb-ble-adv.sh <<'ADVSH'
-#!/bin/bash
-# Legacy ADV_IND advertiser for BCM4345C0. BlueZ's mgmt path is unreliable on
-# this chip (ext-adv rejected, legacy add-adv runs at ~1280ms — too slow for
-# Android scans), so program advertising directly over HCI at 100ms.
-# The SentryUSB apps filter scans by the "SentryUSB-" name prefix, so the
-# local name must be in the scan response.
-UUID_LE="9e ca dc 24 0e e5 a9 e0 93 f3 a3 b5 01 00 40 6e"   # 6e400001-b5a3-f393-e0a9-e50e24dcca9e, little-endian
-ADV_DATA="15 02 01 06 11 07 ${UUID_LE} 00 00 00 00 00 00 00 00 00 00 00 00 00"
-
-# Scan-response bytes = [len][0x09 Complete Local Name][name…]. Function is
-# defined before the run-guard so it's sourceable for unit-style testing.
-build_scanrsp() {
-    local name hex namebytes len
-    name=$(timeout 5 btmgmt info 2>/dev/null | sed -n 's/^[[:space:]]*name[[:space:]]*//p' | head -1)
-    [ -z "$name" ] && name=$(hostname)
-    name=${name:0:29}                                   # scan-rsp budget: 31 - 2 (len+type)
-    hex=$(printf '%s' "$name" | od -An -tx1 | tr -d ' \n')
-    namebytes=$(( ${#hex} / 2 ))
-    len=$(( namebytes + 1 ))                             # +1 for the AD type byte
-    printf '%02x 09 %s' "$len" "$(echo "$hex" | sed 's/../& /g')"
-}
-
-# Program legacy ADV_IND directly via HCI (bypasses BlueZ mgmt):
-#   disable → set adv data → set scan-rsp (name, zero-padded to 31) →
-#   adv params (100ms min/max ADV_IND connectable undirected, public addr, all 3 chans) → enable
-assert_raw_adv() {
-    local scanrsp; scanrsp=$(build_scanrsp)
-    hcitool -i hci0 cmd 0x08 0x000a 00 >/dev/null 2>&1 || true
-    hcitool -i hci0 cmd 0x08 0x0008 $ADV_DATA >/dev/null 2>&1 || true
-    hcitool -i hci0 cmd 0x08 0x0009 $scanrsp 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 >/dev/null 2>&1 || true
-    hcitool -i hci0 cmd 0x08 0x0006 a0 00 a0 00 00 00 00 00 00 00 00 00 00 07 00 >/dev/null 2>&1 || true
-    hcitool -i hci0 cmd 0x08 0x000a 01 >/dev/null 2>&1 || true
-}
-
-# Run the advertising loop ONLY when executed directly (the systemd ExecStart),
-# never when sourced — otherwise testing build_scanrsp() would loop forever.
-if [ "${BASH_SOURCE[0]}" != "${0}" ]; then
-    return 0 2>/dev/null || exit 0
-fi
-
-for i in $(seq 1 30); do busctl status org.bluez >/dev/null 2>&1 && break; sleep 1; done
-sleep 3   # let the daemon's (failing) ext-adv RegisterAdvertisement settle first
-timeout 5 btmgmt le on >/dev/null 2>&1 || true
-timeout 5 btmgmt connectable on >/dev/null 2>&1 || true
-while true; do
-    # Re-assert only while IDLE — reprogramming advertising while a phone is
-    # connected can disturb Broadcom controllers and isn't needed for a live link.
-    if ! timeout 3 btmgmt con 2>/dev/null | grep -q 'type LE'; then
-        assert_raw_adv
-    fi
-    sleep 5
-done
-ADVSH
-    chmod +x /usr/local/bin/sentryusb-ble-adv.sh
-    cat > /etc/systemd/system/sentryusb-ble-adv.service <<'ADVSVC'
-[Unit]
-Description=SentryUSB: legacy LE advertising (Rock 4C+ BCM4345C0 ext-adv workaround)
-After=bluetooth.service sentryusb-ble.service
-Wants=bluetooth.service
-BindsTo=sentryusb-ble.service
-
-[Service]
-Type=simple
-ExecStart=/usr/local/bin/sentryusb-ble-adv.sh
-Restart=always
-RestartSec=10
-
-[Install]
-WantedBy=multi-user.target
-ADVSVC
-    cat > /etc/udev/rules.d/99-sentryusb-ble-hci.rules <<'UDEV'
-# Rock 4C+ (BCM4345C0): the UART BT controller attaches a few seconds into boot,
-# AFTER systemd checks bluetooth.service's ConditionPathIsDirectory, so the BLE
-# stack is skipped on a cold boot. Start it the moment hci0 appears (condition now
-# passes; the daemon's Wants= pulls bluetooth.service + the advertising helper).
-ACTION=="add", SUBSYSTEM=="bluetooth", KERNEL=="hci0", TAG+="systemd", ENV{SYSTEMD_WANTS}+="sentryusb-ble.service"
-UDEV
-    mkdir -p /etc/systemd/system/sentryusb-ble.service.d
-    cat > /etc/systemd/system/sentryusb-ble.service.d/wants-bluetooth.conf <<'WANTS'
-[Unit]
-Wants=bluetooth.service sentryusb-ble-adv.service
-WANTS
-    systemctl disable --now sentryusb-ble-le.service 2>/dev/null || true
-    rm -f /etc/systemd/system/sentryusb-ble-le.service 2>/dev/null
-    rm -rf /etc/systemd/system/sentryusb-ble-le.service.d 2>/dev/null
-    systemctl enable bluetooth.service >/dev/null 2>&1 || true
-    systemctl daemon-reload 2>/dev/null || true
-    udevadm control --reload-rules 2>/dev/null || true
-    systemctl enable sentryusb-ble-adv.service >/dev/null 2>&1 || true
-    ok "BLE legacy-advertising fix installed (daemon patch + adv service + hci0 udev rule)"
-    NEEDS_REBOOT=1
-
     # 4. (Recommended) OpenSSH instead of Dropbear — Dropbear ships no SFTP
     #    subsystem, so scp/sftp to the Pi fail.
     if command -v dropbear >/dev/null 2>&1 && [ -x /boot/dietpi/func/dietpi-set_software ]; then
@@ -642,6 +536,65 @@ WANTS
     fi
 
     set -e  # end best-effort section
+fi
+
+# ── Step 3g: BLE legacy-advertising helper (chip-gated install) ────
+#
+# A small per-chip workaround: Broadcom controllers in the BCM4345/43430/43438
+# family reject BlueZ's modern RegisterAdvertisement (or default to a
+# scannable-but-non-connectable advertising type), so SC's connect attempt
+# fails ~10s later with "GATT 147 bond=BOND_NONE". The helper service
+# installed here programs legacy ADV_IND (connectable) directly over raw
+# HCI at 100ms intervals, plus a udev rule that brings the BLE stack up the
+# moment hci0 appears (UART BT attaches late on cold boot).
+#
+# Gate: only install where the chip is known affected. Pi 4 / Pi 5
+# (BCM43455 / CYW43455) are deliberately EXCLUDED — their modern bluetoothd
+# path works, and the raw-HCI helper here would override their good ext-adv
+# with legacy adv (regression). If a Pi 4/5 user DOES hit the same
+# "GATT 147 bond=BOND_NONE" symptom they can opt in with:
+#     sudo touch /mutable/force-ble-adv-helper
+# That sentinel forces install regardless of chip detection.
+is_known_broken_ble_chip() {
+    [ -f /mutable/force-ble-adv-helper ] && return 0   # operator override
+    local chips="BCM4345C0\|BCM43430B0\|BCM43438"
+    dmesg 2>/dev/null | grep -qE "hci0: ($chips)" && return 0
+    grep -qai 'rock-4c-plus\|rockpi4c-plus\|ROCK 4C+\|Raspberry Pi Zero 2 W\|Raspberry Pi 3 Model B\|Raspberry Pi Zero W' \
+        /proc/device-tree/model 2>/dev/null && return 0
+    return 1
+}
+if is_known_broken_ble_chip; then
+    info "Known-affected BLE chip detected — installing raw-HCI advertising helper..."
+    BLE_ADV_BASE_URL="https://raw.githubusercontent.com/${REPO}/main/setup/pi"
+    LOCAL_PI_DIR="$(dirname "${1:-/dev/null}")/setup/pi"
+    fetch_file() {
+        # $1 = filename, $2 = destination. Tries local repo first, then URL.
+        if [ -f "$LOCAL_PI_DIR/$1" ]; then
+            install -m 644 "$LOCAL_PI_DIR/$1" "$2"
+        elif curl -fsSL --max-time 15 "$BLE_ADV_BASE_URL/$1" -o "$2" 2>/dev/null; then
+            :
+        else
+            warn "Failed to fetch $1 — BLE LE advertising may not work"
+            return 1
+        fi
+        return 0
+    }
+    if fetch_file sentryusb-ble-adv.sh /usr/local/bin/sentryusb-ble-adv.sh; then
+        chmod +x /usr/local/bin/sentryusb-ble-adv.sh
+        fetch_file sentryusb-ble-adv.service /etc/systemd/system/sentryusb-ble-adv.service
+        fetch_file 99-sentryusb-ble-hci.rules /etc/udev/rules.d/99-sentryusb-ble-hci.rules
+        mkdir -p /etc/systemd/system/sentryusb-ble.service.d
+        fetch_file sentryusb-ble-wants-bluetooth.conf /etc/systemd/system/sentryusb-ble.service.d/wants-bluetooth.conf
+        # Retire any older single-purpose unit from earlier installs.
+        systemctl disable --now sentryusb-ble-le.service 2>/dev/null || true
+        rm -f /etc/systemd/system/sentryusb-ble-le.service 2>/dev/null
+        rm -rf /etc/systemd/system/sentryusb-ble-le.service.d 2>/dev/null
+        systemctl enable bluetooth.service >/dev/null 2>&1 || true
+        systemctl daemon-reload 2>/dev/null || true
+        udevadm control --reload-rules 2>/dev/null || true
+        systemctl enable sentryusb-ble-adv.service >/dev/null 2>&1 || true
+        ok "BLE legacy-advertising helper installed (script + service + hci0 udev rule)"
+    fi
 fi
 
 # ── Step 4: Sample Config ───────────────────────────────────────────

--- a/setup/pi/99-sentryusb-ble-hci.rules
+++ b/setup/pi/99-sentryusb-ble-hci.rules
@@ -1,0 +1,6 @@
+# Broadcom Pi-family chips: the UART BT controller attaches a few seconds into
+# boot, AFTER systemd checks bluetooth.service's ConditionPathIsDirectory, so
+# the BLE stack is skipped on a cold boot. Start it the moment hci0 appears
+# (condition now passes; the daemon's Wants= pulls bluetooth.service + the
+# advertising helper).
+ACTION=="add", SUBSYSTEM=="bluetooth", KERNEL=="hci0", TAG+="systemd", ENV{SYSTEMD_WANTS}+="sentryusb-ble.service"

--- a/setup/pi/apply-runtime-patches.sh
+++ b/setup/pi/apply-runtime-patches.sh
@@ -42,17 +42,52 @@ is_rock_4cplus() {
         /proc/device-tree/model /proc/device-tree/compatible 2>/dev/null
 }
 
-# ── BLE non-fatal-adv patch (Rock 4C+ / BCM4345C0) ──────────────────────
+# Known-affected Broadcom chips where BlueZ's extended advertising fails OR
+# defaults to non-connectable parameters — i.e., where SC's BLE pair fails
+# without our raw-HCI ADV_IND helper. Detected by parsing the chip family ID
+# kernel logs on first BT probe (e.g. "Bluetooth: hci0: BCM43430B0 (002.001.012)").
 #
-# The BCM4345C0 firmware rejects BlueZ extended advertising with "Invalid
-# Parameters (0x0d)". The shipped sentryusb-ble.py calls sys.exit(1) on
-# that error, which tears down GATT and lets systemd re-spawn the daemon
-# in a fast crash loop. The Pi's actual advertising is handled out-of-band
-# by sentryusb-ble-adv.service via raw HCI, so the BlueZ failure is
-# legitimately non-fatal for our use case — we just need the GATT server
-# to stay up. Patch swallows the BlueZ adv error and logs it instead.
+# Currently:
+#   BCM4345C0 — Rock 4C+ (confirmed broken via field evidence)
+#   BCM43430B0 — Pi Zero 2 W (confirmed broken via btmon trace 2026-06-20)
+#   BCM43438 — Pi 3B/3B+, Pi Zero W (same chip family / same firmware tree)
+#
+# DELIBERATELY EXCLUDED until tested:
+#   BCM43455 / CYW43455 — Pi 4 / Pi 5; their modern bluetoothd path is
+#   reported to work fine, and running our raw-HCI helper there would
+#   override their working ext-adv with legacy adv (regression). If a Pi
+#   4/5 user does hit "GATT 147 bond=BOND_NONE" they can opt in with:
+#       sudo touch /mutable/force-ble-adv-helper
+#   That sentinel forces install regardless of chip detection. The next OTA
+#   (or `sudo /usr/local/bin/sentryusb-apply-runtime-patches`) lands it.
+is_known_broken_ble_chip() {
+    # Operator override — for chips we haven't detection-listed yet but
+    # field-confirmed need the helper.
+    [ -f /mutable/force-ble-adv-helper ] && { log "BLE adv: /mutable/force-ble-adv-helper present — forcing install"; return 0; }
+    local chips="BCM4345C0\|BCM43430B0\|BCM43438"
+    dmesg 2>/dev/null | grep -qE "hci0: ($chips)" && return 0
+    # dmesg may not retain that line on a long-running box; also check the
+    # board model as a backstop (4C+'s 4345C0 + Zero 2 W's 43430B0 are
+    # board-specific so model match is unambiguous).
+    grep -qai 'rock-4c-plus\|rockpi4c-plus\|ROCK 4C+\|Raspberry Pi Zero 2 W\|Raspberry Pi 3 Model B\|Raspberry Pi Zero W' \
+        /proc/device-tree/model 2>/dev/null && return 0
+    return 1
+}
+
+# ── BLE non-fatal-adv patch (all Broadcom Pi-family chips) ──────────────
+#
+# Broadcom Pi-family chips (BCM4345C0 on Rock 4C+, BCM43430B0 on Pi Zero 2 W,
+# the BCM43455 sibling on Pi 4/Compute Module, etc.) all reject BlueZ's
+# extended advertising with "Invalid Parameters 0x0d". The shipped
+# sentryusb-ble.py calls sys.exit(1) on that error, which tears down GATT
+# and lets systemd re-spawn the daemon in a fast crash loop. The Pi's actual
+# advertising is handled out-of-band by sentryusb-ble-adv.service via raw
+# HCI (ADV_IND programmed directly), so the BlueZ failure is legitimately
+# non-fatal — we just need the GATT server to stay up. Patch swallows the
+# BlueZ adv error and logs it instead.
+#
+# Was 4C+-gated through v3.11.7; widened to all Pi families in v3.11.8.
 apply_ble_nonfatal_adv() {
-    is_rock_4cplus || return 0
     local f=/root/bin/sentryusb-ble.py
     [ -f "$f" ] || { warn "BLE: $f missing — skipping non-fatal-adv patch"; return 0; }
 
@@ -99,7 +134,7 @@ PYEOF
         if grep -q 'legacy btmgmt advertising' "$f"; then
             log "BLE non-fatal-adv: applied via sed fallback"
         else
-            err  "BLE non-fatal-adv: BOTH patch paths failed — SC discovery may be broken on this 4C+ install"
+            err  "BLE non-fatal-adv: BOTH patch paths failed — SC discovery may be broken on this install"
             return 1
         fi
     fi
@@ -153,9 +188,70 @@ apply_eatt_disable() {
     return 0
 }
 
+# ── BLE legacy-advertising helper install (all Broadcom Pi-family chips) ──
+#
+# Fresh installs get these files from install-pi.sh; this function brings
+# existing v3.11.7-and-earlier installs up to parity. Idempotent — each file
+# is only written when missing OR when the on-disk contents differ from the
+# current upstream version.
+#
+# Files installed:
+#   /usr/local/bin/sentryusb-ble-adv.sh
+#   /etc/systemd/system/sentryusb-ble-adv.service
+#   /etc/udev/rules.d/99-sentryusb-ble-hci.rules
+#   /etc/systemd/system/sentryusb-ble.service.d/wants-bluetooth.conf
+apply_ble_adv_helper() {
+    # Gate to known-affected chips so Pi 4/5 (where bluetoothd's modern
+    # ext-adv works) don't get the raw-HCI helper overriding their good
+    # advertising. See is_known_broken_ble_chip above for the full list.
+    is_known_broken_ble_chip || { log "BLE adv: chip not in known-broken list — skipping helper install"; return 0; }
+    local repo="${REPO:-Sentry-Six/Sentry-USB-Rusty}"
+    local base="https://raw.githubusercontent.com/${repo}/main/setup/pi"
+    local changed=0
+
+    install_one() {
+        # $1 = source filename, $2 = destination path, $3 = mode
+        local src="$1" dst="$2" mode="$3"
+        local tmp; tmp="$(mktemp)" || { warn "BLE adv: mktemp failed"; return 1; }
+        if ! curl -fsSL --max-time 15 "$base/$src" -o "$tmp" 2>/dev/null; then
+            rm -f "$tmp"
+            warn "BLE adv: failed to fetch $src — leaving any existing copy alone"
+            return 1
+        fi
+        if [ -f "$dst" ] && cmp -s "$tmp" "$dst"; then
+            rm -f "$tmp"
+            return 0  # already up to date
+        fi
+        [ -x /root/bin/remountfs_rw ] && /root/bin/remountfs_rw >/dev/null 2>&1 || true
+        install -m "$mode" "$tmp" "$dst"
+        rm -f "$tmp"
+        changed=1
+        log "BLE adv: installed/refreshed $dst"
+    }
+
+    install_one sentryusb-ble-adv.sh /usr/local/bin/sentryusb-ble-adv.sh 755 || return 0
+    install_one sentryusb-ble-adv.service /etc/systemd/system/sentryusb-ble-adv.service 644
+    install_one 99-sentryusb-ble-hci.rules /etc/udev/rules.d/99-sentryusb-ble-hci.rules 644
+    mkdir -p /etc/systemd/system/sentryusb-ble.service.d
+    install_one sentryusb-ble-wants-bluetooth.conf \
+                /etc/systemd/system/sentryusb-ble.service.d/wants-bluetooth.conf 644
+
+    if [ "$changed" = "1" ]; then
+        systemctl daemon-reload 2>/dev/null || true
+        udevadm control --reload-rules 2>/dev/null || true
+        systemctl enable sentryusb-ble-adv.service >/dev/null 2>&1 || true
+        systemctl restart sentryusb-ble-adv.service 2>/dev/null || true
+        log "BLE adv: service enabled + restarted"
+    else
+        log "BLE adv: all files current, nothing to do"
+    fi
+    return 0
+}
+
 # ── Run all patches ─────────────────────────────────────────────────────
 
 apply_ble_nonfatal_adv
+apply_ble_adv_helper
 apply_eatt_disable
 
 # Future patches that must survive an OTA update get appended here. Each

--- a/setup/pi/sentryusb-ble-adv.service
+++ b/setup/pi/sentryusb-ble-adv.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=SentryUSB: legacy LE advertising (Broadcom Pi-family chip workaround)
+After=bluetooth.service sentryusb-ble.service
+Wants=bluetooth.service
+BindsTo=sentryusb-ble.service
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/sentryusb-ble-adv.sh
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target

--- a/setup/pi/sentryusb-ble-adv.sh
+++ b/setup/pi/sentryusb-ble-adv.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Legacy ADV_IND advertiser for Broadcom Pi-family chips where BlueZ's modern
+# advertising path is unreliable (the BCM controllers reject EXTENDED
+# advertising, and even `btmgmt advertising on` defaults to non-connectable
+# parameters on some chip revisions). Programs advertising directly over raw
+# HCI as connectable undirected (ADV_IND) at 100ms intervals.
+#
+# The SentryUSB apps filter scans by the "SentryUSB-" name prefix, so the
+# local name MUST appear in the scan response (BlueZ doesn't include the
+# name in this path by default, hence the explicit scan-rsp builder below).
+UUID_LE="9e ca dc 24 0e e5 a9 e0 93 f3 a3 b5 01 00 40 6e"   # 6e400001-b5a3-f393-e0a9-e50e24dcca9e, little-endian
+ADV_DATA="15 02 01 06 11 07 ${UUID_LE} 00 00 00 00 00 00 00 00 00 00 00 00 00"
+
+# Scan-response bytes = [len][0x09 Complete Local Name][name…]. Function is
+# defined before the run-guard so it's sourceable for unit-style testing.
+build_scanrsp() {
+    local name hex namebytes len
+    name=$(timeout 5 btmgmt info 2>/dev/null | sed -n 's/^[[:space:]]*name[[:space:]]*//p' | head -1)
+    [ -z "$name" ] && name=$(hostname)
+    name=${name:0:29}                                   # scan-rsp budget: 31 - 2 (len+type)
+    hex=$(printf '%s' "$name" | od -An -tx1 | tr -d ' \n')
+    namebytes=$(( ${#hex} / 2 ))
+    len=$(( namebytes + 1 ))                             # +1 for the AD type byte
+    printf '%02x 09 %s' "$len" "$(echo "$hex" | sed 's/../& /g')"
+}
+
+# Program legacy ADV_IND directly via HCI (bypasses BlueZ mgmt):
+#   disable → set adv data → set scan-rsp (name, zero-padded to 31) →
+#   adv params (100ms min/max ADV_IND connectable undirected, public addr, all 3 chans) → enable
+# The "0x00" after the intervals is the advertising-type byte — ADV_IND
+# (connectable). DO NOT change to ADV_SCAN_IND (0x02) — the chip will then
+# silently refuse incoming GATT connect requests, surfacing as the phone
+# logging "GATT 147 bond=BOND_NONE" 10s into the attempt.
+assert_raw_adv() {
+    local scanrsp; scanrsp=$(build_scanrsp)
+    hcitool -i hci0 cmd 0x08 0x000a 00 >/dev/null 2>&1 || true
+    hcitool -i hci0 cmd 0x08 0x0008 $ADV_DATA >/dev/null 2>&1 || true
+    hcitool -i hci0 cmd 0x08 0x0009 $scanrsp 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 >/dev/null 2>&1 || true
+    hcitool -i hci0 cmd 0x08 0x0006 a0 00 a0 00 00 00 00 00 00 00 00 00 00 07 00 >/dev/null 2>&1 || true
+    hcitool -i hci0 cmd 0x08 0x000a 01 >/dev/null 2>&1 || true
+}
+
+# Run the advertising loop ONLY when executed directly (the systemd ExecStart),
+# never when sourced — otherwise testing build_scanrsp() would loop forever.
+if [ "${BASH_SOURCE[0]}" != "${0}" ]; then
+    return 0 2>/dev/null || exit 0
+fi
+
+for i in $(seq 1 30); do busctl status org.bluez >/dev/null 2>&1 && break; sleep 1; done
+sleep 3   # let bluetoothd's (failing) ext-adv RegisterAdvertisement settle first
+timeout 5 btmgmt le on >/dev/null 2>&1 || true
+timeout 5 btmgmt connectable on >/dev/null 2>&1 || true
+while true; do
+    # Re-assert only while IDLE — reprogramming advertising while a phone is
+    # connected can disturb Broadcom controllers and isn't needed for a live link.
+    if ! timeout 3 btmgmt con 2>/dev/null | grep -q 'type LE'; then
+        assert_raw_adv
+    fi
+    sleep 5
+done

--- a/setup/pi/sentryusb-ble-wants-bluetooth.conf
+++ b/setup/pi/sentryusb-ble-wants-bluetooth.conf
@@ -1,0 +1,2 @@
+[Unit]
+Wants=bluetooth.service sentryusb-ble-adv.service


### PR DESCRIPTION
## Problem

Existing 4C+ users have a raw-HCI `ADV_IND` advertising helper installed by `install-pi.sh` to work around a Broadcom controller quirk (BlueZ's ext-adv returns \"Invalid Parameters 0x0d\", and `btmgmt add-adv` defaults to non-connectable params on some firmware revisions). Field evidence from a Pi Zero 2 W tester proves the **same bug** bites BCM43430B0 the same way — they're siblings in the Broadcom BCM43xx Pi-class family, sharing the firmware tree and the advertising-stack quirks.

SC's connect attempt fails ~10s after discovery with \"GATT 147 bond=BOND_NONE\" — chip refused at the link layer because the advertising type wasn't connectable.

## Root cause (verified via `btmon` trace)

```
< HCI Command: LE Set Advertising Parameters
        Type: Scannable undirected - ADV_SCAN_IND (0x02)
```

`ADV_SCAN_IND` is scannable (devices can see it + read the scan response → so it appears in SC's discovery list + nRF Connect's scanner), but it's **not connectable**. Any GATT connect request is silently refused at the link layer, manifesting as the phone logging \`GATT 147 bond=BOND_NONE\` after the Android-side 10s connect timeout.

Re-running the helper with `ADV_IND` (0x00) — the legacy connectable type — makes the chip accept the connection. SC pairs cleanly + the WiFi setup / commands flow works end-to-end.

## Changes

- Extract the BLE-adv helper files out of `install-pi.sh`'s inline heredocs into standalone files under `setup/pi/`:
  - `sentryusb-ble-adv.sh` (raw-HCI ADV_IND advertiser, 100ms intervals)
  - `sentryusb-ble-adv.service` (systemd unit)
  - `99-sentryusb-ble-hci.rules` (udev rule — brings BLE stack up the moment hci0 attaches, since UART BT attaches late on cold boot)
  - `sentryusb-ble-wants-bluetooth.conf` (`sentryusb-ble.service` drop-in)
- `install-pi.sh` fetches them from `setup/pi/` (local repo) or `main` branch (curl fallback), gated by a new `is_known_broken_ble_chip` detection.
- `setup/pi/apply-runtime-patches.sh` widens the non-fatal-adv Python patch from `is_rock_4cplus()` only to universal — harmless on chips where BlueZ works (patch only fires on actual RegisterAdvertisement failure).
- Adds `apply_ble_adv_helper` to the runtime-patches script so existing v3.11.7 OTAs heal automatically without re-running `install-pi.sh`.

## Chip detection

```sh
is_known_broken_ble_chip() {
    local chips=\"BCM4345C0\\|BCM43430B0\\|BCM43438\"
    dmesg 2>/dev/null | grep -qE \"hci0: (\$chips)\" && return 0
    grep -qai 'rock-4c-plus\\|ROCK 4C+\\|Raspberry Pi Zero 2 W\\|Raspberry Pi 3 Model B\\|Raspberry Pi Zero W' \\
        /proc/device-tree/model 2>/dev/null && return 0
    return 1
}
```

| Board | Chip | Status |
|---|---|---|
| Rock Pi 4C+ | BCM4345C0 | Helper installs (already known broken) |
| Pi Zero 2 W | BCM43430B0 | Helper installs (field-confirmed 2026-06-20) |
| Pi 3B/3B+, Pi Zero W | BCM43438 | Helper installs (same family) |
| Pi 4 / Compute Module 4 | BCM43455 | **Skipped** — modern bluetoothd path works; running our helper would override (regression risk) |
| Pi 5 | CYW43455 | **Skipped** — same reason |
| amd64, RK3399 non-4C+ | n/a | Skipped — no chip match |

If a Pi 4 / Pi 5 user later reports BLE pair failures, expanding the gate is one line.

## End-to-end OTA delivery walkthrough

- **4C+ v3.11.7 → v3.11.8:** `update.rs` always-refreshes `apply-runtime-patches.sh` from main (PR #105), helper files already on disk from earlier install, `apply_ble_adv_helper` reports \"already current, nothing to do\". No change in behavior.
- **Pi Zero 2 W v3.11.7 → v3.11.8:** Same path; helper files fetched + installed fresh (chip-gate matches via dmesg + board-model backstop). BLE pair works after restart.
- **Pi 4 / Pi 5 v3.11.7 → v3.11.8:** Chip-gate fails, helper skipped; their working bluetoothd ext-adv stays untouched.
- **Fresh install on any board:** `install-pi.sh`'s `is_known_broken_ble_chip` decides the same way.

## Test plan

- [ ] OTA chufleco bench (4C+) v3.11.7 → v3.11.8 pre-release; verify all 4 helper files present + `systemctl is-active sentryusb-ble-adv` = active + SC pair still works
- [ ] Field test on the Pi Zero 2 W tester via the same OTA; verify BLE pair works for the first time
- [ ] `grep -c apply_ble_adv_helper /usr/local/bin/sentryusb-apply-runtime-patches` shows the function landed
- [ ] No regression on a Pi 4 if one's available — confirm `apply_ble_adv_helper` log shows \"chip not in known-broken list — skipping\"