### PR TITLE
feat(keep-awake): 4-valued sampler verb (off/wake/charge-port-close/combo)

### DIFF
--- a/crates/api/src/ble.rs
+++ b/crates/api/src/ble.rs
@@ -156,7 +156,13 @@ pub fn migrate_legacy_ble_flag() {
 /// editor surface the key as a togglable row out of the box, instead
 /// of forcing every tester to add it by hand with the `+` button.
 /// Idempotent — skips if the key is already set (so a tester who
-/// flipped it to `yes` doesn't get clobbered back to `no` on restart).
+/// flipped it doesn't get clobbered back to `no` on restart).
+///
+/// Accepted values (parsed in `tesla_telemetry::config`):
+///   * `no` (default) → legacy spawned `ble-action charge-port-close`
+///   * `wake` (or `yes`/`true`/`1`) → sampler-emit + VCSEC wake
+///   * `charge-port-close` → sampler-emit + Infotainment charge-port-close
+///   * `combo` → sampler-emit + wake → 2s pause → charge-port-close
 pub fn ensure_keep_awake_via_sampler_key_present() {
     let config_path = sentryusb_config::find_config_path();
     let Ok((mut active, _commented)) = sentryusb_config::parse_file(config_path) else {

--- a/crates/tesla_telemetry/src/config.rs
+++ b/crates/tesla_telemetry/src/config.rs
@@ -53,15 +53,42 @@ pub struct BleConfig {
     /// install, so a pre-release build never changes behavior unless a
     /// tester explicitly turns it on. See the consolidation RFC.
     pub experimental: bool,
-    /// Emit periodic keep-awake nudges from inside the sampler on its
-    /// already-held PersistentSession instead of having `awake_start`
-    /// spawn a separate `ble-action` process every 300s. Default OFF
-    /// — set `BLE_KEEP_AWAKE_VIA_SAMPLER=yes` to enable. When on,
-    /// `awake_start`'s Case-3 BLE branch skips its `ble-action` call
-    /// while the sampler socket is present and lets the sampler emit
-    /// the nudge. When off (or the sampler is down), the legacy
-    /// spawned-loop path stays in charge. See task #329.
-    pub keep_awake_via_sampler: bool,
+    /// Which BLE verb (if any) the sampler emits as its periodic
+    /// keep-awake nudge. Default `Off` — when off, `awake_start`'s
+    /// legacy spawned `ble-action charge-port-close` path stays in
+    /// charge. When non-`Off`, the sampler emits the nudge on its
+    /// already-held PersistentSession every 300s and `awake_start`'s
+    /// Case-3 BLE branch delegates to it. See task #329.
+    ///
+    /// Conf key: `BLE_KEEP_AWAKE_VIA_SAMPLER`. Accepted values:
+    ///   * `no` / unset → `Off` (default; legacy charge-port-close path)
+    ///   * `wake` / `yes` / `true` / `1` → `Wake` (VCSEC domain — bumps
+    ///     car out of doze; the 2026-06-10 investigation noted it only
+    ///     wakes momentarily and doesn't reliably hold)
+    ///   * `charge-port-close` / `charge_port_close` → `ChargePortClose`
+    ///     (Infotainment domain — the team-validated "actually holds"
+    ///     verb, on the warm sampler session this time)
+    ///   * `combo` / `wake+charge-port-close` → `Combo` (send `wake`
+    ///     first, ~2s pause, then `charge-port-close` — uses the wake
+    ///     to bump the car out of doze so charge-port-close lands while
+    ///     Infotainment is awake)
+    pub keep_awake_mode: KeepAwakeMode,
+}
+
+/// What the sampler-emitted keep-awake nudge does each cycle. See
+/// `BleConfig::keep_awake_mode` for value semantics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeepAwakeMode {
+    Off,
+    Wake,
+    ChargePortClose,
+    Combo,
+}
+
+impl Default for KeepAwakeMode {
+    fn default() -> Self {
+        Self::Off
+    }
 }
 
 impl Default for BleConfig {
@@ -73,7 +100,7 @@ impl Default for BleConfig {
             keep_accessory: KeepAccessoryConfig::default(),
             away_auto_enabled: false,
             experimental: false,
-            keep_awake_via_sampler: false,
+            keep_awake_mode: KeepAwakeMode::Off,
         }
     }
 }
@@ -176,18 +203,29 @@ impl BleConfig {
         .map(|v| matches!(v.as_str(), "yes" | "true" | "1"))
         .unwrap_or(false);
 
-        // Sampler-emitted keep-awake nudge opt-in. Default OFF — when
-        // the flag isn't set, behavior is byte-for-byte the legacy
-        // spawned `ble-action charge-port-close` loop. Read fresh on
-        // every loop iteration so a tester can flip it via a conf edit
-        // without bouncing the service.
-        let keep_awake_via_sampler = sentryusb_config::get_config_value(
+        // Sampler-emitted keep-awake nudge mode. Default Off — when off,
+        // behavior is byte-for-byte the legacy spawned
+        // `ble-action charge-port-close` loop. Read fresh on every loop
+        // iteration so a tester can flip the value via a conf edit
+        // without bouncing the service. `yes` / `true` / `1` are kept
+        // as aliases for `wake` so testers on v3.11.10 / v3.11.11 don't
+        // have to re-flip after upgrade.
+        let keep_awake_mode = match sentryusb_config::get_config_value(
             &active,
             &commented,
             "BLE_KEEP_AWAKE_VIA_SAMPLER",
         )
-        .map(|v| matches!(v.as_str(), "yes" | "true" | "1"))
-        .unwrap_or(false);
+        .as_deref()
+        {
+            Some("wake") | Some("yes") | Some("true") | Some("1") => KeepAwakeMode::Wake,
+            Some("charge-port-close") | Some("charge_port_close") => {
+                KeepAwakeMode::ChargePortClose
+            }
+            Some("combo") | Some("wake+charge-port-close") | Some("wake+charge_port_close") => {
+                KeepAwakeMode::Combo
+            }
+            _ => KeepAwakeMode::Off,
+        };
 
         Ok(Self {
             enabled,
@@ -196,7 +234,7 @@ impl BleConfig {
             keep_accessory,
             away_auto_enabled,
             experimental,
-            keep_awake_via_sampler,
+            keep_awake_mode,
         })
     }
 }

--- a/crates/tesla_telemetry/src/main.rs
+++ b/crates/tesla_telemetry/src/main.rs
@@ -34,7 +34,7 @@ use rusqlite::Connection;
 use tokio::sync::mpsc;
 use tracing::{debug, error, info, warn};
 
-use crate::config::BleConfig;
+use crate::config::{BleConfig, KeepAwakeMode};
 use crate::sample::Sample;
 use crate::usb_watch::CarState;
 
@@ -592,33 +592,70 @@ async fn tick(
     let keep_awake_active = lock::keep_awake_requested();
 
     // Sampler-emitted keep-awake nudge (task #329). When opted in via
-    // BLE_KEEP_AWAKE_VIA_SAMPLER=yes and a keep-awake is in effect, emit
-    // a periodic `wake` action on the already-held PersistentSession
-    // instead of letting awake_start spawn a separate `ble-action` every
-    // 300s. The legacy path fails for two reasons that this fixes at
-    // once: (a) charge-port-close hits Domain::Infotainment which sleeps
-    // along with the main computer, while `wake` rides Domain::VehicleSecurity
-    // which stays up; (b) a second BLE client desyncs the framing on the
-    // GATT link the sampler is already holding. Both validated on-vehicle
-    // 2026-06-22 — Infotainment was deaf, a clean VCSEC wake flipped USB
-    // addressed→configured in ~4s, recording resumed. Sentry-on => car
-    // is already awake; no need to nudge.
-    if cfg.keep_awake_via_sampler && keep_awake_active && !sentry_on {
+    // BLE_KEEP_AWAKE_VIA_SAMPLER and a keep-awake is in effect, emit a
+    // periodic action on the already-held PersistentSession instead of
+    // letting awake_start spawn a separate `ble-action` every 300s. The
+    // legacy path fails for two reasons that the sampler-emit fixes at
+    // once: (a) the spawned `ble-action` is a second BLE client on the
+    // same GATT link as the sampler — framing desync on both sides; (b)
+    // when the conf selects the `wake` verb instead of `charge-port-close`,
+    // the nudge rides Domain::VehicleSecurity which stays up while
+    // Infotainment is dozing. Conf supports `wake`, `charge-port-close`,
+    // and `combo` (wake → 2s pause → charge-port-close) so the verb axis
+    // can be tuned independently from the architecture change. Sentry-on
+    // => car is already awake; no need to nudge.
+    if cfg.keep_awake_mode != KeepAwakeMode::Off && keep_awake_active && !sentry_on {
         let now = Instant::now();
         let due = next_nudge_due_at.map(|t| now >= t).unwrap_or(true);
         if due {
-            let payload = sentryusb_tesla_ble::actions::wake_vehicle();
-            match session.send_action(payload).await {
+            let verb_label = match cfg.keep_awake_mode {
+                KeepAwakeMode::Wake => "wake",
+                KeepAwakeMode::ChargePortClose => "charge-port-close",
+                KeepAwakeMode::Combo => "combo (wake + charge-port-close)",
+                KeepAwakeMode::Off => unreachable!(),
+            };
+            let result = match cfg.keep_awake_mode {
+                KeepAwakeMode::Wake => {
+                    session.send_action(sentryusb_tesla_ble::actions::wake_vehicle()).await
+                }
+                KeepAwakeMode::ChargePortClose => {
+                    session.send_action(sentryusb_tesla_ble::actions::charge_port_close()).await
+                }
+                KeepAwakeMode::Combo => {
+                    // Two-step nudge: wake (VCSEC) to bump the car out of
+                    // any current doze, then charge-port-close (Infotainment,
+                    // the team-validated "actually holds" verb) to land
+                    // while Infotainment is awake enough to honor it. The
+                    // ~2s pause matches the on-vehicle isolation test's
+                    // USB addressed→configured window. Wake is best-effort
+                    // (logged but not retry-driving); charge-port-close
+                    // drives the retry/notification budget.
+                    let wake_result = session
+                        .send_action(sentryusb_tesla_ble::actions::wake_vehicle())
+                        .await;
+                    match &wake_result {
+                        Ok(_) => info!("keep-awake: combo step 1/2 wake sent"),
+                        Err(e) => warn!(
+                            "keep-awake: combo step 1/2 wake failed (continuing to step 2): {:#}",
+                            e
+                        ),
+                    }
+                    tokio::time::sleep(Duration::from_secs(2)).await;
+                    session.send_action(sentryusb_tesla_ble::actions::charge_port_close()).await
+                }
+                KeepAwakeMode::Off => unreachable!(),
+            };
+            match result {
                 Ok(_) => {
-                    info!("keep-awake: wake nudge sent (next in 300s)");
+                    info!("keep-awake: {} nudge sent (next in 300s)", verb_label);
                     *next_nudge_due_at = Some(now + Duration::from_secs(300));
                     *nudge_retry_count = 0;
                 }
                 Err(e) => {
                     *nudge_retry_count += 1;
                     warn!(
-                        "keep-awake: wake nudge failed (attempt {}/3): {:#}",
-                        *nudge_retry_count, e
+                        "keep-awake: {} nudge failed (attempt {}/3): {:#}",
+                        verb_label, *nudge_retry_count, e
                     );
                     if *nudge_retry_count >= 3 {
                         let notify_due = last_nudge_notification_at

--- a/run/awake_start
+++ b/run/awake_start
@@ -289,16 +289,18 @@ else
       if [[ -n "${TESLA_BLE_VIN:+x}" ]] && ble_is_enabled
       # use Tesla BLE API to nudge the car
       then
-        # Sampler-delegated path (task #329). When BLE_KEEP_AWAKE_VIA_SAMPLER=yes
-        # AND the sampler's IPC socket is up, the sampler is emitting the
-        # nudge itself on its already-held PersistentSession (using the
-        # `wake` verb, which rides VCSEC and lands while Infotainment is
-        # dozing). Checked per-iteration so a sampler crash mid-cycle
-        # falls back to the spawned-action path below without a break in
-        # nudge coverage. Structured as an if/else (NOT if + `continue`)
-        # so the delegate branch falls through to the bottom-of-loop
-        # sleep instead of busy-looping the log line every tick.
-        if [[ "${BLE_KEEP_AWAKE_VIA_SAMPLER:-no}" =~ ^(yes|true|1)$ ]] \
+        # Sampler-delegated path (task #329). When BLE_KEEP_AWAKE_VIA_SAMPLER
+        # is set to a non-`no` value AND the sampler's IPC socket is up,
+        # the sampler is emitting the nudge itself on its already-held
+        # PersistentSession. Conf accepts `wake`, `charge-port-close`,
+        # and `combo` (wake → 2s pause → charge-port-close); `yes`/`true`/`1`
+        # are kept as aliases for `wake` so v3.11.10/v3.11.11 testers don't
+        # have to re-flip after upgrade. Checked per-iteration so a sampler
+        # crash mid-cycle falls back to the spawned-action path below without
+        # a break in nudge coverage. Structured as if/elif (NOT if + `continue`)
+        # so the delegate branch falls through to the bottom-of-loop sleep
+        # instead of busy-looping the log line every tick.
+        if [[ "${BLE_KEEP_AWAKE_VIA_SAMPLER:-no}" =~ ^(yes|true|1|wake|charge-port-close|charge_port_close|combo|wake\+charge-port-close|wake\+charge_port_close)$ ]] \
            && [[ -S /tmp/sentryusb-telemetry.sock ]]
         then
           log "Tesla BLE: Keep-awake nudge delegated to sampler [$(nudge_label)]."


### PR DESCRIPTION
## Summary

Replaces the binary `BLE_KEEP_AWAKE_VIA_SAMPLER=yes|no` from #113 with a 4-valued enum so testers can isolate the two axes that #113 bundled (verb vs. delivery), and adds a `combo` mode that stacks both verbs sequentially. Default OFF — behavior byte-identical to today until opted in.

## Why

#113 shipped sampler-emit + `wake` together behind one flag. If overnight soak shows `wake` doesn't hold (the 2026-06-10 finding from the matching card), the binary flag forces reverting BOTH the architecture and the verb together — we lose the ability to tell which axis was load-bearing.

The 4-value enum lets each axis be exercised independently, and adds a verb-stacking option:

| Value | Verb | Domain | Delivery |
|---|---|---|---|
| `no` (default) | `charge-port-close` | Infotainment | spawned `ble-action` (legacy) |
| `wake` (alias: `yes`/`true`/`1`) | `wake_vehicle` | VehicleSecurity | sampler-emit (warm session) |
| `charge-port-close` | `charge_port_close` | Infotainment | sampler-emit (warm session) |
| `combo` | both | both | sampler-emit, wake → 2s pause → charge-port-close |

The `combo` rationale: VCSEC wake bumps the car out of any current doze (validated on-vehicle 2026-06-22 — USB flipped `addressed→configured` in ~4s while Infotainment was deaf). After a 2s pause for the state transition to land, fire `charge-port-close` (Infotainment, the team-validated "actually holds" verb in this card's prior investigation). Stacks the strengths of both.

## Backward compat

v3.11.10 / v3.11.11 testers may already have `BLE_KEEP_AWAKE_VIA_SAMPLER=yes` in their conf. `yes` / `true` / `1` map to `wake` so opted-in testers keep getting the same behavior on upgrade without re-flipping.

## Retry semantics in combo mode

Wake is best-effort — logged but not retry-driving. The `charge-port-close` result determines retry / notification budget (same 30s × 3 + 600s dedup as before). So if wake fails but charge-port-close succeeds, the cycle still counts as a clean nudge. If wake succeeds but cpc fails, normal retry/notify fires.

## What does NOT change

- Default OFF behavior (no surprises for non-opt-in users)
- `awake_start`'s legacy spawned `ble-action charge-port-close` path
- Tessie / Webhook keep-awake paths
- Crash-safety per-iteration delegation check
- Notification format (SC client regex still matches)

## Testing

Bench:
1. Set `BLE_KEEP_AWAKE_VIA_SAMPLER=wake` — sampler logs `keep-awake: wake nudge sent (next in 300s)` (= v3.11.10/v3.11.11 behavior).
2. Set `=charge-port-close` — sampler logs `keep-awake: charge-port-close nudge sent`. Isolates architecture vs. verb.
3. Set `=combo` — sampler logs `keep-awake: combo step 1/2 wake sent`, 2s pause, then `keep-awake: combo (wake + charge-port-close) nudge sent`.
4. Set `=yes` — maps to `wake` (backward compat).
5. Set `=no` or unset — sampler nudge code is inert; `awake_start` runs its legacy spawned path. No regression.

`cargo test -p sentryusb-tesla-telemetry` — all 29 unit tests pass.

## Rollback

Same as before — flip the flag to `no` in `/root/sentryusb.conf` (Web UI or `sed -i`). Sampler re-reads next tick, legacy `charge-port-close` resumes immediately.

## Commits

- `feat(keep-awake): split BLE_KEEP_AWAKE_VIA_SAMPLER into 4-valued mode + add combo`

Continues #329 (#113 architecture, #114 hotfix).