### PR TITLE
fix(ble): drop mgmt advertising during central connects (BCM4345C0 0x3c) — completes #121

### DIFF
--- a/crates/tesla_ble/src/manager.rs
+++ b/crates/tesla_ble/src/manager.rs
@@ -1481,6 +1481,45 @@ fn touch_connecting_flag() {
     }
 }
 
+/// hci index from an adapter name like "hci0"; defaults to 0.
+fn hci_index(adapter_name: Option<&str>) -> u8 {
+    adapter_name
+        .and_then(|n| n.strip_prefix("hci"))
+        .and_then(|n| n.parse().ok())
+        .unwrap_or(0)
+}
+
+/// Set the kernel mgmt advertising setting via btmgmt. stdin is piped and
+/// closed immediately (btmgmt blocks forever on a null stdin) and the call is
+/// killed after 3s (btmgmt can hang on a contended mgmt socket).
+async fn set_mgmt_advertising(hci_idx: u8, on: bool) {
+    let arg = if on { "on" } else { "off" };
+    let idx = hci_idx.to_string();
+    let mut child = match tokio::process::Command::new("btmgmt")
+        .args(["--index", &idx, "advertising", arg])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            warn!("AdvSuspend: spawning btmgmt advertising {arg} failed: {e}");
+            return;
+        }
+    };
+    drop(child.stdin.take());
+    match tokio::time::timeout(Duration::from_secs(3), child.wait()).await {
+        Ok(Ok(status)) if status.success() => {}
+        Ok(Ok(status)) => warn!("AdvSuspend: btmgmt advertising {arg} exited {status}"),
+        Ok(Err(e)) => warn!("AdvSuspend: btmgmt advertising {arg}: {e}"),
+        Err(_) => {
+            warn!("AdvSuspend: btmgmt advertising {arg} timed out — killing");
+            let _ = child.kill().await;
+        }
+    }
+}
+
 /// RAII guard that suspends advertising for one connect via the connecting flag.
 struct AdvSuspend {
     heartbeat: Option<tokio::task::JoinHandle<()>>,
@@ -1549,7 +1588,11 @@ async fn ensure_connected(state: &mut SessionState) -> Result<()> {
             }
         },
     };
-    // Suspend advertising across both the scan and the connect; Drop restores it.
+    // Drop the mgmt advertising setting for the connect window; restored after
+    // the attempt. With it set, chips without simultaneous-role support
+    // (BCM4345C0) connect as peripheral via directed advertising → HCI 0x3c.
+    let hci_idx = hci_index(state.adapter_name.as_deref());
+    set_mgmt_advertising(hci_idx, false).await;
     let attempt = {
         let _adv = AdvSuspend::enter(state.adapter_name.as_deref());
         match scan::scan_for_vin(&adapter, &state.vin, Duration::from_secs(30)).await {
@@ -1576,6 +1619,7 @@ async fn ensure_connected(state: &mut SessionState) -> Result<()> {
             Err(e) => Err(e).context(ConnectFailure).context("scan failed"),
         }
     };
+    set_mgmt_advertising(hci_idx, true).await;
 
     let (conn, scan_rssi, peer_mac) = match attempt {
         Ok(t) => t,


### PR DESCRIPTION
## Problem

On BCM4345C0 boards (Rock 4C+, and the same silicon behind the Pi 4/5 "BCM43455" which loads `BCM4345C0.hcd`), the telemetry sampler intermittently stops connecting to the car: every GATT connect times out, telemetry freezes, keep-awake nudges and alerts are missed. In the field it reads as endless `BLE connect timed out … slot likely held by phone key` retries. A reboot temporarily clears it, then it returns — usually on the first reconnect after a session drops.

This completes #121, which diagnosed this exact wedge and coordinated the advertisers through the `/tmp/ble_connecting` flag, but left one gap (below).

## Root cause (btmon-verified)

With the kernel mgmt **advertising** setting on, a controller that can't do simultaneous LE roles (BCM4345C0) opens each outbound connect **as peripheral via directed advertising** (`ADV_DIRECT_IND` at the car) instead of `LE Create Connection`. The car has ~1.28 s to connect back — an awake car sometimes catches it (so the session holds fine, because the role is chosen at connect time); a dozing car never does → `LE Connection Complete: Advertising Timeout (0x3c)` on every attempt.

A/B proof on the affected board: with mgmt advertising **on**, connects use directed-adv and 0x3c every time; toggle it **off**, and the very next connect is `LE Create Connection → Status: Success`, first try.

## The gap in #121

#121 suspends the raw-hcitool advertiser via the connecting flag and *defers* the mgmt advertising flag in `sentryusb-ble.py` — but only at **startup**. Once the flag is set after the first connect it stays set, and nothing disables it on **subsequent reconnects**, so every reconnect still overlaps advertising → 0x3c. #121's own commit message even names the cure (`btmgmt advertising off`); this PR is that cure, applied per-connect.

## Fix

Bracket each scan+connect in the sampler with `btmgmt advertising off` before and `on` after (`crates/tesla_ble/src/manager.rs`, in `ensure_connected`):

- Advertising is disabled only for the few-second connect window, so connects take the correct central path (`LE Create Connection`).
- It is restored immediately after, so the phone companion app stays discoverable at rest.
- `btmgmt` is spawned with stdin piped+closed (it blocks forever on a null stdin) and killed after a 3 s timeout (it can hang on a contended mgmt socket).

Composes with the existing `AdvSuspend` connecting-flag from #121 — this adds the missing piece: actually clearing the kernel setting that drives the role choice.

## Why not remove the mgmt advertisement entirely

Without a bluetoothd-owned advertisement, inbound phone connections form at the link layer but bluetoothd never services their GATT — the companion app breaks. Bracketing keeps advertising on at rest and only drops it for the connect. The change is also chip-agnostic (no board detection), so it covers the whole Broadcom Pi-family that wedges the same way.

## Testing

- **Rock 4C+ (BCM4345C0), btmon-verified:** forced reconnect shows `Set Advertising: Disabled → LE Create Connection → Status: Success → Set Advertising: Enabled`, **0** directed-adv, **0** 0x3c. ~4.5 h soak + 2 drives: **0** connect timeouts, **0** adapter rebuilds (vs 73 connect timeouts + 7 rebuilds over a single 45-min drive on the pre-fix build). Companion app BLE control worked simultaneously throughout. Survives reboot.
- **Raspberry Pi 5 (also BCM4345C0):** a field bundle shows the identical connect-timeout signature (45 `connect timed out … slot likely held` over ~26 min) — same chip, same wedge. Bracket applies (btmon confirmation on that board still welcome).
- **Pi Zero 2 W (BCM43430B0):** same Broadcom family, same reliability symptom reported in the field.

## Note

On boards where bluetoothd uses *extended* advertising, the off→on toggle momentarily drops the advert during the connect window (a few seconds of non-discoverability) — acceptable in practice.
