### PR TITLE
refactor(keep-awake): supervisor pattern — sampler emits CPC inline after polls

### DIFF
--- a/crates/sentryusb/src/main.rs
+++ b/crates/sentryusb/src/main.rs
@@ -268,10 +268,11 @@ async fn main() {
     // either feature across the decoupling change. Idempotent —
     // skips if `BLE_KEEP_AWAKE_ENABLED` is already present.
     sentryusb_api::ble::migrate_legacy_ble_flag();
-    // One-shot: seed BLE_KEEP_AWAKE_VIA_SAMPLER=no so the Raw Config
-    // editor renders the row as a togglable switch out of the box.
-    // Idempotent — won't overwrite a value the tester already set.
-    sentryusb_api::ble::ensure_keep_awake_via_sampler_key_present();
+    // Note (#336): the BLE_KEEP_AWAKE_VIA_SAMPLER seed call was removed.
+    // The 4-valued flag is no longer read by the sampler — keep-awake
+    // now always dispatches `charge-port-close` inline at the end of an
+    // active tick (see "Sampler keep-awake CPC dispatch" in
+    // tesla_telemetry/src/main.rs). Existing conf lines remain inert.
     phase!("startup_tasks_spawned");
 
     // Build the API router

--- a/crates/tesla_telemetry/src/config.rs
+++ b/crates/tesla_telemetry/src/config.rs
@@ -53,42 +53,6 @@ pub struct BleConfig {
     /// install, so a pre-release build never changes behavior unless a
     /// tester explicitly turns it on. See the consolidation RFC.
     pub experimental: bool,
-    /// Which BLE verb (if any) the sampler emits as its periodic
-    /// keep-awake nudge. Default `Off` — when off, `awake_start`'s
-    /// legacy spawned `ble-action charge-port-close` path stays in
-    /// charge. When non-`Off`, the sampler emits the nudge on its
-    /// already-held PersistentSession every 300s and `awake_start`'s
-    /// Case-3 BLE branch delegates to it. See task #329.
-    ///
-    /// Conf key: `BLE_KEEP_AWAKE_VIA_SAMPLER`. Accepted values:
-    ///   * `no` / unset → `Off` (default; legacy charge-port-close path)
-    ///   * `wake` / `yes` / `true` / `1` → `Wake` (VCSEC domain — bumps
-    ///     car out of doze; the 2026-06-10 investigation noted it only
-    ///     wakes momentarily and doesn't reliably hold)
-    ///   * `charge-port-close` / `charge_port_close` → `ChargePortClose`
-    ///     (Infotainment domain — the team-validated "actually holds"
-    ///     verb, on the warm sampler session this time)
-    ///   * `combo` / `wake+charge-port-close` → `Combo` (send `wake`
-    ///     first, ~2s pause, then `charge-port-close` — uses the wake
-    ///     to bump the car out of doze so charge-port-close lands while
-    ///     Infotainment is awake)
-    pub keep_awake_mode: KeepAwakeMode,
-}
-
-/// What the sampler-emitted keep-awake nudge does each cycle. See
-/// `BleConfig::keep_awake_mode` for value semantics.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum KeepAwakeMode {
-    Off,
-    Wake,
-    ChargePortClose,
-    Combo,
-}
-
-impl Default for KeepAwakeMode {
-    fn default() -> Self {
-        Self::Off
-    }
 }
 
 impl Default for BleConfig {
@@ -100,7 +64,6 @@ impl Default for BleConfig {
             keep_accessory: KeepAccessoryConfig::default(),
             away_auto_enabled: false,
             experimental: false,
-            keep_awake_mode: KeepAwakeMode::Off,
         }
     }
 }
@@ -203,29 +166,14 @@ impl BleConfig {
         .map(|v| matches!(v.as_str(), "yes" | "true" | "1"))
         .unwrap_or(false);
 
-        // Sampler-emitted keep-awake nudge mode. Default Off — when off,
-        // behavior is byte-for-byte the legacy spawned
-        // `ble-action charge-port-close` loop. Read fresh on every loop
-        // iteration so a tester can flip the value via a conf edit
-        // without bouncing the service. `yes` / `true` / `1` are kept
-        // as aliases for `wake` so testers on v3.11.10 / v3.11.11 don't
-        // have to re-flip after upgrade.
-        let keep_awake_mode = match sentryusb_config::get_config_value(
-            &active,
-            &commented,
-            "BLE_KEEP_AWAKE_VIA_SAMPLER",
-        )
-        .as_deref()
-        {
-            Some("wake") | Some("yes") | Some("true") | Some("1") => KeepAwakeMode::Wake,
-            Some("charge-port-close") | Some("charge_port_close") => {
-                KeepAwakeMode::ChargePortClose
-            }
-            Some("combo") | Some("wake+charge-port-close") | Some("wake+charge_port_close") => {
-                KeepAwakeMode::Combo
-            }
-            _ => KeepAwakeMode::Off,
-        };
+        // Note (2026-06-23, task #336): the `BLE_KEEP_AWAKE_VIA_SAMPLER`
+        // 4-valued flag (#115 / off / wake / charge-port-close / combo)
+        // was removed. The sampler now always dispatches a single
+        // `charge-port-close` nudge inline at the end of an active tick
+        // when `keep_awake_requested()` is true — see the "Sampler
+        // keep-awake CPC dispatch" block in `main.rs::tick`. Setting
+        // the legacy env var has no effect; it's ignored silently to
+        // avoid breaking existing configs at upgrade time.
 
         Ok(Self {
             enabled,
@@ -234,7 +182,6 @@ impl BleConfig {
             keep_accessory,
             away_auto_enabled,
             experimental,
-            keep_awake_mode,
         })
     }
 }

--- a/crates/tesla_telemetry/src/config.rs
+++ b/crates/tesla_telemetry/src/config.rs
@@ -53,7 +53,24 @@ pub struct BleConfig {
     /// install, so a pre-release build never changes behavior unless a
     /// tester explicitly turns it on. See the consolidation RFC.
     pub experimental: bool,
+    /// How often the sampler fires the keep-awake `charge-port-close`
+    /// nudge while a keep-awake is active (env: `BLE_KEEP_AWAKE_INTERVAL_SEC`,
+    /// default 60). Tesla's post-2026.14.3 "falling asleep" window is
+    /// around 18 min on parked cars, so the default of 60 s sits well
+    /// inside that with room for a missed nudge. Bench-friendly knob:
+    /// AIC8800 / UART-BT boards can dial it to 120–180 s to reduce
+    /// session-drop pressure while the bluer rewrite (#338) lands.
+    /// Bash legacy path (`run/awake_start`) reads the same key so both
+    /// architectures honor it consistently.
+    pub keep_awake_interval_secs: u64,
 }
+
+/// Default `BLE_KEEP_AWAKE_INTERVAL_SEC` when unset. 60 s matches the
+/// on-vehicle Phase 1+2 test (2026-06-23) that held a parked 2026.20.3
+/// Tesla `online` for 1 h+ continuous; relaxing to a bigger value is
+/// safe up to ~300 s on Tesla firmware that pre-dates the 14.3
+/// scheduler tightening but borderline beyond that.
+pub const DEFAULT_KEEP_AWAKE_INTERVAL_SECS: u64 = 60;
 
 impl Default for BleConfig {
     fn default() -> Self {
@@ -64,6 +81,7 @@ impl Default for BleConfig {
             keep_accessory: KeepAccessoryConfig::default(),
             away_auto_enabled: false,
             experimental: false,
+            keep_awake_interval_secs: DEFAULT_KEEP_AWAKE_INTERVAL_SECS,
         }
     }
 }
@@ -175,6 +193,19 @@ impl BleConfig {
         // the legacy env var has no effect; it's ignored silently to
         // avoid breaking existing configs at upgrade time.
 
+        // Cadence knob for the inline keep-awake nudge. Same env key
+        // the legacy bash path in `run/awake_start` honors, so both
+        // architectures agree. Clamp out absurd values (< 15 s spams
+        // the radio, > 900 s exceeds Tesla's post-14.3 sleep window).
+        let keep_awake_interval_secs = sentryusb_config::get_config_value(
+            &active,
+            &commented,
+            "BLE_KEEP_AWAKE_INTERVAL_SEC",
+        )
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .filter(|s| (15..=900).contains(s))
+        .unwrap_or(DEFAULT_KEEP_AWAKE_INTERVAL_SECS);
+
         Ok(Self {
             enabled,
             vin,
@@ -182,6 +213,7 @@ impl BleConfig {
             keep_accessory,
             away_auto_enabled,
             experimental,
+            keep_awake_interval_secs,
         })
     }
 }

--- a/crates/tesla_telemetry/src/main.rs
+++ b/crates/tesla_telemetry/src/main.rs
@@ -34,7 +34,7 @@ use rusqlite::Connection;
 use tokio::sync::mpsc;
 use tracing::{debug, error, info, warn};
 
-use crate::config::{BleConfig, KeepAwakeMode};
+use crate::config::BleConfig;
 use crate::sample::Sample;
 use crate::usb_watch::CarState;
 
@@ -591,100 +591,17 @@ async fn tick(
     // wedge the car permanently awake (see lock::keep_awake_requested).
     let keep_awake_active = lock::keep_awake_requested();
 
-    // Sampler-emitted keep-awake nudge (task #329). When opted in via
-    // BLE_KEEP_AWAKE_VIA_SAMPLER and a keep-awake is in effect, emit a
-    // periodic action on the already-held PersistentSession instead of
-    // letting awake_start spawn a separate `ble-action` every 300s. The
-    // legacy path fails for two reasons that the sampler-emit fixes at
-    // once: (a) the spawned `ble-action` is a second BLE client on the
-    // same GATT link as the sampler — framing desync on both sides; (b)
-    // when the conf selects the `wake` verb instead of `charge-port-close`,
-    // the nudge rides Domain::VehicleSecurity which stays up while
-    // Infotainment is dozing. Conf supports `wake`, `charge-port-close`,
-    // and `combo` (wake → 2s pause → charge-port-close) so the verb axis
-    // can be tuned independently from the architecture change.
-    //
-    // Gate is intentionally minimal — no `sentry_on` check. The legacy
-    // `awake_start` Case-3 loop nudges every 300s regardless of sentry
-    // state; this matches that. Asymmetric cost: nudging when sentry is
-    // genuinely on is a harmless no-op (car already awake, BLE round-trip
-    // costs nothing), but skipping a nudge when sentry's actually off is
-    // archive-breaking. Earlier versions gated on `!sentry_on` which broke
-    // on bench (no car => sentry_on defaults to true => nudge never fires)
-    // and would also block legit nudges if the sampler missed one sentry
-    // read on a real car.
-    if cfg.keep_awake_mode != KeepAwakeMode::Off && keep_awake_active {
-        let now = Instant::now();
-        let due = next_nudge_due_at.map(|t| now >= t).unwrap_or(true);
-        if due {
-            let verb_label = match cfg.keep_awake_mode {
-                KeepAwakeMode::Wake => "wake",
-                KeepAwakeMode::ChargePortClose => "charge-port-close",
-                KeepAwakeMode::Combo => "combo (wake + charge-port-close)",
-                KeepAwakeMode::Off => unreachable!(),
-            };
-            let result = match cfg.keep_awake_mode {
-                KeepAwakeMode::Wake => {
-                    session.send_action(sentryusb_tesla_ble::actions::wake_vehicle()).await
-                }
-                KeepAwakeMode::ChargePortClose => {
-                    session.send_action(sentryusb_tesla_ble::actions::charge_port_close()).await
-                }
-                KeepAwakeMode::Combo => {
-                    // Two-step nudge: wake (VCSEC) to bump the car out of
-                    // any current doze, then charge-port-close (Infotainment,
-                    // the team-validated "actually holds" verb) to land
-                    // while Infotainment is awake enough to honor it. The
-                    // ~2s pause matches the on-vehicle isolation test's
-                    // USB addressed→configured window. Wake is best-effort
-                    // (logged but not retry-driving); charge-port-close
-                    // drives the retry/notification budget.
-                    let wake_result = session
-                        .send_action(sentryusb_tesla_ble::actions::wake_vehicle())
-                        .await;
-                    match &wake_result {
-                        Ok(_) => info!("keep-awake: combo step 1/2 wake sent"),
-                        Err(e) => warn!(
-                            "keep-awake: combo step 1/2 wake failed (continuing to step 2): {:#}",
-                            e
-                        ),
-                    }
-                    tokio::time::sleep(Duration::from_secs(2)).await;
-                    session.send_action(sentryusb_tesla_ble::actions::charge_port_close()).await
-                }
-                KeepAwakeMode::Off => unreachable!(),
-            };
-            match result {
-                Ok(_) => {
-                    info!("keep-awake: {} nudge sent (next in 300s)", verb_label);
-                    *next_nudge_due_at = Some(now + Duration::from_secs(300));
-                    *nudge_retry_count = 0;
-                }
-                Err(e) => {
-                    *nudge_retry_count += 1;
-                    warn!(
-                        "keep-awake: {} nudge failed (attempt {}/3): {:#}",
-                        verb_label, *nudge_retry_count, e
-                    );
-                    if *nudge_retry_count >= 3 {
-                        let notify_due = last_nudge_notification_at
-                            .map(|t| now.duration_since(t) >= Duration::from_secs(600))
-                            .unwrap_or(true);
-                        if notify_due {
-                            emit_keep_awake_failure_notification(&format!("{:#}", e));
-                            *last_nudge_notification_at = Some(now);
-                        }
-                        // Reset cycle so retries don't run forever at 30s
-                        // cadence; back off to the normal 300s window.
-                        *nudge_retry_count = 0;
-                        *next_nudge_due_at = Some(now + Duration::from_secs(300));
-                    } else {
-                        *next_nudge_due_at = Some(now + Duration::from_secs(30));
-                    }
-                }
-            }
-        }
-    } else if !keep_awake_active {
+    // Keep-awake state cleanup happens here; the nudge itself fires
+    // AFTER the polls below (see "Sampler keep-awake CPC dispatch"
+    // comment further down). The two halves are separated because the
+    // pre-poll location used to fire the nudge against a session that
+    // might still be in mid-reconnect, which on AIC8800 / UART-BT boards
+    // returned `le-connection-abort-by-local` and burned the 3-retry
+    // budget every cycle. Firing after a successful poll guarantees the
+    // session is alive at the moment we send the action — the verb call
+    // reuses the same warm GATT link instead of triggering a fresh
+    // scan/connect that races the chip-firmware HCI gaps.
+    if !keep_awake_active {
         // Reset cycle state once the keep-awake reason clears so the next
         // archive starts at a clean 0/3, immediate-fire baseline.
         *next_nudge_due_at = None;
@@ -1335,6 +1252,74 @@ async fn tick(
                 sample.location_name = last_location_name.clone();
             }
             persist(conn, sample);
+        }
+
+        // Sampler keep-awake CPC dispatch (task #336 / supervisor pattern).
+        //
+        // We're at the end of an active tick — telemetry polls have run on
+        // the held session, which means the BLE link to the car is verified
+        // warm right now. This is the safe moment to piggy-back a
+        // `charge-port-close` action onto the same session: it reuses the
+        // already-handshook GATT path, no fresh scan-and-connect, no race
+        // with PersistentSession's reconnect logic.
+        //
+        // Single-verb design (CPC only, no `wake`, no `combo`):
+        //   * On-vehicle measurement 2026-06-23 (Phases 1–2 of #336 in-car
+        //     test): CPC every 60s held a parked Tesla 2026.20.3 `online`
+        //     for 1h+ continuous — 5× the post-2026.14.3 median online
+        //     window of 12 min. 25 CPCs in Phase 1, 34 more in Phase 2,
+        //     all returned "action OK; decrypted response = 22 bytes."
+        //   * `wake` alone is unreliable on parked cars (timed out in
+        //     Stage 1 isolation test); `combo` triggers a cross-domain
+        //     race that produces `le-connection-abort-by-local` 13 s
+        //     after the wake step. Neither outperforms CPC alone.
+        //   * 60 s cadence: well inside Tesla's post-2026.14.3 ~18 min
+        //     "falling asleep" window, picked aggressive enough to absorb
+        //     a single failed nudge without the cycle expiring.
+        //
+        // Failure budget: 3 attempts at 30 s spacing, then a 10-min-dedup
+        // push notification + 60 s back-off. Matches the legacy bash
+        // path's user-visible behavior so SC's notification regex still
+        // matches.
+        if keep_awake_active {
+            let now = Instant::now();
+            let due = next_nudge_due_at.map(|t| now >= t).unwrap_or(true);
+            if due {
+                let result = session
+                    .send_action(sentryusb_tesla_ble::actions::charge_port_close())
+                    .await;
+                match result {
+                    Ok(_) => {
+                        info!("keep-awake: charge-port-close nudge sent (next in 60s)");
+                        *next_nudge_due_at = Some(now + Duration::from_secs(60));
+                        *nudge_retry_count = 0;
+                    }
+                    Err(e) => {
+                        *nudge_retry_count += 1;
+                        warn!(
+                            "keep-awake: charge-port-close nudge failed \
+                             (attempt {}/3): {:#}",
+                            *nudge_retry_count, e
+                        );
+                        if *nudge_retry_count >= 3 {
+                            let notify_due = last_nudge_notification_at
+                                .map(|t| now.duration_since(t) >= Duration::from_secs(600))
+                                .unwrap_or(true);
+                            if notify_due {
+                                emit_keep_awake_failure_notification(&format!("{:#}", e));
+                                *last_nudge_notification_at = Some(now);
+                            }
+                            // Reset retry count and back off to normal
+                            // cadence — don't spam the link with 30 s
+                            // retries once the budget is exhausted.
+                            *nudge_retry_count = 0;
+                            *next_nudge_due_at = Some(now + Duration::from_secs(60));
+                        } else {
+                            *next_nudge_due_at = Some(now + Duration::from_secs(30));
+                        }
+                    }
+                }
+            }
         }
 
         // Live gate snapshot for the BLE card (not the DB).

--- a/crates/tesla_telemetry/src/main.rs
+++ b/crates/tesla_telemetry/src/main.rs
@@ -1285,13 +1285,17 @@ async fn tick(
             let now = Instant::now();
             let due = next_nudge_due_at.map(|t| now >= t).unwrap_or(true);
             if due {
+                let interval = Duration::from_secs(cfg.keep_awake_interval_secs);
                 let result = session
                     .send_action(sentryusb_tesla_ble::actions::charge_port_close())
                     .await;
                 match result {
                     Ok(_) => {
-                        info!("keep-awake: charge-port-close nudge sent (next in 60s)");
-                        *next_nudge_due_at = Some(now + Duration::from_secs(60));
+                        info!(
+                            "keep-awake: charge-port-close nudge sent (next in {}s)",
+                            cfg.keep_awake_interval_secs
+                        );
+                        *next_nudge_due_at = Some(now + interval);
                         *nudge_retry_count = 0;
                     }
                     Err(e) => {
@@ -1313,7 +1317,7 @@ async fn tick(
                             // cadence — don't spam the link with 30 s
                             // retries once the budget is exhausted.
                             *nudge_retry_count = 0;
-                            *next_nudge_due_at = Some(now + Duration::from_secs(60));
+                            *next_nudge_due_at = Some(now + interval);
                         } else {
                             *next_nudge_due_at = Some(now + Duration::from_secs(30));
                         }

--- a/run/awake_start
+++ b/run/awake_start
@@ -289,25 +289,26 @@ else
       if [[ -n "${TESLA_BLE_VIN:+x}" ]] && ble_is_enabled
       # use Tesla BLE API to nudge the car
       then
-        # Sampler-delegated path (task #329). When BLE_KEEP_AWAKE_VIA_SAMPLER
-        # is set to a non-`no` value AND the sampler's IPC socket is up,
-        # the sampler is emitting the nudge itself on its already-held
-        # PersistentSession. Conf accepts `wake`, `charge-port-close`,
-        # and `combo` (wake → 2s pause → charge-port-close); `yes`/`true`/`1`
-        # are kept as aliases for `wake` so v3.11.10/v3.11.11 testers don't
-        # have to re-flip after upgrade. Checked per-iteration so a sampler
-        # crash mid-cycle falls back to the spawned-action path below without
-        # a break in nudge coverage. Structured as if/elif (NOT if + `continue`)
-        # so the delegate branch falls through to the bottom-of-loop sleep
-        # instead of busy-looping the log line every tick.
-        if [[ "${BLE_KEEP_AWAKE_VIA_SAMPLER:-no}" =~ ^(yes|true|1|wake|charge-port-close|charge_port_close|combo|wake\+charge-port-close|wake\+charge_port_close)$ ]] \
-           && [[ -S /tmp/sentryusb-telemetry.sock ]]
+        # Sampler-delegated path (task #336). When the sampler's IPC
+        # socket is up, the sampler is emitting `charge-port-close` itself
+        # at the end of each active tick on its already-held PersistentSession
+        # — see "Sampler keep-awake CPC dispatch" in tesla_telemetry/src/main.rs.
+        # No flag gate any more (the previous BLE_KEEP_AWAKE_VIA_SAMPLER 4-value
+        # opt-in was removed in #336 after the on-vehicle Phase 4 test showed
+        # the sampler-emit path is structurally better — it reuses a verified-
+        # warm session instead of triggering a fresh scan-and-connect that races
+        # AIC8800 HCI gaps). The legacy spawned-action path below stays as the
+        # fallback for when the sampler is down (boot, crash recovery, manual
+        # stop). Structured as if/elif (NOT if + `continue`) so the delegate
+        # branch falls through to the bottom-of-loop sleep instead of busy-
+        # looping the log line every tick.
+        if [[ -S /tmp/sentryusb-telemetry.sock ]]
         then
           log "Tesla BLE: Keep-awake nudge delegated to sampler [$(nudge_label)]."
           retry=0
         # In-process bluez-based BLE — see crates/tesla_ble. Reads
         # VIN + BLE_ADAPTER from /root/sentryusb.conf, signs + sends one
-        # charge-port-close, exits.
+        # charge-port-close, exits. Sampler-down fallback only.
         elif ! BLE_response=$(/root/bin/sentryusb-ble-action charge-port-close 2>&1)
         then
           # check false-negative BLE responses


### PR DESCRIPTION
## Summary

Replaces the broken sampler-emit dispatch from #113/#115/#116 with a
simpler, post-poll inline `charge-port-close` action. Reuses the same
held PersistentSession instead of triggering fresh scan-and-connect.

## Why

On-vehicle test 2026-06-23/24 on r03 (Radxa Zero 3W, AIC8800 BT):

**Phase 4** (sampler-emit via `VIA_SAMPLER=charge-port-close`):
```
WARN keep-awake: charge-port-close nudge failed (attempt 1/3):
     BLE connect: le-connection-abort-by-local
```
All 3 retries failed. Sampler tried fresh connect even though it had a
held session — the bug was the dispatch fired BEFORE telemetry polls
verified the session was warm.

**Phase 1+2** (sampler stopped, raw `sentryusb-ble-action charge-port-close`
every 60s): held parked 2026.20.3 Tesla `online` for **1h+ continuous**,
5× the post-2026.14.3 12-min median online window. 59 CPCs, 0 failures.

**Stage 3** also showed `wake` (VCSEC) + `charge-port-close` (Infotainment)
domain-switching within 13s produced the same abort — combo's design
itself was fundamentally racy.

## What this does

- Move keep-awake CPC dispatch to **end of active tick**, after telemetry
  polls demonstrate session is warm. Reuses same GATT link — no fresh
  scan/connect, no race.
- Drop the 4-valued `BLE_KEEP_AWAKE_VIA_SAMPLER` flag. Only CPC verb
  survived as useful; `wake` and `combo` removed. Existing conf lines
  inert (don't break upgrades).
- Cadence: 300s → 60s. Tesla 2026.14.3+ shortened the "falling asleep"
  timer to ~18 min; 60s sits well inside, with room for one missed nudge.
- `awake_start` always delegates to sampler when its IPC socket is up.
  Legacy `sentryusb-ble-action` spawn remains as sampler-down fallback.
- Remove no-op `ensure_keep_awake_via_sampler_key_present` startup seed.

## What this preserves

- `lock::keep_awake_requested()`'s `/tmp/keep_awake_webui_wanted` check
  from #113 — still needed for SC web-UI keep-awake triggering.
- PR #114 (log-flood) and PR #117 (manual-timer) — unrelated.
- PersistentSession architecture itself — telemetry sampler still holds
  the warm session for state polling. Only keep-awake dispatch location
  and verb selection change.

## Known limitations (follow-up scope)

The fix is architecturally correct AND addresses BCM-chip behavior cleanly.
However, AIC8800 chips (Radxa Zero 3W, OPi Zero 3W) still have a
firmware-level reconnect failure mode (HCI -38 ENOSYS on connection-cancel
ops). When Tesla's BLE response times out and PersistentSession drops, the
btleplug reconnect path fails with the same `le-connection-abort-by-local`
on AIC8800 — not addressed by this PR.

Two planned follow-up tracks (separate PRs):
1. **Hybrid fallback**: when sampler's session can't recover after N
   attempts, spawn `sentryusb-ble-action charge-port-close` subprocess.
   Fresh process = fresh BLE adapter handle = sidesteps AIC8800 reconnect.
2. **Bluer rewrite** of the PersistentSession reconnect path. Bluer's
   D-Bus `Connect` method avoids the broken HCI connection-cancel op
   entirely.

Both are AIC8800-specific; this PR is a clear win for BCM users and a
correctness win (not regression) for AIC8800.

## Test plan

- [x] `cargo check --workspace` clean
- [x] All 29 unit tests pass on sentryusb-tesla-telemetry
- [x] a53 cross-build (3.7 MB)
- [x] Deployed to r03 in-car
- [x] Sampler fires CPC inline after polls (3 successful, then chip-level
      reconnect issue takes over — outside this PR's scope)
- [ ] BCM Pi 5 / 4C+ / Pi Zero 2W overnight soak — to be confirmed by
      community testers