### PR TITLE
fix(keep-awake): stop log-flood in sampler-delegate branch (#113 follow-up)

### DIFF
--- a/run/awake_start
+++ b/run/awake_start
@@ -295,18 +295,18 @@ else
         # `wake` verb, which rides VCSEC and lands while Infotainment is
         # dozing). Checked per-iteration so a sampler crash mid-cycle
         # falls back to the spawned-action path below without a break in
-        # nudge coverage.
+        # nudge coverage. Structured as an if/else (NOT if + `continue`)
+        # so the delegate branch falls through to the bottom-of-loop
+        # sleep instead of busy-looping the log line every tick.
         if [[ "${BLE_KEEP_AWAKE_VIA_SAMPLER:-no}" =~ ^(yes|true|1)$ ]] \
            && [[ -S /tmp/sentryusb-telemetry.sock ]]
         then
           log "Tesla BLE: Keep-awake nudge delegated to sampler [$(nudge_label)]."
           retry=0
-          continue
-        fi
         # In-process bluez-based BLE — see crates/tesla_ble. Reads
         # VIN + BLE_ADAPTER from /root/sentryusb.conf, signs + sends one
         # charge-port-close, exits.
-        if ! BLE_response=$(/root/bin/sentryusb-ble-action charge-port-close 2>&1)
+        elif ! BLE_response=$(/root/bin/sentryusb-ble-action charge-port-close 2>&1)
         then
           # check false-negative BLE responses
           if [[ ( "$BLE_response" != *"already closed"* ) && ( "$BLE_response" != *"cable connected"* ) ]]


### PR DESCRIPTION
## Summary

Hotfix for a bug introduced in #113: the sampler-delegate branch in `awake_start`'s Case-3 BLE nudge loop used `continue` to skip the legacy `ble-action` spawn, but `continue` also skipped the `sleep \$NUDGE_INTERVAL` at the bottom of the while-loop body — so the loop hammered the \"Keep-awake nudge delegated to sampler [Archive]\" log line every CPU tick instead of once per 300s.

Reported by a tester on v3.11.10 with `BLE_KEEP_AWAKE_VIA_SAMPLER=yes` during an archive cycle. Log was filling at thousands of lines per second.

## The fix

Restructured the delegate check from `if delegate { ... continue }` to `if delegate { ... } elif ble-action { ... }`. The delegate branch now logs once + falls through to the bottom-of-loop sleep, exactly matching the cadence of the legacy `ble-action` success path it replaces.

## Who's affected

- v3.11.10 testers with `BLE_KEEP_AWAKE_VIA_SAMPLER=yes` (or `true`/`1`) **and** an active archive cycle.
- Default `=no` users were unaffected — the regex didn't match, the legacy `ble-action` path ran with its own sleep.

## Immediate workaround for affected testers (no upgrade required)

Flip the flag back to `no` until the v3.11.11 pre-release ships:

\`\`\`bash
sudo /root/bin/remountfs_rw && sudo sed -i 's/^BLE_KEEP_AWAKE_VIA_SAMPLER=.*/BLE_KEEP_AWAKE_VIA_SAMPLER=no/' /root/sentryusb.conf
\`\`\`

No service restart needed (sampler re-reads next tick; awake_start picks it up next loop iteration). On the next pre-release with this fix, they can opt back in.

## Crash-safety

Per-iteration delegation check preserved — if the sampler crashes mid-archive, the next iteration's `-S /tmp/sentryusb-telemetry.sock` test fails, the `elif` fires `ble-action`, no coverage gap.

Closes #329 follow-up.