### PR TITLE
fix(setup): persist /root/.sentryusb on /mutable so cloud pairing works on read-only root

### DIFF
--- a/crates/setup/src/readonly.rs
+++ b/crates/setup/src/readonly.rs
@@ -213,6 +213,30 @@ pub async fn make_readonly(env: &SetupEnv, emitter: &SetupEmitter) -> Result<boo
         let _ = sentryusb_shell::run("chmod", &["700", "/mutable/.bluetooth"]).await;
     }
 
+    // ---- SentryUSB runtime credentials (/root/.sentryusb) ----
+    // The cloud uploader and notification setup write credential JSON to
+    // /root/.sentryusb at RUNTIME — cloud pairing and notification config are
+    // post-setup user actions, so there is no read-write window during setup.
+    // On a read-only root that write fails ("set credentials") and cloud
+    // pairing hangs forever on "waiting for browser to finish". Bind-mount
+    // from .sentryusb (dot-prefixed so the folder is hidden from
+    // Finder/Explorer when the drive is plugged into a computer) so the
+    // credentials persist on the writable /mutable partition.
+    if !Path::new("/mutable/.sentryusb").is_dir() {
+        emitter.progress("Creating /mutable/.sentryusb for cloud/notification credential persistence");
+        let _ = std::fs::create_dir_all("/mutable/.sentryusb");
+        if Path::new("/root/.sentryusb").is_dir()
+            && std::fs::read_dir("/root/.sentryusb")
+                .map(|mut e| e.next().is_some())
+                .unwrap_or(false)
+        {
+            let _ = sentryusb_shell::run(
+                "cp", &["-a", "/root/.sentryusb/.", "/mutable/.sentryusb/"],
+            ).await;
+        }
+        let _ = sentryusb_shell::run("chmod", &["700", "/mutable/.sentryusb"]).await;
+    }
+
     // ---- DHCP lease directories: real dirs for tmpfs (not symlinks) ----
     if Path::new("/var/lib/dhcp").is_symlink() {
         emitter.progress("Replacing /var/lib/dhcp symlink with directory for tmpfs");
@@ -662,6 +686,18 @@ fn update_fstab() -> Result<()> {
         fstab.push_str(
             "/mutable/.bluetooth /var/lib/bluetooth none \
              bind,x-systemd.requires-mounts-for=/mutable,x-systemd.before=bluetooth.service 0 0\n",
+        );
+    }
+
+    // Bind-mount /mutable/.sentryusb over /root/.sentryusb so the cloud
+    // uploader and notification setup can persist credential JSON written at
+    // runtime on the read-only root FS. Without this, cloud pairing fails at
+    // "set credentials" and hangs. x-systemd.before ensures the bind is in
+    // place before the daemon reads/writes credentials at startup.
+    if !fstab_has_mountpoint(&fstab, "/root/.sentryusb") {
+        fstab.push_str(
+            "/mutable/.sentryusb /root/.sentryusb none \
+             bind,x-systemd.requires-mounts-for=/mutable,x-systemd.before=sentryusb.service 0 0\n",
         );
     }
 


### PR DESCRIPTION
## Problem

On a read-only-root image, SentryCloud pairing hangs forever on "waiting for browser to finish". The dashboard registers the Pi immediately, but the Pi never completes its side — `/api/cloud/status` stays `paired: false, pairingState: "polling"` and the log shows:

```
cloud pair begin failed: set credentials
```

Root cause: the cloud uploader saves credentials to `/root/.sentryusb/cloud-credentials.json` (`DEFAULT_CREDENTIALS_PATH`), and notification setup writes to the same directory. Both are **post-setup runtime actions** — there is no read-write window during setup to catch them — so on a read-only root the `save_atomic` write fails and the pairing handshake can't persist. Cloud and Pi end up desynced (cloud thinks paired, Pi has no creds).

## Fix

Bind-mount `/root/.sentryusb` from `/mutable/.sentryusb`, mirroring the existing `/var/lib/bluetooth` bond-persistence bind in `readonly.rs`. Runtime credential writes now land on the writable `/mutable` partition and survive reboots.

- `x-systemd.requires-mounts-for=/mutable` — bind waits for `/mutable`
- `x-systemd.before=sentryusb.service` — bind is active before the daemon reads/writes creds at startup
- existing contents (BLE pin, notification credentials) copied across during setup

## Testing

Applied the equivalent bind on a live read-only-root Rock 4C+ (v3.12.2). Before: pairing hung at "waiting for browser to finish" with a `set credentials` failure in the log. After: pairing completed (`paired: true`, `pairingState: complete`), `cloud-credentials.json` persisted under `/mutable/.sentryusb`, and the queued route backlog uploaded cleanly. Survives reboot via the fstab ordering.
