### PR TITLE
fix(ble): parse the phone-BLE bridge's error body as JSON, not a raw string

### DIFF
--- a/server/ble/sentryusb-ble.py
+++ b/server/ble/sentryusb-ble.py
@@ -489,7 +489,11 @@ def proxy_api_request(method, path, body=None, retries=2, retry_delay=1.5):
             return {'status': resp.getcode(), 'body': parsed}
         except urllib.error.HTTPError as e:
             body_text = e.read().decode() if e.fp else ''
-            return {'status': e.code, 'body': body_text}
+            try:
+                parsed_body = json.loads(body_text)
+            except (json.JSONDecodeError, ValueError):
+                parsed_body = body_text
+            return {'status': e.code, 'body': parsed_body}
         except (urllib.error.URLError, ConnectionRefusedError, OSError) as e:
             last_error = e
             if attempt < retries:


### PR DESCRIPTION
The phone-BLE API bridge (`server/ble/sentryusb-ble.py`, `proxy_api_request`) parses the **success** response body as JSON but leaves the **error** (HTTPError) body as a raw string, never parsed.

```python
resp = urllib.request.urlopen(req, timeout=15)
...
parsed = json.loads(response_body)          # success: real object
return {"status": resp.getcode(), "body": parsed}
except urllib.error.HTTPError as e:
    body_text = e.read().decode() if e.fp else ""
    return {"status": e.code, "body": body_text}   # error: raw STRING
```

So the BLE response envelope carries `"body"` as a JSON object on success but as a JSON-encoded string on error. A phone app that reads `body` the same way for both (e.g. `body.optJSONObject("body").optString("error")`) gets `null` on every error, even though the Pi's `json_error()` responses are always valid JSON with a real message. Companion apps end up showing a bare `HTTP 409` / `HTTP 412` instead of the actual reason.

**Fix:** parse the error body the same way the success body already is, falling back to the raw string only if it is not valid JSON.

**Confirmed live.** Curling the endpoints directly on three boards returned correct bodies with real messages that the bridge was dropping:
- `409` `{"error":"Away Mode is in Automatic mode — switch to Manual to use the timer."}`
- `412` `{"error":"AP not configured. Run setup with AP settings first."}`

Then patched one board in place and re-tested over BLE from the phone: the app now shows the real message ("AP not configured. Run setup with AP settings first.") instead of "HTTP 412".

One file, five lines.