### PR TITLE
feat(keep-awake): move BLE nudge into sampler + switch verb to wake

### DIFF
--- a/crates/api/src/ble.rs
+++ b/crates/api/src/ble.rs
@@ -151,6 +151,31 @@ pub fn migrate_legacy_ble_flag() {
     }
 }
 
+/// One-shot: ensure `BLE_KEEP_AWAKE_VIA_SAMPLER` is present in the
+/// config file with a default of `no`. Lets the Raw Configuration
+/// editor surface the key as a togglable row out of the box, instead
+/// of forcing every tester to add it by hand with the `+` button.
+/// Idempotent — skips if the key is already set (so a tester who
+/// flipped it to `yes` doesn't get clobbered back to `no` on restart).
+pub fn ensure_keep_awake_via_sampler_key_present() {
+    let config_path = sentryusb_config::find_config_path();
+    let Ok((mut active, _commented)) = sentryusb_config::parse_file(config_path) else {
+        return;
+    };
+    if active.contains_key("BLE_KEEP_AWAKE_VIA_SAMPLER") {
+        return;
+    }
+    active.insert("BLE_KEEP_AWAKE_VIA_SAMPLER".to_string(), "no".to_string());
+    let _ = std::process::Command::new("bash")
+        .args(["-c", "/root/bin/remountfs_rw"])
+        .status();
+    if let Err(e) = sentryusb_config::write_file(config_path, &active) {
+        tracing::warn!("BLE_KEEP_AWAKE_VIA_SAMPLER seed write failed: {e}");
+    } else {
+        tracing::info!("seeded BLE_KEEP_AWAKE_VIA_SAMPLER=no (togglable in Raw Config editor)");
+    }
+}
+
 /// GET /api/system/ble-enabled
 pub async fn ble_enabled_get(
     State(_s): State<AppState>,

--- a/crates/sentryusb/src/main.rs
+++ b/crates/sentryusb/src/main.rs
@@ -268,6 +268,10 @@ async fn main() {
     // either feature across the decoupling change. Idempotent —
     // skips if `BLE_KEEP_AWAKE_ENABLED` is already present.
     sentryusb_api::ble::migrate_legacy_ble_flag();
+    // One-shot: seed BLE_KEEP_AWAKE_VIA_SAMPLER=no so the Raw Config
+    // editor renders the row as a togglable switch out of the box.
+    // Idempotent — won't overwrite a value the tester already set.
+    sentryusb_api::ble::ensure_keep_awake_via_sampler_key_present();
     phase!("startup_tasks_spawned");
 
     // Build the API router

--- a/crates/tesla_telemetry/src/config.rs
+++ b/crates/tesla_telemetry/src/config.rs
@@ -53,6 +53,15 @@ pub struct BleConfig {
     /// install, so a pre-release build never changes behavior unless a
     /// tester explicitly turns it on. See the consolidation RFC.
     pub experimental: bool,
+    /// Emit periodic keep-awake nudges from inside the sampler on its
+    /// already-held PersistentSession instead of having `awake_start`
+    /// spawn a separate `ble-action` process every 300s. Default OFF
+    /// — set `BLE_KEEP_AWAKE_VIA_SAMPLER=yes` to enable. When on,
+    /// `awake_start`'s Case-3 BLE branch skips its `ble-action` call
+    /// while the sampler socket is present and lets the sampler emit
+    /// the nudge. When off (or the sampler is down), the legacy
+    /// spawned-loop path stays in charge. See task #329.
+    pub keep_awake_via_sampler: bool,
 }
 
 impl Default for BleConfig {
@@ -64,6 +73,7 @@ impl Default for BleConfig {
             keep_accessory: KeepAccessoryConfig::default(),
             away_auto_enabled: false,
             experimental: false,
+            keep_awake_via_sampler: false,
         }
     }
 }
@@ -166,6 +176,19 @@ impl BleConfig {
         .map(|v| matches!(v.as_str(), "yes" | "true" | "1"))
         .unwrap_or(false);
 
+        // Sampler-emitted keep-awake nudge opt-in. Default OFF — when
+        // the flag isn't set, behavior is byte-for-byte the legacy
+        // spawned `ble-action charge-port-close` loop. Read fresh on
+        // every loop iteration so a tester can flip it via a conf edit
+        // without bouncing the service.
+        let keep_awake_via_sampler = sentryusb_config::get_config_value(
+            &active,
+            &commented,
+            "BLE_KEEP_AWAKE_VIA_SAMPLER",
+        )
+        .map(|v| matches!(v.as_str(), "yes" | "true" | "1"))
+        .unwrap_or(false);
+
         Ok(Self {
             enabled,
             vin,
@@ -173,6 +196,7 @@ impl BleConfig {
             keep_accessory,
             away_auto_enabled,
             experimental,
+            keep_awake_via_sampler,
         })
     }
 }

--- a/crates/tesla_telemetry/src/lock.rs
+++ b/crates/tesla_telemetry/src/lock.rs
@@ -47,6 +47,12 @@ const ARCHIVE_STATUS_FRESH_SECS: u64 = 120;
 /// PID file written by the Case-3 keep-awake nudge loop in awake_start.
 const NUDGE_PID_FILE: &str = "/tmp/keep_awake_nudge_pid";
 
+/// Wanted-flag written by `drives_handler::register_keep_awake_want` —
+/// presence means at least one in-process owner (web UI session,
+/// drive-data processor) currently wants the car kept awake. Path
+/// must match `KEEP_AWAKE_WANTED_FLAG` in `crates/api/src/drives_handler.rs`.
+const WEBUI_WANTED_FLAG: &str = "/tmp/keep_awake_webui_wanted";
+
 /// Acquire the radio lock for `owner`. Returns `true` if we now hold
 /// it. Returns `false` if another fresh owner holds it — callers
 /// should back off and retry later.
@@ -249,15 +255,29 @@ fn is_nudge_alive_at(pid_file: &Path) -> bool {
     Path::new(&format!("/proc/{pid}")).exists()
 }
 
+/// True when an in-process owner has registered a keep-awake want via
+/// `drives_handler::register_keep_awake_want`. Presence-only — the flag
+/// is removed on the 1→0 transition. Bridges the gap when `awake_start`
+/// hasn't been spawned (and therefore no nudge PID file exists) but the
+/// web UI or drive processor still wants the car awake.
+fn is_webui_keep_awake_wanted_at(flag_path: &Path) -> bool {
+    flag_path.exists()
+}
+
 /// True when something currently wants the car kept awake: an archive
-/// cycle (fresh `archive_status.json`) or any keep-awake nudge loop
+/// cycle (fresh `archive_status.json`), a keep-awake nudge loop
 /// (`awake_start`'s Case-3 PID file — archiveloop, web-UI, drive
-/// processing). The quiet-mode gate consults this so it never green-lights
-/// sleep out from under an in-flight archive. Both inputs self-clear — the
-/// status file goes stale (120s), the PID dies — so this can't wedge the
-/// car permanently awake once the work finishes.
+/// processing), or an in-process keep-awake want (web UI session,
+/// drive-data processor, future sampler-delegated keep-awake). The
+/// quiet-mode gate consults this so it never green-lights sleep out
+/// from under an in-flight archive. All inputs self-clear — the
+/// status file goes stale (120s), the PID dies, the wanted-flag is
+/// removed on release — so this can't wedge the car permanently
+/// awake once the work finishes.
 pub fn keep_awake_requested() -> bool {
-    is_archive_active() || is_nudge_alive()
+    is_archive_active()
+        || is_nudge_alive()
+        || is_webui_keep_awake_wanted_at(Path::new(WEBUI_WANTED_FLAG))
 }
 
 #[cfg(test)]
@@ -392,5 +412,16 @@ mod tests {
         env.acquire("keep_awake");
         release_at(&env.lock, "telemetry").unwrap();
         assert_eq!(env.owner().as_deref(), Some("keep_awake"));
+    }
+
+    #[test]
+    fn webui_wanted_flag_presence_detected() {
+        let dir = tempfile::tempdir().unwrap();
+        let flag = dir.path().join("keep_awake_webui_wanted");
+        assert!(!is_webui_keep_awake_wanted_at(&flag));
+        std::fs::write(&flag, b"").unwrap();
+        assert!(is_webui_keep_awake_wanted_at(&flag));
+        std::fs::remove_file(&flag).unwrap();
+        assert!(!is_webui_keep_awake_wanted_at(&flag));
     }
 }

--- a/crates/tesla_telemetry/src/main.rs
+++ b/crates/tesla_telemetry/src/main.rs
@@ -327,6 +327,15 @@ async fn main() -> Result<()> {
     let mut last_location_poll: Option<Instant> = None;
     // Keep-Accessory-Power automation policy state (see keep_accessory.rs).
     let mut keep_accessory_state = keep_accessory::KeepAccessoryState::default();
+    // Sampler-emitted keep-awake nudge state (see #329 / nudge_keep_awake).
+    // `next_nudge_due_at`: when the next `wake` action should fire; `None`
+    // = fire on the first eligible tick. `nudge_retry_count`: consecutive
+    // failures in the current 3-attempt cycle. `last_nudge_notification_at`:
+    // dedup window for the "Keep awake failed (attempt 3/3)" push so a
+    // prolonged outage emits at most one notification per 10 min.
+    let mut next_nudge_due_at: Option<Instant> = None;
+    let mut nudge_retry_count: u32 = 0;
+    let mut last_nudge_notification_at: Option<Instant> = None;
 
     // SIGTERM handler — release the radio on shutdown so the iOS
     // GATT daemon can come back up cleanly.
@@ -416,6 +425,9 @@ async fn main() -> Result<()> {
                     &mut last_lon,
                     &mut last_location_name,
                     &mut last_location_poll,
+                    &mut next_nudge_due_at,
+                    &mut nudge_retry_count,
+                    &mut last_nudge_notification_at,
                 ).await;
                 // Keep-Accessory-Power automation runs after each tick
                 // with the freshly-updated signals. Best-effort; gated
@@ -504,6 +516,9 @@ async fn tick(
     last_lon: &mut Option<f64>,
     last_location_name: &mut Option<String>,
     last_location_poll: &mut Option<Instant>,
+    next_nudge_due_at: &mut Option<Instant>,
+    nudge_retry_count: &mut u32,
+    last_nudge_notification_at: &mut Option<Instant>,
 ) -> (Duration, Option<BleConfig>) {
     let cfg = match BleConfig::load() {
         Ok(c) => c,
@@ -575,6 +590,60 @@ async fn tick(
     // aborts the copy. Self-clears when the work finishes, so it can't
     // wedge the car permanently awake (see lock::keep_awake_requested).
     let keep_awake_active = lock::keep_awake_requested();
+
+    // Sampler-emitted keep-awake nudge (task #329). When opted in via
+    // BLE_KEEP_AWAKE_VIA_SAMPLER=yes and a keep-awake is in effect, emit
+    // a periodic `wake` action on the already-held PersistentSession
+    // instead of letting awake_start spawn a separate `ble-action` every
+    // 300s. The legacy path fails for two reasons that this fixes at
+    // once: (a) charge-port-close hits Domain::Infotainment which sleeps
+    // along with the main computer, while `wake` rides Domain::VehicleSecurity
+    // which stays up; (b) a second BLE client desyncs the framing on the
+    // GATT link the sampler is already holding. Both validated on-vehicle
+    // 2026-06-22 — Infotainment was deaf, a clean VCSEC wake flipped USB
+    // addressed→configured in ~4s, recording resumed. Sentry-on => car
+    // is already awake; no need to nudge.
+    if cfg.keep_awake_via_sampler && keep_awake_active && !sentry_on {
+        let now = Instant::now();
+        let due = next_nudge_due_at.map(|t| now >= t).unwrap_or(true);
+        if due {
+            let payload = sentryusb_tesla_ble::actions::wake_vehicle();
+            match session.send_action(payload).await {
+                Ok(_) => {
+                    info!("keep-awake: wake nudge sent (next in 300s)");
+                    *next_nudge_due_at = Some(now + Duration::from_secs(300));
+                    *nudge_retry_count = 0;
+                }
+                Err(e) => {
+                    *nudge_retry_count += 1;
+                    warn!(
+                        "keep-awake: wake nudge failed (attempt {}/3): {:#}",
+                        *nudge_retry_count, e
+                    );
+                    if *nudge_retry_count >= 3 {
+                        let notify_due = last_nudge_notification_at
+                            .map(|t| now.duration_since(t) >= Duration::from_secs(600))
+                            .unwrap_or(true);
+                        if notify_due {
+                            emit_keep_awake_failure_notification(&format!("{:#}", e));
+                            *last_nudge_notification_at = Some(now);
+                        }
+                        // Reset cycle so retries don't run forever at 30s
+                        // cadence; back off to the normal 300s window.
+                        *nudge_retry_count = 0;
+                        *next_nudge_due_at = Some(now + Duration::from_secs(300));
+                    } else {
+                        *next_nudge_due_at = Some(now + Duration::from_secs(30));
+                    }
+                }
+            }
+        }
+    } else if !keep_awake_active {
+        // Reset cycle state once the keep-awake reason clears so the next
+        // archive starts at a clean 0/3, immediate-fire baseline.
+        *next_nudge_due_at = None;
+        *nudge_retry_count = 0;
+    }
 
     // Two paths to quiet mode: car_truly_asleep (no recent clip writes)
     // or parked_confirmed (Park 3+ polls). Both also require the car isn't
@@ -1580,6 +1649,22 @@ async fn release_radio() {
     if let Err(e) = lock::release(OWNER) {
         warn!("failed to release radio lock: {e}");
     }
+}
+
+/// Shell out to `/root/bin/send-push-message` with the same arg shape
+/// `awake_start::notify_nudge_failure` uses, so the existing SC client
+/// regex (NotificationsScreen) still routes this push into the
+/// keep-awake-failure category. Best-effort: any failure to spawn is
+/// swallowed (the nudge cycle has already done its retries; a missing
+/// FCM relay can't recover the underlying BLE failure).
+fn emit_keep_awake_failure_notification(reason: &str) {
+    let title = std::env::var("NOTIFICATION_TITLE").unwrap_or_else(|_| "SentryUSB".into());
+    let body = format!(
+        "Tesla BLE: Keep awake failed (attempt 3/3). BLE command failed. Response: {reason}"
+    );
+    let _ = std::process::Command::new("/root/bin/send-push-message")
+        .args([&format!("{title}:"), &body, "", "keep_awake_failure"])
+        .spawn();
 }
 
 #[cfg(test)]

--- a/run/awake_start
+++ b/run/awake_start
@@ -289,6 +289,20 @@ else
       if [[ -n "${TESLA_BLE_VIN:+x}" ]] && ble_is_enabled
       # use Tesla BLE API to nudge the car
       then
+        # Sampler-delegated path (task #329). When BLE_KEEP_AWAKE_VIA_SAMPLER=yes
+        # AND the sampler's IPC socket is up, the sampler is emitting the
+        # nudge itself on its already-held PersistentSession (using the
+        # `wake` verb, which rides VCSEC and lands while Infotainment is
+        # dozing). Checked per-iteration so a sampler crash mid-cycle
+        # falls back to the spawned-action path below without a break in
+        # nudge coverage.
+        if [[ "${BLE_KEEP_AWAKE_VIA_SAMPLER:-no}" =~ ^(yes|true|1)$ ]] \
+           && [[ -S /tmp/sentryusb-telemetry.sock ]]
+        then
+          log "Tesla BLE: Keep-awake nudge delegated to sampler [$(nudge_label)]."
+          retry=0
+          continue
+        fi
         # In-process bluez-based BLE — see crates/tesla_ble. Reads
         # VIN + BLE_ADAPTER from /root/sentryusb.conf, signs + sends one
         # charge-port-close, exits.


### PR DESCRIPTION
## Summary

Moves the periodic keep-awake nudge from the spawned `awake_start` ble-action loop into the telemetry sampler, and switches the verb from `charge-port-close` (`Domain::Infotainment`) to `wake` (`Domain::VehicleSecurity`). Flag-gated, default OFF.

## The bug

During an archive cycle, `awake_start` Case-3 spawns a 300s bash loop that runs `sentryusb-ble-action charge-port-close` to keep the car awake until the rsync finishes. Two failure modes that fire together as the car settles toward sleep:

1. **Wrong domain.** `charge-port-close` is `Domain::Infotainment`. Infotainment dozes with the main computer — exactly when the nudge is most needed. `wake_vehicle()` rides `Domain::VehicleSecurity`, which stays up. The author's own comment on `wake_vehicle()` in `crates/tesla_ble/src/actions.rs` spells it out: \"VCSEC controller is awake even when the main computer is asleep — this is the same path \`tesla-control wake\` uses.\"

2. **Wrong delivery.** The spawned `ble-action` tries the sampler's IPC fast-path; under stress it falls back to opening its own direct-BLE session on the GATT link the sampler is already holding. Two BLE clients on one link desync the byte framing on both sides — VCSEC session-info handshake comes back garbled, the nudge never actually lands, USB drops to `addressed`, archive aborts.

Result on affected users: \"Tesla BLE: Keep awake failed (attempt 3/3)\" push notifications during overnight archives, archive aborts mid-cycle.

## The fix

When `BLE_KEEP_AWAKE_VIA_SAMPLER=yes`:

- `awake_start` Case-3 BLE branch checks `/tmp/sentryusb-telemetry.sock` per-iteration. Socket up → log \"delegated to sampler\" and skip the `ble-action` call. Socket down (sampler crashed/restarting) → fall through to today's path. No coverage gap.
- Sampler tick loop emits `wake_vehicle()` on its already-held PersistentSession every 300s while a keep-awake is in effect. Reuses the in-process BLE handle that's already production-hardened across the existing reconnect-in-3s machinery.
- 30s × 3 retry cadence matches the legacy path so the SC client's existing \"Keep awake failed (attempt 3/3)\" regex still fires. 600s dedup window on the notification so a prolonged outage emits at most one push per 10 min.

Flag default OFF → behavior byte-identical to today until opted in.

## Tester UX

A startup seed writes `BLE_KEEP_AWAKE_VIA_SAMPLER=no` to `/root/sentryusb.conf` on first boot after upgrade (idempotent — won't overwrite an existing value). The Raw Configuration editor in Settings → System surfaces it as a togglable row out of the box; opt-in is one tap + Save. No restart needed — sampler re-reads the conf every tick (~15s).

## Validation

On-vehicle isolation test (Infotainment domain was deaf, drive not mounted):

\`\`\`
state=addressed         ← car asleep, drive not mounted, sampler stopped
wake → VCSEC session-info: counter=0, status=0
action OK; decrypted response = 0 bytes  ← wake DELIVERED
state=addressed
state=configured        ← FLIPPED in ~4s, USB re-mounted, recording resumes
state=configured        ← held configured the whole window
\`\`\`

Same test earlier the same hour with `ble-action wake` spawned as a separate process while the sampler held the link → framing desync logged on both sides, wake's handshake garbled, no flip. Confirms the architecture half (sampler-emit) is load-bearing, not just the verb swap.

## What does NOT change

- Tessie + Webhook keep-awake paths
- `/tmp/keep_awake_nudge_pid` semantics (still written; quiet-mode gate still works)
- `sentryusb-ble-action` binary (kept for one-off SC/web actions and the fallback path)
- Keep-Accessory (12V) feature
- Failure-notification format (SC client regex still matches)
- Case 1 / Case 2 toggles, archiveloop, sampler reconnect logic

## Rollback

Two levers if a tester hits trouble:

1. Per-Pi: flip the toggle to `no` in Settings → System → Raw Configuration (re-read every tick — no restart). Falls through to today's legacy path immediately.
2. Pre-release: demote so new installs don't pull it.

## Commits

- extend `keep_awake_requested()` to also consult `/tmp/keep_awake_webui_wanted` (strict improvement; lands cleanly even if the rest gets reverted)
- add `BLE_KEEP_AWAKE_VIA_SAMPLER` to `BleConfig`
- sampler tick-time nudge scheduler + emission using `wake_vehicle()`
- `awake_start` per-iteration delegation check
- startup seed so the editor surfaces the toggle out of the box

Closes #329.