### PR TITLE
feat(ble): force-close stale session after repeated keep-awake nudge fails

### DIFF
--- a/crates/tesla_ble/src/manager.rs
+++ b/crates/tesla_ble/src/manager.rs
@@ -167,7 +167,33 @@ enum Command {
     AddKey {
         reply: oneshot::Sender<Result<()>>,
     },
+    /// Tactical recovery: caller asks the background task to force-close
+    /// the current connection (if any) and let `ensure_connected` reopen
+    /// it on the next command. Used by the keep-awake nudge loop when
+    /// repeated in-band attempts are failing — gives a known-good
+    /// teardown when sampler's session is stuck but the chip is fine.
+    /// No-op if `state.conn` is already `None`. Cooldown-gated inside the
+    /// handler so repeated calls during one stuck window don't thrash.
+    /// `reason` is logged so the disconnect line ties to the trigger.
+    ForceReconnect {
+        reason: String,
+        reply: oneshot::Sender<ForceReconnectOutcome>,
+    },
     Shutdown,
+}
+
+/// Outcome of a [`Command::ForceReconnect`]:
+///   * `Closed` — there was a live conn and we closed it cleanly; the
+///     next query will reconnect via the normal path.
+///   * `NoConn` — sampler already had no conn (existing reconnect loop
+///     in flight). Call was a no-op.
+///   * `Cooldown` — last ForceReconnect was within the cooldown window;
+///     skipped to avoid thrashing while the car/chip is unreachable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ForceReconnectOutcome {
+    Closed,
+    NoConn,
+    Cooldown,
 }
 
 /// Per-domain authenticated session state cached across commands.
@@ -257,6 +283,11 @@ struct SessionState {
     /// link has worked at least once on this session). Reset on any
     /// successful query.
     query_timeout_retries: u32,
+    /// When [`Command::ForceReconnect`] last actually closed a conn. Gates
+    /// repeated calls (cooldown = `FORCE_RECONNECT_COOLDOWN`) so the
+    /// keep-awake nudge loop can't thrash a stuck-but-unreachable session.
+    /// `None` until the first force-reconnect; cleared on a fresh connect.
+    last_force_reconnect_at: Option<Instant>,
 }
 
 /// Timing-sample window for the percentiles. 100 ≈ 5-10 min of
@@ -289,6 +320,14 @@ const STATUS_LOG_EVERY_N_QUERIES: u32 = 25;
 /// path. Reset to 0 on any successful query.
 const MAX_QUERY_TIMEOUT_RETRIES: u32 = 2;
 
+/// Minimum time between consecutive [`Command::ForceReconnect`] actions
+/// that actually close a conn. Inside this window, ForceReconnect returns
+/// `Cooldown` and the caller falls through to existing retry/backoff.
+/// Sized to cover one full keep-awake nudge cycle (default 60 s) plus
+/// reconnect time so the loop doesn't thrash when the car/chip is
+/// genuinely unreachable.
+const FORCE_RECONNECT_COOLDOWN: Duration = Duration::from_secs(90);
+
 impl PersistentSession {
     /// Spawn the background session task and return a handle. The first
     /// `query()` triggers the actual connection. `adapter_name` forces
@@ -318,6 +357,7 @@ impl PersistentSession {
             cached_adapter: None,
             consecutive_connect_failures: 0,
             query_timeout_retries: 0,
+            last_force_reconnect_at: None,
         };
         tokio::spawn(run_session_task(state, cmd_rx));
         Self { cmd_tx }
@@ -434,6 +474,35 @@ impl PersistentSession {
             .await
             .context("PersistentSession background task has stopped")?;
         rx.await.context("session task dropped the reply channel")?
+    }
+
+    /// Tactical recovery: ask the background task to close the current
+    /// connection (if any) so the next command reopens it via the normal
+    /// `ensure_connected` path. Used by the keep-awake nudge loop when
+    /// repeated in-band attempts are failing, on the theory that the
+    /// sampler's session may be stale-but-stuck (bluez state lagging,
+    /// chip in a degraded state, etc.) while the chip itself is fine.
+    ///
+    /// Internally cooldown-gated to [`FORCE_RECONNECT_COOLDOWN`] — calls
+    /// inside that window return [`ForceReconnectOutcome::Cooldown`] and
+    /// the caller should fall through to existing retry/backoff. If
+    /// there is no live conn, returns [`ForceReconnectOutcome::NoConn`]
+    /// (existing reconnect loop is already in flight).
+    ///
+    /// `reason` is logged so the resulting disconnect line ties back to
+    /// the trigger (e.g. `"keep-awake nudge fail 2/3"`).
+    ///
+    /// This is a *recovery* tweak, not a fix for slot contention — if
+    /// the car (or whatever's holding the slot on Tesla's side) is
+    /// refusing fresh connects, the subsequent reconnect will fail too.
+    pub async fn force_reconnect(&self, reason: String) -> Result<ForceReconnectOutcome> {
+        let (tx, rx) = oneshot::channel();
+        self.cmd_tx
+            .send(Command::ForceReconnect { reason, reply: tx })
+            .await
+            .context("PersistentSession background task has stopped")?;
+        rx.await
+            .context("session task dropped the reply channel")
     }
 
     // Typed wrappers: each does a raw Infotainment `query()` and
@@ -624,6 +693,10 @@ async fn run_session_task(
                     note_successful_query(&mut state, started.elapsed().as_millis());
                 }
                 let _ = reply.send(result);
+            }
+            Command::ForceReconnect { reason, reply } => {
+                let outcome = handle_force_reconnect(&mut state, &reason).await;
+                let _ = reply.send(outcome);
             }
             Command::Shutdown => break,
         }
@@ -1470,6 +1543,7 @@ async fn ensure_connected(state: &mut SessionState) -> Result<()> {
     state.connected_at = Some(Instant::now());
     state.queries_since_connect = 0;
     state.query_timeout_retries = 0;
+    state.last_force_reconnect_at = None;
     state.last_scan_rssi = scan_rssi;
     state.last_peer_mac = Some(peer_mac);
     // Drop the old latency history — a new link negotiates fresh BLE
@@ -1654,6 +1728,102 @@ fn payload_variant_name(p: Option<&routable_message::Payload>) -> &'static str {
         Some(routable_message::Payload::SessionInfoRequest(_)) => "SessionInfoRequest",
         None => "<none>",
     }
+}
+
+/// [`Command::ForceReconnect`] handler. Closes the current connection
+/// (if any) using the same cleanup path normal transport-error teardown
+/// uses (`conn.close().await` + clear domains/queries_since_connect/
+/// connected_at + write Disconnected status). The next command then
+/// reopens via `ensure_connected`.
+///
+/// Cooldown-gated by [`FORCE_RECONNECT_COOLDOWN`] so the keep-awake
+/// nudge loop can't thrash a session while the car/chip is genuinely
+/// unreachable.
+async fn handle_force_reconnect(
+    state: &mut SessionState,
+    reason: &str,
+) -> ForceReconnectOutcome {
+    // No-op when there's no conn — existing reconnect loop is already
+    // in flight via the normal `ensure_connected` path with backoff.
+    if state.conn.is_none() {
+        debug!(
+            "PersistentSession: ForceReconnect ({}) — no conn, deferring to existing reconnect loop",
+            reason
+        );
+        return ForceReconnectOutcome::NoConn;
+    }
+    // Cooldown gate: don't force-close more than once per window. Inside
+    // the window the caller falls through to its existing retry/backoff
+    // (which will eventually escalate to its own notification path).
+    if let Some(last) = state.last_force_reconnect_at {
+        if last.elapsed() < FORCE_RECONNECT_COOLDOWN {
+            let remaining = FORCE_RECONNECT_COOLDOWN.saturating_sub(last.elapsed());
+            debug!(
+                "PersistentSession: ForceReconnect ({}) — cooldown, {}s remaining",
+                reason,
+                remaining.as_secs()
+            );
+            return ForceReconnectOutcome::Cooldown;
+        }
+    }
+    // Do the teardown. Mirror the post-transport-error cleanup so the
+    // disconnect log + status file stay consistent with the established
+    // shape (lifetime drops, percentiles, peer MAC retained for
+    // continuity, etc.). Bump lifetime_drops so a journal tail still
+    // shows the drop is happening.
+    state.lifetime_drops = state.lifetime_drops.saturating_add(1);
+    let held_secs = state
+        .connected_at
+        .map(|t| t.elapsed().as_secs())
+        .unwrap_or(0);
+    let last_ok_secs = state
+        .last_successful_query_at
+        .map(|t| t.elapsed().as_secs() as i64)
+        .unwrap_or(-1);
+    let (p50, p95, p99) = compute_percentiles(&state.recent_latencies_ms);
+    let scan_rssi_str = state
+        .last_scan_rssi
+        .map(|r| r.to_string())
+        .unwrap_or_else(|| "?".into());
+    warn!(
+        "PersistentSession: ForceReconnect — closing held conn \
+         (reason={}, held={}m{}s queries={} last_ok={}s_ago drops_total={} \
+         p50/p95/p99={}/{}/{}ms scan_rssi={})",
+        reason,
+        held_secs / 60,
+        held_secs % 60,
+        state.queries_since_connect,
+        last_ok_secs,
+        state.lifetime_drops,
+        p50,
+        p95,
+        p99,
+        scan_rssi_str,
+    );
+    // Same persistent-log row shape as a normal drop so cross-tester
+    // aggregation in the bundle works (`grep reason=ForceReconnect:`).
+    append_disconnect_log(
+        held_secs,
+        state.queries_since_connect,
+        last_ok_secs,
+        state.lifetime_drops,
+        p50,
+        p95,
+        p99,
+        state.last_scan_rssi,
+        state.framing_desync_recoveries,
+        &format!("ForceReconnect: {}", reason),
+    );
+    if let Some(conn) = state.conn.take() {
+        conn.close().await;
+    }
+    state.domains.clear();
+    state.connected_at = None;
+    state.queries_since_connect = 0;
+    state.query_timeout_retries = 0;
+    state.last_force_reconnect_at = Some(Instant::now());
+    write_status_file(state, ConnectionEvent::Disconnected);
+    ForceReconnectOutcome::Closed
 }
 
 /// Heuristic: does this error look like the BLE link dropped (vs a

--- a/crates/tesla_telemetry/src/main.rs
+++ b/crates/tesla_telemetry/src/main.rs
@@ -1305,6 +1305,38 @@ async fn tick(
                              (attempt {}/3): {:#}",
                             *nudge_retry_count, e
                         );
+                        // v3.11.17 tactical recovery: after two consecutive
+                        // in-band nudge failures, ask PersistentSession to
+                        // force-close its current connection so the next
+                        // command reopens via the normal ensure_connected
+                        // path. Targets the "sampler thinks it has a
+                        // connection but writes fail / next nudge stuck
+                        // behind bad state" case observed on BCM Pi 5 +
+                        // Rock 4C+ even after the v3.11.16 query-timeout
+                        // absorption shipped. NOT expected to fix slot
+                        // contention — if the car is genuinely refusing
+                        // fresh connects, the subsequent reconnect will
+                        // fail too. Cooldown-gated inside the handler
+                        // (FORCE_RECONNECT_COOLDOWN = 90s) so a stuck
+                        // window doesn't thrash the radio.
+                        if *nudge_retry_count == 2 {
+                            match session
+                                .force_reconnect(format!(
+                                    "keep-awake nudge fail 2/3: {:#}",
+                                    e
+                                ))
+                                .await
+                            {
+                                Ok(outcome) => info!(
+                                    "keep-awake: ForceReconnect outcome={:?}",
+                                    outcome
+                                ),
+                                Err(fe) => warn!(
+                                    "keep-awake: ForceReconnect send failed: {:#}",
+                                    fe
+                                ),
+                            }
+                        }
                         if *nudge_retry_count >= 3 {
                             let notify_due = last_nudge_notification_at
                                 .map(|t| now.duration_since(t) >= Duration::from_secs(600))

--- a/run/awake_start
+++ b/run/awake_start
@@ -231,6 +231,25 @@ else
     echo "$label"
   }
 
+  # When the sampler is handling keep-awake, the bash loop's own log line
+  # is purely a "not my job this cycle" marker — the actual nudge success
+  # or failure is logged by the sampler in its own journal. Field tester
+  # confusion ("why does it keep delegating every 5 minutes?") motivated
+  # appending the sampler's most-recent result so the bash line tells the
+  # full story in one place. Returns "sent", "failed (1/3)" etc., or
+  # empty if there's no recent sampler keep-awake line (sampler down,
+  # not nudging this window, etc.).
+  function sampler_last_nudge_status {
+    local line
+    line=$(journalctl -u sentryusb-telemetry --since "2 min ago" --no-pager 2>/dev/null \
+             | grep -E "keep-awake: .*nudge (sent|failed)" | tail -1)
+    if [[ "$line" == *"nudge sent"* ]]; then
+      echo "sent"
+    elif [[ "$line" =~ nudge\ failed\ \(attempt\ ([0-9]+/[0-9]+) ]]; then
+      echo "failed (${BASH_REMATCH[1]})"
+    fi
+  }
+
   function nudge {
     local retry=1
 
@@ -304,7 +323,11 @@ else
         # looping the log line every tick.
         if [[ -S /tmp/sentryusb-telemetry.sock ]]
         then
-          log "Tesla BLE: Keep-awake nudge delegated to sampler [$(nudge_label)]."
+          local _status _suffix
+          _status="$(sampler_last_nudge_status)"
+          _suffix=""
+          [[ -n "$_status" ]] && _suffix=" — last nudge: $_status"
+          log "Tesla BLE: Keep-awake handled by telemetry sampler [$(nudge_label)]${_suffix}."
           retry=0
         # In-process bluez-based BLE — see crates/tesla_ble. Reads
         # VIN + BLE_ADAPTER from /root/sentryusb.conf, signs + sends one


### PR DESCRIPTION
## Summary

After two consecutive in-band keep-awake nudge failures, `PersistentSession` now sends `Command::ForceReconnect` to its background task. The handler closes the held connection via the same teardown path normal transport-error recovery uses (`conn.close().await` + clear domains + reset `queries_since_connect` + reset `connected_at` + write Disconnected status). The next command reopens via the normal `ensure_connected` path with its existing backoff + adapter-rebuild machinery.

Targets the case where the sampler has a held BLE connection but writes start failing or the next nudge is stuck behind bad state — a class observed on multiple BCM Pi platforms even after v3.11.16's query-timeout absorption shipped. The previous behavior in that case was to keep trying in-band attempts 1/3 → 2/3 → 3/3 on the same (potentially stuck) connection before falling through to the push notification.

NOT expected to fix slot contention or other Tesla-side / car-side refusal modes. If the car is genuinely refusing fresh connects, the subsequent reconnect will fail too. This is a recovery tweak for the in-process held-session-but-stale case, not a replacement for the deeper diagnosis work.

## Change

- New `Command::ForceReconnect { reason, reply }` variant + `ForceReconnectOutcome` enum (`Closed` / `NoConn` / `Cooldown`)
- New `pub async fn force_reconnect(&self, reason: String) -> Result<ForceReconnectOutcome>` on `PersistentSession`
- New `handle_force_reconnect` background-task handler mirroring the existing teardown path at `manager.rs:1098-1167` (the one that already correctly does `conn.close().await`)
- New `last_force_reconnect_at` field on `SessionState`; reset on every fresh connect
- New `FORCE_RECONNECT_COOLDOWN = 90 s` constant
- Call site in `crates/tesla_telemetry/src/main.rs` keep-awake nudge fail path: on attempt 2/3, send `force_reconnect` before letting the existing path escalate to attempt 3/3

## Safety guards

- **`conn.close().await`** — actually closes at the bluez level, NOT just `state.conn.take()`. There is no `Drop` impl on `Connection` that would call disconnect implicitly; the explicit `close()` is load-bearing
- **Cooldown gate (90 s)** — repeated calls inside the window return `Cooldown` and the caller falls through to its existing retry/backoff so the loop can't thrash a stuck-but-unreachable session
- **No-op when no conn** — returns `NoConn` and defers to the existing reconnect loop (which is already in flight via the normal `ensure_connected` backoff)
- **Trigger only after 2 consecutive failures** — not every single nudge failure; matches the existing 3-attempt budget
- **Disconnect log row tagged `ForceReconnect: <reason>`** — so the resulting drop ties to the trigger in the cross-tester aggregate
- **Bumps `lifetime_drops`** + writes Disconnected status file — keeps the disconnect diagnostic shape consistent with normal teardown so the bundle's `grep reason=` aggregation continues to work

## Bash log clarity (separate small fix in same commit)

The bash `awake_start` loop's per-cycle "delegated to sampler" log line was confusing for users — read as if the bash loop was actively delegating work every cycle when it's really a no-op acknowledgment that the sampler is handling things in-process. Reworded to "Keep-awake handled by telemetry sampler" and appended the sampler's most-recent nudge result (`sent` or `failed (N/3)`) so the bash line tells the full story in one place. Pure bash, journalctl read per cycle, no Rust side changes.

## Tests

Unit tests for the existing classifier predicates (`is_transport_error` / `is_query_response_timeout` / `is_decrypt_error`) still pass — the new path is gated by call-site logic, not by predicate changes. Workspace `cargo check` clean, all 40 unit tests pass.

## Bench result (Rock 4C+, BCM4345C0)

Soaked ~57 min on real production conditions. Sampler held a 37-min continuous session, 23 keep-awake nudges all OK, 4 v3.11.16 absorbs fired naturally (kept sessions alive), 0 keep-awake failures, 0 ForceReconnect fires (never needed). The earlier debug run also exercised the ForceReconnect call site and confirmed it correctly returns `NoConn` when no session exists (the gracefully-handled edge case).

## Files changed

- `crates/tesla_ble/src/manager.rs` (+170)
- `crates/tesla_telemetry/src/main.rs` (+32)
- `run/awake_start` (+25 / -1)