### PR TITLE
fix(ble): suspend peripheral advertising during central connect (Broadcom 0x3c role-state wedge)

### DIFF
--- a/crates/tesla_ble/src/manager.rs
+++ b/crates/tesla_ble/src/manager.rs
@@ -65,6 +65,15 @@ const RECONNECT_BACKOFF_MAX: Duration = Duration::from_secs(30);
 /// a fresh D-Bus connection per reconnect).
 const ADAPTER_REBUILD_AFTER: u32 = 5;
 
+/// Flag the advertiser daemons watch to suppress advertising during a connect.
+const CONNECTING_FLAG_PATH: &str = "/tmp/ble_connecting";
+
+/// Heartbeat interval for the connecting flag (under the daemons' 15s max-age).
+const CONNECTING_FLAG_REFRESH: Duration = Duration::from_secs(5);
+
+/// Overall timeout for `Connection::open` (covers discovery/subscribe too).
+const CONNECTION_OPEN_TIMEOUT: Duration = Duration::from_secs(20);
+
 /// Seconds added to the *estimated* car clock to produce the
 /// `expires_at` field. Tesla caps this at a few minutes (commands
 /// stamped too far in the future are rejected as a replay-prevention
@@ -1465,6 +1474,40 @@ async fn handle_check_pairing(state: &mut SessionState) -> Result<PairingStatus>
     }
 }
 
+/// Write the connecting flag, refreshing its mtime.
+fn touch_connecting_flag() {
+    if let Err(e) = std::fs::write(CONNECTING_FLAG_PATH, b"1") {
+        warn!("AdvSuspend: could not write {}: {}", CONNECTING_FLAG_PATH, e);
+    }
+}
+
+/// RAII guard that suspends advertising for one connect via the connecting flag.
+struct AdvSuspend {
+    heartbeat: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl AdvSuspend {
+    fn enter(_adapter_name: Option<&str>) -> Self {
+        touch_connecting_flag();
+        let heartbeat = tokio::spawn(async move {
+            loop {
+                sleep(CONNECTING_FLAG_REFRESH).await;
+                touch_connecting_flag();
+            }
+        });
+        AdvSuspend { heartbeat: Some(heartbeat) }
+    }
+}
+
+impl Drop for AdvSuspend {
+    fn drop(&mut self) {
+        if let Some(hb) = self.heartbeat.take() {
+            hb.abort();
+        }
+        let _ = std::fs::remove_file(CONNECTING_FLAG_PATH);
+    }
+}
+
 /// Record an `ensure_connected` failure; after `ADAPTER_REBUILD_AFTER` in
 /// a row, drop the cached adapter so the next attempt rebuilds it.
 fn note_connect_failure(state: &mut SessionState) {
@@ -1506,34 +1549,42 @@ async fn ensure_connected(state: &mut SessionState) -> Result<()> {
             }
         },
     };
-    // 30s scan window matches what the one-shot examples use; covers
-    // a car waking from sleep + advertising stabilizing.
-    let scan_result = match scan::scan_for_vin(&adapter, &state.vin, Duration::from_secs(30)).await
-    {
-        Ok(r) => r,
-        Err(e) => {
-            // Connect failure — back off before letting the caller
-            // retry. Subsequent failures double the wait; success
-            // resets it.
-            note_connect_failure(state);
-            sleep(state.backoff).await;
-            state.backoff = (state.backoff * 2).min(RECONNECT_BACKOFF_MAX);
-            return Err(e).context(ConnectFailure).context("scan failed");
+    // Suspend advertising across both the scan and the connect; Drop restores it.
+    let attempt = {
+        let _adv = AdvSuspend::enter(state.adapter_name.as_deref());
+        match scan::scan_for_vin(&adapter, &state.vin, Duration::from_secs(30)).await {
+            Ok(scan_result) => {
+                // Capture RSSI + MAC before Connection::open consumes the peripheral.
+                let scan_rssi = scan_result.rssi;
+                let peer_mac = scan_result.peripheral.address().to_string();
+                match tokio::time::timeout(
+                    CONNECTION_OPEN_TIMEOUT,
+                    Connection::open(scan_result.peripheral),
+                )
+                .await
+                {
+                    Ok(Ok(c)) => Ok((c, scan_rssi, peer_mac)),
+                    Ok(Err(e)) => Err(e).context(ConnectFailure).context("connect failed"),
+                    Err(_) => Err(anyhow::anyhow!(
+                        "Connection::open exceeded {}s (GATT discovery/subscribe hang)",
+                        CONNECTION_OPEN_TIMEOUT.as_secs()
+                    ))
+                    .context(ConnectFailure)
+                    .context("connect failed"),
+                }
+            }
+            Err(e) => Err(e).context(ConnectFailure).context("scan failed"),
         }
     };
 
-    // Capture RSSI + MAC before Connection::open consumes the
-    // peripheral; address() is cheap and the status file needs the MAC.
-    let scan_rssi = scan_result.rssi;
-    let peer_mac = scan_result.peripheral.address().to_string();
-
-    let conn = match Connection::open(scan_result.peripheral).await {
-        Ok(c) => c,
+    let (conn, scan_rssi, peer_mac) = match attempt {
+        Ok(t) => t,
         Err(e) => {
+            // Connect failure — back off (doubling) before the caller retries.
             note_connect_failure(state);
             sleep(state.backoff).await;
             state.backoff = (state.backoff * 2).min(RECONNECT_BACKOFF_MAX);
-            return Err(e).context(ConnectFailure).context("connect failed");
+            return Err(e);
         }
     };
 

--- a/server/ble/sentryusb-ble.py
+++ b/server/ble/sentryusb-ble.py
@@ -36,6 +36,19 @@ except ImportError:
 logging.basicConfig(level=logging.INFO, format='[BLE] %(levelname)s %(message)s')
 log = logging.getLogger('sentryusb-ble')
 
+# Fresh flag = a central connect is in flight; defer advertising while it is.
+CONNECTING_FLAG_PATH = '/tmp/ble_connecting'
+CONNECTING_FLAG_MAX_AGE_S = 15  # ignore a stale flag a crashed connect left behind
+
+
+def connect_in_flight():
+    """True while a central (re)connect is in flight (flag fresh)."""
+    try:
+        age = time.time() - os.stat(CONNECTING_FLAG_PATH).st_mtime
+    except OSError:
+        return False
+    return 0 <= age < CONNECTING_FLAG_MAX_AGE_S
+
 # ============================================================
 # D-Bus policy self-healing
 # ============================================================
@@ -1127,6 +1140,11 @@ class Advertisement(dbus.service.Object):
 
     def _reregister(self, retry_count=0):
         max_retries = 5
+        # Defer while a central connect is in flight (no retry consumed).
+        if connect_in_flight():
+            log.info('Re-registration deferred: central connect in flight')
+            GLib.timeout_add(1000, self._reregister, retry_count)
+            return False
         log.info(f'Re-registering advertisement... (attempt {retry_count + 1})')
 
         def on_success():
@@ -1332,7 +1350,15 @@ def enable_controller_advertising(adapter_path):
         log.warning(f'btmgmt mgmt socket still unresponsive after {PROBE_CAP_S}s — flag set may fail')
 
     # Mgmt socket is responsive — set each flag with up to 3 quick retries.
+    # 'advertising' is deferred while a connect is in flight; the adv helper
+    # re-asserts it after. connectable/bondable are always safe to set.
+    deferred_adv = False
     for flag in required:
+        if flag == 'advertising' and connect_in_flight():
+            deferred_adv = True
+            log.info(f'Deferring "advertising" flag on {hci}: central connect in '
+                     'flight (BCM4345C0 0x3c race); adv helper re-asserts it after')
+            continue
         for attempt in range(1, 4):
             if flag in current_flags():
                 if attempt > 1:
@@ -1349,7 +1375,8 @@ def enable_controller_advertising(adapter_path):
         else:
             log.warning(f'Could not enable {flag} on {hci} after 3 attempts — pair attempts may fail')
 
-    missing = set(required) - current_flags()
+    check_required = tuple(f for f in required if not (f == 'advertising' and deferred_adv))
+    missing = set(check_required) - current_flags()
     if missing:
         log.warning(f'Controller flags incomplete on {hci}: missing {sorted(missing)}')
     else:
@@ -1614,10 +1641,19 @@ def main():
     adv = Advertisement(bus, 0, 'peripheral', ad_manager,
                         service_manager=service_manager, app=app,
                         local_name=ble_name)
-    ad_manager.RegisterAdvertisement(
-        adv.get_path(), {},
-        reply_handler=register_ad_cb,
-        error_handler=register_ad_error_cb)
+
+    # Defer initial advertisement registration while a connect is in flight.
+    def register_initial_adv():
+        if connect_in_flight():
+            log.info('Initial advertisement deferred: central connect in flight')
+            GLib.timeout_add(1000, register_initial_adv)
+            return False
+        ad_manager.RegisterAdvertisement(
+            adv.get_path(), {},
+            reply_handler=register_ad_cb,
+            error_handler=register_ad_error_cb)
+        return False
+    register_initial_adv()
 
     log.info(f'SentryUSB BLE peripheral started: {ble_name}')
     log.info(f'WiFi Setup Service: {WIFI_SERVICE_UUID}')

--- a/setup/pi/sentryusb-ble-adv.sh
+++ b/setup/pi/sentryusb-ble-adv.sh
@@ -8,6 +8,10 @@
 # The SentryUSB apps filter scans by the "SentryUSB-" name prefix, so the
 # local name MUST appear in the scan response (BlueZ doesn't include the
 # name in this path by default, hence the explicit scan-rsp builder below).
+# Fresh flag = a central connect is in flight; don't re-assert advertising then.
+CONNECTING_FLAG="/tmp/ble_connecting"
+CONNECTING_FLAG_MAX_AGE=15   # seconds; ignore a stale flag a crashed connect left behind
+
 UUID_LE="9e ca dc 24 0e e5 a9 e0 93 f3 a3 b5 01 00 40 6e"   # 6e400001-b5a3-f393-e0a9-e50e24dcca9e, little-endian
 ADV_DATA="15 02 01 06 11 07 ${UUID_LE} 00 00 00 00 00 00 00 00 00 00 00 00 00"
 
@@ -37,7 +41,18 @@ assert_raw_adv() {
     hcitool -i hci0 cmd 0x08 0x0008 $ADV_DATA >/dev/null 2>&1 || true
     hcitool -i hci0 cmd 0x08 0x0009 $scanrsp 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 >/dev/null 2>&1 || true
     hcitool -i hci0 cmd 0x08 0x0006 a0 00 a0 00 00 00 00 00 00 00 00 00 00 07 00 >/dev/null 2>&1 || true
+    # Re-check right before enabling so we never re-arm advertising mid-connect.
+    connect_in_flight && return 0
     hcitool -i hci0 cmd 0x08 0x000a 01 >/dev/null 2>&1 || true
+}
+
+# True while a central connect is in flight (flag fresh within max-age).
+connect_in_flight() {
+    local mtime now age
+    mtime=$(stat -c %Y "$CONNECTING_FLAG" 2>/dev/null) || return 1
+    now=$(date +%s)
+    age=$(( now - mtime ))
+    [ "$age" -ge 0 ] && [ "$age" -lt "$CONNECTING_FLAG_MAX_AGE" ]
 }
 
 # Run the advertising loop ONLY when executed directly (the systemd ExecStart),
@@ -51,9 +66,8 @@ sleep 3   # let bluetoothd's (failing) ext-adv RegisterAdvertisement settle firs
 timeout 5 btmgmt le on >/dev/null 2>&1 || true
 timeout 5 btmgmt connectable on >/dev/null 2>&1 || true
 while true; do
-    # Re-assert only while IDLE — reprogramming advertising while a phone is
-    # connected can disturb Broadcom controllers and isn't needed for a live link.
-    if ! timeout 3 btmgmt con 2>/dev/null | grep -q 'type LE'; then
+    # Re-assert only while IDLE and no central connect is in flight.
+    if ! connect_in_flight && ! timeout 3 btmgmt con 2>/dev/null | grep -q 'type LE'; then
         assert_raw_adv
     fi
     sleep 5


### PR DESCRIPTION
## Summary
Broadcom/Cypress onboard BT controllers wedge their role-state when peripheral
advertising overlaps a central scan/initiate on the reconnect path — they
return LE Connection Complete `0x3c` (Advertising Timeout) and drop into a
state that only a reboot (or a manual `btmgmt advertising off`) clears.
Confirmed on the BCM4345C0 (Rock 4C+); the same wedge is reported on
Raspberry Pi boards with Broadcom/Cypress onboard BT, which share the same
controller lineage. This coordinates all three advertiser actors through a
single `/tmp/ble_connecting` flag so advertising is suspended for the duration
of each connect.

## What's Changed
**BLE (sampler)**
- `manager.rs`: an `AdvSuspend` RAII guard writes the flag (5s heartbeat)
  across the whole scan + `Connection::open`, removing it on block exit so
  backoff sleeps and pairing discovery aren't starved while idle. Also bounds
  `Connection::open` with a 20s timeout so a GATT discovery/subscribe hang
  can't wedge indefinitely.

**BLE (advertiser helpers)**
- `sentryusb-ble-adv.sh`: skip re-asserting hcitool advertising while the
  flag is fresh (15s staleness max-age), with a re-check immediately before
  enabling.
- `sentryusb-ble.py`: defer the initial + re-registration and the
  `advertising` mgmt flag while a connect is in flight; the adv helper
  re-asserts within ~5s after the connect clears, so nothing is lost.

## Test plan
- [x] Bench-validated on BCM4345C0 (Rock 4C+): connect path no longer emits
      `0x3c`; advertising re-asserts after the connect clears
- [ ] Expected to resolve the same `0x3c` wedge on Raspberry Pi boards with
      Broadcom/Cypress onboard BT — field-reported, not yet bench-confirmed there