### PR TITLE
fix(keep-awake): drop sentry_on guard from sampler nudge gate

### DIFF
--- a/crates/tesla_telemetry/src/main.rs
+++ b/crates/tesla_telemetry/src/main.rs
@@ -602,9 +602,18 @@ async fn tick(
     // the nudge rides Domain::VehicleSecurity which stays up while
     // Infotainment is dozing. Conf supports `wake`, `charge-port-close`,
     // and `combo` (wake → 2s pause → charge-port-close) so the verb axis
-    // can be tuned independently from the architecture change. Sentry-on
-    // => car is already awake; no need to nudge.
-    if cfg.keep_awake_mode != KeepAwakeMode::Off && keep_awake_active && !sentry_on {
+    // can be tuned independently from the architecture change.
+    //
+    // Gate is intentionally minimal — no `sentry_on` check. The legacy
+    // `awake_start` Case-3 loop nudges every 300s regardless of sentry
+    // state; this matches that. Asymmetric cost: nudging when sentry is
+    // genuinely on is a harmless no-op (car already awake, BLE round-trip
+    // costs nothing), but skipping a nudge when sentry's actually off is
+    // archive-breaking. Earlier versions gated on `!sentry_on` which broke
+    // on bench (no car => sentry_on defaults to true => nudge never fires)
+    // and would also block legit nudges if the sampler missed one sentry
+    // read on a real car.
+    if cfg.keep_awake_mode != KeepAwakeMode::Off && keep_awake_active {
         let now = Instant::now();
         let due = next_nudge_due_at.map(|t| now >= t).unwrap_or(true);
         if due {


### PR DESCRIPTION
## Summary

Drop the `!sentry_on` clause from the sampler nudge gate added in #115. The legacy `awake_start` Case-3 loop nudges every 300s regardless of sentry state; we now match that.

## The problem

`sentry_on` defaults to `true` when the sampler can't read it from the car. With the previous gate (`keep_awake_mode != Off && keep_awake_active && !sentry_on`), the nudge never fires when:

- The Pi is on the bench (no car to read sentry from)
- The Pi is in the car but the BLE link blips for one tick

Validated on r03 today (v3.11.12 binary, `BLE_KEEP_AWAKE_VIA_SAMPLER=combo`, `keep_awake_active=true`): the v3.11.12 binary loaded combo correctly, but the gate held the nudge off because `sentry_on=true [DEFAULTED: unread]`.

## The fix

```rust
// before
if cfg.keep_awake_mode != KeepAwakeMode::Off && keep_awake_active && !sentry_on { ... }
// after
if cfg.keep_awake_mode != KeepAwakeMode::Off && keep_awake_active { ... }
```

Asymmetric cost analysis:

- Nudging when sentry is genuinely on: **harmless no-op** (car already awake, BLE round-trip costs nothing).
- Skipping a nudge when sentry is actually off: **archive-breaking** (the whole reason the nudge exists).

The legacy `awake_start` charge-port-close loop has no sentry gate either — this matches its semantics.

## Testing

- `cargo test -p sentryusb-tesla-telemetry` — all 29 unit tests pass.
- Bench validation post-deploy: r03 with `BLE_KEEP_AWAKE_VIA_SAMPLER=combo` will now log `keep-awake: combo step 1/2 wake sent` etc. every 300s during an active keep-awake. Both BLE sends fail (no car in range) but the code path executes, proving conf parsing + dispatch + retry logic work end-to-end.

## Rollback

Same as before — flip `BLE_KEEP_AWAKE_VIA_SAMPLER` back to `no` in `/root/sentryusb.conf`. No code-revert needed.

Continues #329 (#113 architecture, #114 loop-flood hotfix, #115 4-value enum).