### PR TITLE
fix(keep-awake): stop heartbeat from clobbering manual-mode duration to 10m

### DIFF
--- a/crates/api/src/keep_awake.rs
+++ b/crates/api/src/keep_awake.rs
@@ -129,16 +129,27 @@ impl KeepAwakeManager {
     }
 
     /// Auto-mode heartbeat: extend by AUTO_TIMEOUT, start if idle.
+    ///
+    /// Manual-mode sessions are NOT extended — the user picked an explicit
+    /// duration that the heartbeat must not silently shorten. Previously the
+    /// `Active` arm unconditionally set `expires_at = now + AUTO_TIMEOUT`,
+    /// which meant the web UI's periodic heartbeat clobbered a 2-hour manual
+    /// session down to a rolling 10-minute window — manual timers visibly
+    /// reset themselves to 10 min after the first heartbeat tick.
     pub async fn heartbeat(self: &Arc<Self>) -> KaState {
         {
             let mut inner = self.inner.lock().await;
             match inner.state {
                 KaState::Active => {
-                    inner.expires_at = Some(SystemTime::now() + AUTO_TIMEOUT);
+                    if inner.mode == "auto" {
+                        inner.expires_at = Some(SystemTime::now() + AUTO_TIMEOUT);
+                    }
                     return KaState::Active;
                 }
                 KaState::Pending => {
-                    inner.pending_duration = AUTO_TIMEOUT;
+                    if inner.mode == "auto" {
+                        inner.pending_duration = AUTO_TIMEOUT;
+                    }
                     return KaState::Pending;
                 }
                 KaState::Idle => {}


### PR DESCRIPTION
## Summary

`/api/keep-awake/heartbeat` was rewriting `expires_at = now + AUTO_TIMEOUT` whenever the session was Active, regardless of mode. Result: a tester who set manual keep-awake to 120 min would watch the timer silently reset to 10 min the moment the web UI's background heartbeat fired (~5 min in), and the session ended ~15 min after start.

Fix gates the heartbeat extension on `mode == "auto"`. Auto-mode is the original design intent of the heartbeat (clients keep a background session alive); manual-mode users picked an explicit duration we must honor exactly.

## Repro (without this fix)

1. SC or web UI → Keep Awake → Manual, 120 min
2. Wait ~5 min for the web UI's `setInterval` heartbeat to fire
3. `expires_at` flips from `now + 7200s` to `now + 600s`
4. Session expires ~15 min after start instead of 120 min

## Files

- `crates/api/src/keep_awake.rs` — `heartbeat()` `Active` and `Pending` arms guarded on `inner.mode == "auto"`

`Idle` fall-through (heartbeat-creates-an-auto-session) unchanged. Auto-mode behavior unchanged.

## Tracking

Reported in card 1803733817064687438. Same field bug as #329's overnight soak interpretation issue — manual sessions ending early made it look like the BLE nudge couldn't hold the car, when in fact the timer had silently re-armed for 10 min and just elapsed.