### PR TITLE
feat(drives): fill mid-drive RecentClips gaps from Sentry/Saved pre-roll (map + playback)

### DIFF
--- a/crates/drives/src/aggregate_telemetry.rs
+++ b/crates/drives/src/aggregate_telemetry.rs
@@ -17,7 +17,7 @@ use anyhow::Result;
 use chrono::{Local, TimeZone};
 use rusqlite::{params, Connection, OptionalExtension};
 
-use crate::grouper::parse_file_timestamp;
+use crate::grouper::parse_clip_timestamp;
 pub use crate::types::RouteTelemetryAggregates;
 
 /// Clip duration in seconds — must match `clip_duration_ms` in
@@ -28,7 +28,10 @@ const CLIP_WINDOW_SECS: i64 = 60;
 /// Returns `None` when the filename doesn't embed a parseable
 /// timestamp — pre-grouper / corrupted paths just skip telemetry.
 pub fn window_for_route_file(file: &str) -> Option<(i64, i64)> {
-    let naive = parse_file_timestamp(file)?;
+    // Basename parse: gap-fill routes live at event-folder paths whose
+    // folder timestamp a left-to-right scan would pick over the clip's own,
+    // matching telemetry against the wrong minute.
+    let naive = parse_clip_timestamp(file)?;
     // Tesla writes the filename using the car's local clock, and the
     // Pi writes telemetry samples using its own local clock — on the
     // same install these are the same zone, so reading both as

--- a/crates/drives/src/db.rs
+++ b/crates/drives/src/db.rs
@@ -625,6 +625,24 @@ impl DriveStore {
         Ok(f(&routes))
     }
 
+    /// Files of every route row that lives in an event folder — i.e. the
+    /// Saved/Sentry clips the gap-fill spliced into a drive to cover a
+    /// RecentClips recording hole. Normal drive routes are keyed under
+    /// `RecentClips/`, so this returns exactly the gap-fill set. The
+    /// snapshot builder reads a manifest derived from this to cross-link
+    /// those clips back into RecentClips for continuous playback.
+    pub fn gap_fill_files(&self) -> Result<Vec<String>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT file FROM routes \
+             WHERE file LIKE 'SavedClips/%' OR file LIKE 'SentryClips/%'",
+        )?;
+        let rows = stmt
+            .query_map([], |r| r.get::<_, String>(0))?
+            .collect::<std::result::Result<Vec<String>, _>>()?;
+        Ok(rows)
+    }
+
     /// Wipe routes + processed_files + drive_tags and bulk-insert `data`.
     /// Used by `POST /api/drives/data/upload` to restore a previously-
     /// downloaded `drive-data.json`.

--- a/crates/drives/src/db.rs
+++ b/crates/drives/src/db.rs
@@ -625,22 +625,54 @@ impl DriveStore {
         Ok(f(&routes))
     }
 
-    /// Files of every route row that lives in an event folder — i.e. the
+    /// Files of every **driving** event-folder route row — i.e. the
     /// Saved/Sentry clips the gap-fill spliced into a drive to cover a
     /// RecentClips recording hole. Normal drive routes are keyed under
-    /// `RecentClips/`, so this returns exactly the gap-fill set. The
-    /// snapshot builder reads a manifest derived from this to cross-link
-    /// those clips back into RecentClips for continuous playback.
+    /// `RecentClips/`, so the LIKE clause returns exactly the gap-fill
+    /// set, and the driving filter drops any parked row that entered the
+    /// table before the `do_process` driving gate existed (older builds,
+    /// drive-data.json imports). The snapshot builder reads a manifest
+    /// derived from this to cross-link those clips back into RecentClips
+    /// for continuous playback — a parked event clip in the manifest would
+    /// reintroduce exactly the parked presence 60c5602 removed.
+    ///
+    /// The predicate is `grouper::row_has_driving` — the SAME one the
+    /// grouper applies to stored rows when admitting gap-fills — so the
+    /// manifest and the drive list never disagree on which event clips are
+    /// part of a drive.
     pub fn gap_fill_files(&self) -> Result<Vec<String>> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
-            "SELECT file FROM routes \
+            "SELECT file, raw_park_count, raw_frame_count, gear_runs_blob, max_speed_mps \
+             FROM routes \
              WHERE file LIKE 'SavedClips/%' OR file LIKE 'SentryClips/%'",
         )?;
         let rows = stmt
-            .query_map([], |r| r.get::<_, String>(0))?
-            .collect::<std::result::Result<Vec<String>, _>>()?;
-        Ok(rows)
+            .query_map([], |r| {
+                Ok((
+                    r.get::<_, String>(0)?,
+                    r.get::<_, i64>(1)? as u32,
+                    r.get::<_, i64>(2)? as u32,
+                    r.get::<_, Option<Vec<u8>>>(3)?,
+                    r.get::<_, Option<f64>>(4)?,
+                ))
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        let mut out = Vec::with_capacity(rows.len());
+        for (file, raw_park, raw_frame, gear_blob, max_speed) in rows {
+            let gear_runs = decode_gear_runs(gear_blob.as_deref())
+                .with_context(|| format!("decode gear_runs {}", file))?
+                .unwrap_or_default();
+            if crate::grouper::row_has_driving(
+                &gear_runs,
+                raw_park,
+                raw_frame,
+                max_speed.unwrap_or(0.0),
+            ) {
+                out.push(file);
+            }
+        }
+        Ok(out)
     }
 
     /// Wipe routes + processed_files + drive_tags and bulk-insert `data`.
@@ -2798,6 +2830,71 @@ mod tests {
         let conn = store.conn.lock().unwrap();
         let ver = meta_get(&conn, "aggregate_formula_version").unwrap();
         assert_eq!(ver.as_deref(), Some(AGGREGATE_FORMULA_VERSION));
+    }
+
+    #[test]
+    fn gap_fill_files_excludes_parked_event_rows() {
+        use crate::extract::{GEAR_DRIVE, GEAR_PARK};
+        let store = DriveStore::open_memory().unwrap();
+        let pts: Vec<GpsPoint> = vec![[37.0, -122.0], [37.001, -122.0]];
+
+        // A driving event row (real gap-fill) — must appear.
+        store
+            .add_route(
+                "SentryClips/2026-07-05_16-12-51/2026-07-05_16-05-47-front.mp4",
+                "2026-07-05",
+                &pts,
+                &[GEAR_DRIVE, GEAR_DRIVE],
+                &[0, 0],
+                &[20.0, 21.0],
+                &[0.0, 0.0],
+                0,
+                2,
+                &[GearRun { gear: GEAR_DRIVE, frames: 2 }],
+            )
+            .unwrap();
+
+        // A fully-PARKED event row (drive 241's arrival residue from an
+        // older build, before the do_process gate) — must be filtered out
+        // so the playback manifest never cross-links it into RecentClips.
+        let parked_pts: Vec<GpsPoint> = vec![[37.001, -122.0], [37.001, -122.0]];
+        store
+            .add_route(
+                "SentryClips/2026-07-05_16-12-51/2026-07-05_16-07-48-front.mp4",
+                "2026-07-05",
+                &parked_pts,
+                &[GEAR_PARK, GEAR_PARK],
+                &[0, 0],
+                &[0.0, 0.0],
+                &[0.0, 0.0],
+                60,
+                60,
+                &[GearRun { gear: GEAR_PARK, frames: 60 }],
+            )
+            .unwrap();
+
+        // A normal RecentClips drive row is never in the event-folder set.
+        store
+            .add_route(
+                "2026-07-05/2026-07-05_16-04-47-front.mp4",
+                "2026-07-05",
+                &pts,
+                &[GEAR_DRIVE, GEAR_DRIVE],
+                &[0, 0],
+                &[20.0, 21.0],
+                &[0.0, 0.0],
+                0,
+                2,
+                &[GearRun { gear: GEAR_DRIVE, frames: 2 }],
+            )
+            .unwrap();
+
+        let files = store.gap_fill_files().unwrap();
+        assert_eq!(
+            files,
+            vec!["SentryClips/2026-07-05_16-12-51/2026-07-05_16-05-47-front.mp4".to_string()],
+            "manifest must list the driving event clip and exclude the parked arrival"
+        );
     }
 
     /// 61-point clip (dt = 1000 ms) for boundary tests: per-point AP and

--- a/crates/drives/src/db.rs
+++ b/crates/drives/src/db.rs
@@ -95,7 +95,11 @@ const ARCHIVE_SYNC_SAMPLE_COUNT_KEY: &str = "archive_sync_sample_count";
 // to the numerically-stable atan2(haversine) form (calc.rs), fixing a
 // ~0.7% short-segment undercount on native dashcam drives. Per-drive
 // distance shifts up; stale v6 caches hold the undercounted mileage.
-const DRIVE_LIST_CACHE_ALGO_VERSION: &str = "7";
+//
+// v8 (2026-07-06): event-clip gap-fill — the summary grouper now admits
+// SavedClips/SentryClips rows that fill RecentClips holes (and filters
+// all other event rows, which it previously passed through untouched).
+const DRIVE_LIST_CACHE_ALGO_VERSION: &str = "8";
 
 /// Version tag for the per-clip aggregate FORMULA (compute_route_aggregates).
 /// Distinct from the cache algo version above: this gates a one-shot
@@ -297,6 +301,9 @@ impl DriveStore {
                 // Stray SavedClips/SentryClips routes pre-date the
                 // processor's event-folder skip; the grouper already hides
                 // them from drives, so deleting only trims dead rows.
+                // NOTE for future key-format bumps: event rows can now be
+                // legitimate gap-fills (processor::scan_event_gap_fill) —
+                // a canon-2 migration must not blanket-delete them.
                 let events = mg.execute(
                     "DELETE FROM routes \
                      WHERE file LIKE 'SavedClips/%' OR file LIKE 'SentryClips/%'",

--- a/crates/drives/src/grouper.rs
+++ b/crates/drives/src/grouper.rs
@@ -26,13 +26,35 @@ const DRIVE_GAP_MS: i64 = 5 * 60 * 1000;
 /// as a recording hole (≥1 missing minute-clip; normal spacing is ~60s).
 pub(crate) const GAP_FILL_MIN_MS: i64 = 90 * 1000;
 
-/// Max hole (ms) event clips may fill. Sentry-covered dropouts run long —
-/// the car parked, so the gap spans the arrival + a chain of ~10-min
-/// pre-roll events (real data: 9-19 min). Wider than DRIVE_GAP_MS on
-/// purpose; the coverage requirement (an event clip must exist for each
-/// filled minute) is what actually bounds the fill. Beyond this it's a
-/// genuine multi-drive boundary, not a recording dropout.
+/// Max hole (ms) event clips may fill, and the max distance a chained
+/// edge fill may extend past the nearest RecentClips clip. Sentry-covered
+/// dropouts run long — the car parked, so the gap spans the arrival + a
+/// chain of ~10-min pre-roll events (real data: 9-19 min). Wider than
+/// DRIVE_GAP_MS on purpose; the coverage requirement (an event clip must
+/// exist for each filled minute) is what actually bounds the fill. Beyond
+/// this it's a genuine multi-drive boundary, not a recording dropout.
 pub(crate) const GAP_FILL_MAX_MS: i64 = 30 * 60 * 1000;
+
+/// Chain hop window (ms): an event clip is proximity-eligible when it sits
+/// within this of a RecentClips clip or of another eligible event clip.
+/// Event pre-roll segments run ~60-77 s apart, but real chains show
+/// intra-event gaps up to ~152 s (July 4 data), so one clip length plus
+/// generous slack. Anything further is not a continuation of surrounding
+/// footage.
+pub(crate) const GAP_FILL_ADJ_MS: i64 = 3 * 60 * 1000;
+
+/// Duplicate window (ms): an event clip whose timestamp falls within this
+/// AFTER a RecentClips clip (or after an already-kept event candidate) is
+/// the same recorder segment wearing a different path — Tesla stamps the
+/// twin 0-1 s apart in practice. One-sided on purpose: a clip shortly
+/// BEFORE the next RecentClips clip is the event pre-roll's final segment,
+/// truncated at the trigger, and carries unique hole-tail footage.
+pub(crate) const GAP_FILL_DUP_MS: i64 = 30 * 1000;
+
+/// Speed (m/s) above which a clip counts as containing driving even when
+/// its gear telemetry is missing or reads Park throughout (~1.1 mph;
+/// reverse reports negative speeds, callers compare on abs()).
+pub(crate) const GAP_FILL_MIN_SPEED_MPS: f32 = 0.5;
 
 /// Minimum Park duration (seconds) that ends the current drive within a clip.
 const PARK_GAP_SECONDS: f64 = 2.0;
@@ -316,10 +338,24 @@ pub(crate) fn is_event_folder_path(file: &str) -> bool {
 // The processor only ingests RecentClips, so a hole in the continuous
 // recording becomes a hole in the drive route — even when the same minute
 // clips exist inside a SavedClips/SentryClips event folder (Tesla events
-// carry a ~10-minute pre-roll). Gap-fill admits exactly those event clips:
-// ones whose timestamp falls strictly inside a RecentClips hole within one
-// drive window. Everything else in the event folders (parked Sentry
-// recordings, duplicates of RecentClips clips) stays filtered.
+// carry a ~10-minute pre-roll). Gap-fill admits event clips in three
+// shapes:
+//   interior — timestamp strictly inside a RecentClips hole (a clip on
+//              both sides, gap ≤ GAP_FILL_MAX_MS);
+//   trailing — the drive ran PAST its last RecentClips clip into an event
+//              pre-roll before parking (no clip after, so no "hole");
+//   leading  — departure footage that only made an event pre-roll before
+//              the first RecentClips clip.
+// Edge shapes are admitted by chaining: the clip must sit within
+// GAP_FILL_ADJ_MS of a RecentClips clip or of another eligible event clip,
+// with the whole chain anchored to RecentClips and capped at
+// GAP_FILL_MAX_MS from the nearest anchor. On top of proximity, admission
+// is DRIVING-GATED wherever SEI is available: a clip whose telemetry shows
+// no movement (gear Park throughout, speed ~0) is never admitted, so a
+// parked car's sentry recordings — even ones minutes after a drive ended —
+// stay out of the drive list and out of the playback manifest. Everything
+// else in the event folders (parked recordings, duplicates of RecentClips
+// clips, isolated clusters with no adjacent driving) stays filtered.
 // ---------------------------------------------------------------------------
 
 /// Clip timestamp parsed from the FILENAME component only. Event paths
@@ -332,8 +368,8 @@ pub(crate) fn parse_clip_timestamp(file_path: &str) -> Option<NaiveDateTime> {
 
 /// Holes in a SORTED continuous-clip timestamp sequence that qualify for
 /// event-clip gap-fill: wider than one missing minute-clip but within the
-/// drive-split threshold — a longer gap is a park/drive boundary the
-/// grouper already splits on, not a recording dropout.
+/// fill cap — a longer gap is a park/drive boundary, not a recording
+/// dropout.
 pub(crate) fn fillable_holes(sorted_ts: &[NaiveDateTime]) -> Vec<(NaiveDateTime, NaiveDateTime)> {
     sorted_ts
         .windows(2)
@@ -353,31 +389,186 @@ pub(crate) fn ts_in_holes(holes: &[(NaiveDateTime, NaiveDateTime)], ts: NaiveDat
     i > 0 && ts < holes[i - 1].1
 }
 
-/// Select which event clips fill RecentClips holes. `recent_sorted_ts` is
-/// the sorted continuous-clip timeline; `candidates` are (clip timestamp,
-/// path) pairs. Returns indices into `candidates`: at most one per
-/// timestamp (lowest path wins, so SavedClips/SentryClips twins of the
-/// same minute never both land), and never a timestamp RecentClips covers
-/// (by construction no recent timestamp lies strictly inside a hole).
+/// True when SEI telemetry shows the car moving: any non-Park gear frame
+/// or any speed sample above a crawl. All-Park + speed≈0 (or no telemetry
+/// at all — no positive evidence of driving) returns false.
+pub(crate) fn telemetry_has_driving(
+    gear_runs: &[GearRun],
+    gear_states: &[u8],
+    speeds: &[f32],
+    raw_park_count: u32,
+    raw_frame_count: u32,
+) -> bool {
+    gear_runs.iter().any(|r| r.gear != GEAR_PARK)
+        || gear_states.iter().any(|&g| g != GEAR_PARK)
+        || (gear_runs.is_empty()
+            && gear_states.is_empty()
+            && raw_frame_count > 0
+            && raw_park_count < raw_frame_count)
+        || speeds.iter().any(|&s| s.abs() > GAP_FILL_MIN_SPEED_MPS)
+}
+
+/// [`telemetry_has_driving`] over a full Route row.
+fn route_has_driving(r: &Route) -> bool {
+    telemetry_has_driving(
+        &r.gear_runs,
+        &r.gear_states,
+        &r.speeds,
+        r.raw_park_count,
+        r.raw_frame_count,
+    )
+}
+
+/// [`telemetry_has_driving`] over a stored route row: gear runs + raw
+/// frame counts + the pre-computed aggregate max speed (no per-frame
+/// arrays available post-storage). The single predicate the grouper's
+/// gap-fill admission AND the playback manifest (`Store::gap_fill_files`)
+/// both apply to stored rows, so the two never disagree on whether an
+/// event clip is driving.
+pub(crate) fn row_has_driving(
+    gear_runs: &[GearRun],
+    raw_park_count: u32,
+    raw_frame_count: u32,
+    max_speed_mps: f64,
+) -> bool {
+    telemetry_has_driving(gear_runs, &[], &[], raw_park_count, raw_frame_count)
+        || max_speed_mps > GAP_FILL_MIN_SPEED_MPS as f64
+}
+
+/// [`row_has_driving`] over a summary row.
+fn summary_has_driving(s: &RouteSummary) -> bool {
+    row_has_driving(
+        &s.gear_runs,
+        s.raw_park_count,
+        s.raw_frame_count,
+        s.aggregates.max_speed_mps,
+    )
+}
+
+/// An event clip proposed for gap-fill. `driving` is the SEI verdict:
+/// `Some(true)` = movement frames present, `Some(false)` = parked
+/// throughout (never admitted), `None` = not yet extracted (the
+/// processor's pre-extraction scan, which selects a timestamp-bounded
+/// superset and lets the post-extraction gate discard the parked ones).
+pub(crate) struct GapFillCandidate<'a> {
+    pub(crate) ts: NaiveDateTime,
+    pub(crate) file: &'a str,
+    pub(crate) driving: Option<bool>,
+}
+
+/// Timestamp-only wrapper around [`select_gap_fill`] for callers without
+/// SEI in hand (the processor's disk scan).
 pub(crate) fn select_gap_fill_events(
     recent_sorted_ts: &[NaiveDateTime],
     candidates: &[(NaiveDateTime, &str)],
 ) -> Vec<usize> {
-    let holes = fillable_holes(recent_sorted_ts);
-    if holes.is_empty() || candidates.is_empty() {
+    let cands: Vec<GapFillCandidate> = candidates
+        .iter()
+        .map(|&(ts, file)| GapFillCandidate { ts, file, driving: None })
+        .collect();
+    select_gap_fill(recent_sorted_ts, &cands)
+}
+
+/// Select which event clips fill RecentClips gaps. `recent_sorted_ts` is
+/// the sorted continuous-clip timeline. Returns indices into `candidates`.
+///
+/// Admission pipeline:
+/// 1. drop clips whose SEI says parked-only (`driving == Some(false)`);
+/// 2. drop duplicates of occupied RecentClips slots (timestamp within
+///    GAP_FILL_DUP_MS after a recent clip — Tesla stamps the Saved/Sentry
+///    twin of a segment 0-1 s later);
+/// 3. dedup overlapping candidates (lowest path wins within the dup
+///    window, so twins of the same minute never both land);
+/// 4. admit what remains if it lies strictly inside a RecentClips hole
+///    (interior) OR chains to the recent timeline: hops ≤ GAP_FILL_ADJ_MS
+///    through recent clips / other kept candidates, anchored to at least
+///    one recent clip, capped at GAP_FILL_MAX_MS from the nearest one
+///    (bounds trailing/leading fills; isolated event clusters have no
+///    anchor and never qualify).
+pub(crate) fn select_gap_fill(
+    recent_sorted_ts: &[NaiveDateTime],
+    candidates: &[GapFillCandidate],
+) -> Vec<usize> {
+    if recent_sorted_ts.is_empty() || candidates.is_empty() {
         return Vec::new();
     }
-    let mut order: Vec<usize> = (0..candidates.len()).collect();
-    order.sort_by(|&a, &b| candidates[a].cmp(&candidates[b]));
-    let mut filled = std::collections::HashSet::new();
-    let mut out = Vec::new();
-    for i in order {
-        let (ts, _) = candidates[i];
-        if ts_in_holes(&holes, ts) && filled.insert(ts) {
-            out.push(i);
+    let holes = fillable_holes(recent_sorted_ts);
+
+    // Same recorder segment as an occupied RecentClips slot? One-sided:
+    // shortly-BEFORE-next-recent clips are truncated pre-roll tails that
+    // carry unique footage (see GAP_FILL_DUP_MS).
+    let dup_of_recent = |ts: NaiveDateTime| -> bool {
+        let i = recent_sorted_ts.partition_point(|&r| r <= ts);
+        i > 0 && (ts - recent_sorted_ts[i - 1]).num_milliseconds() <= GAP_FILL_DUP_MS
+    };
+    let nearest_recent_ms = |ts: NaiveDateTime| -> i64 {
+        let i = recent_sorted_ts.partition_point(|&r| r < ts);
+        let mut best = i64::MAX;
+        if i > 0 {
+            best = best.min((ts - recent_sorted_ts[i - 1]).num_milliseconds());
         }
+        if i < recent_sorted_ts.len() {
+            best = best.min((recent_sorted_ts[i] - ts).num_milliseconds());
+        }
+        best
+    };
+
+    // Steps 1-3: eligibility, then dedup in (timestamp, path) order.
+    let mut order: Vec<usize> = (0..candidates.len())
+        .filter(|&i| candidates[i].driving != Some(false) && !dup_of_recent(candidates[i].ts))
+        .collect();
+    order.sort_by(|&a, &b| {
+        (candidates[a].ts, candidates[a].file).cmp(&(candidates[b].ts, candidates[b].file))
+    });
+    let mut kept: Vec<usize> = Vec::new();
+    for i in order {
+        if let Some(&last) = kept.last()
+            && (candidates[i].ts - candidates[last].ts).num_milliseconds() <= GAP_FILL_DUP_MS
+        {
+            continue;
+        }
+        kept.push(i);
     }
-    out
+
+    // Step 4b: chain connectivity over the merged recent+kept timeline.
+    // Clusters are maximal runs whose consecutive gaps stay within
+    // GAP_FILL_ADJ_MS; a kept candidate is chained when its cluster holds
+    // at least one recent clip and it sits within GAP_FILL_MAX_MS of the
+    // nearest recent clip.
+    let mut merged: Vec<(NaiveDateTime, Option<usize>)> = recent_sorted_ts
+        .iter()
+        .map(|&t| (t, None))
+        .chain(kept.iter().enumerate().map(|(k, &i)| (candidates[i].ts, Some(k))))
+        .collect();
+    merged.sort_by_key(|&(t, _)| t);
+
+    let mut chained = vec![false; kept.len()];
+    let mut cluster_start = 0usize;
+    for idx in 0..=merged.len() {
+        let cluster_ends = idx == merged.len()
+            || (idx > 0
+                && (merged[idx].0 - merged[idx - 1].0).num_milliseconds() > GAP_FILL_ADJ_MS);
+        if !cluster_ends {
+            continue;
+        }
+        let cluster = &merged[cluster_start..idx];
+        if cluster.iter().any(|&(_, k)| k.is_none()) {
+            for &(ts, k) in cluster {
+                if let Some(k) = k
+                    && nearest_recent_ms(ts) <= GAP_FILL_MAX_MS
+                {
+                    chained[k] = true;
+                }
+            }
+        }
+        cluster_start = idx;
+    }
+
+    kept.iter()
+        .enumerate()
+        .filter(|&(k, &i)| ts_in_holes(&holes, candidates[i].ts) || chained[k])
+        .map(|(_, &i)| i)
+        .collect()
 }
 
 /// Dedup by normalized file path, parse timestamps, sort, split on 5-min gaps,
@@ -460,9 +651,9 @@ fn group_clips(routes: Vec<Route>) -> Vec<Vec<TimedRoute>> {
     timed.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
 
     // Gap-fill: admit event routes whose CLIP timestamp (filename, not
-    // event-folder name) falls strictly inside a RecentClips hole — the
-    // missing minute exists only in the event pre-roll. One route per
-    // timestamp; everything else stays filtered.
+    // event-folder name) fills a RecentClips gap — interior hole or a
+    // driving-gated trailing/leading chain (see the section comment
+    // above). One route per timestamp; everything else stays filtered.
     if !event_candidates.is_empty() {
         let recent_ts: Vec<NaiveDateTime> = timed.iter().map(|t| t.timestamp).collect();
         let mut cands: Vec<(NaiveDateTime, Option<Route>)> = Vec::new();
@@ -472,12 +663,19 @@ fn group_clips(routes: Vec<Route>) -> Vec<Vec<TimedRoute>> {
                 None => filtered_event_folder += 1,
             }
         }
-        let keys: Vec<(NaiveDateTime, &str)> = cands
+        let keys: Vec<GapFillCandidate> = cands
             .iter()
-            .map(|(ts, r)| (*ts, r.as_ref().unwrap().file.as_str()))
+            .map(|(ts, r)| {
+                let r = r.as_ref().unwrap();
+                GapFillCandidate {
+                    ts: *ts,
+                    file: r.file.as_str(),
+                    driving: Some(route_has_driving(r)),
+                }
+            })
             .collect();
         let mut gap_filled = 0usize;
-        for i in select_gap_fill_events(&recent_ts, &keys) {
+        for i in select_gap_fill(&recent_ts, &keys) {
             let (ts, r) = &mut cands[i];
             timed.push(TimedRoute { route: r.take().unwrap(), timestamp: *ts });
             gap_filled += 1;
@@ -1904,9 +2102,15 @@ fn group_summary_clips<'a>(summaries: &'a [RouteSummary]) -> Vec<Vec<SubClipSumm
             .into_iter()
             .filter_map(|s| parse_clip_timestamp(&s.file).map(|ts| (ts, s)))
             .collect();
-        let keys: Vec<(NaiveDateTime, &str)> =
-            cands.iter().map(|(ts, s)| (*ts, s.file.as_str())).collect();
-        let admitted = select_gap_fill_events(&recent_ts, &keys);
+        let keys: Vec<GapFillCandidate> = cands
+            .iter()
+            .map(|(ts, s)| GapFillCandidate {
+                ts: *ts,
+                file: s.file.as_str(),
+                driving: Some(summary_has_driving(s)),
+            })
+            .collect();
+        let admitted = select_gap_fill(&recent_ts, &keys);
         if !admitted.is_empty() {
             for i in admitted {
                 let (ts, s) = cands[i];
@@ -3188,6 +3392,262 @@ mod tests {
                 "2026-06-01/2026-06-01_10-00-00-front.mp4",
                 "SentryClips/2026-06-01_10-02-30/2026-06-01_10-01-00-front.mp4",
                 "2026-06-01/2026-06-01_10-02-00-front.mp4",
+            ]
+        );
+    }
+
+    // ── Comprehensive gap-fill: driving gate + trailing/leading chains ──
+
+    #[test]
+    fn test_telemetry_has_driving() {
+        let d = |g| GearRun { gear: g, frames: 30 };
+        // Non-park gear run → driving.
+        assert!(telemetry_has_driving(&[d(GEAR_PARK), d(1)], &[], &[], 0, 0));
+        // All-park gear runs, no speed → parked.
+        assert!(!telemetry_has_driving(&[d(GEAR_PARK)], &[GEAR_PARK; 60], &[0.0; 60], 60, 60));
+        // Reverse reports NEGATIVE speeds — abs() must count as driving.
+        assert!(telemetry_has_driving(&[d(GEAR_PARK)], &[], &[-2.0], 0, 0));
+        // Crawl below threshold is not driving.
+        assert!(!telemetry_has_driving(&[], &[], &[0.2], 0, 0));
+        // Legacy row: raw counts only, some non-park frames.
+        assert!(telemetry_has_driving(&[], &[], &[], 40, 60));
+        // No telemetry at all: no positive evidence → not driving.
+        assert!(!telemetry_has_driving(&[], &[], &[], 0, 0));
+    }
+
+    #[test]
+    fn test_gap_fill_trailing_chain_admits_driving_rejects_parked_tail() {
+        // Drive 236 shape (Jul 4): RecentClips end mid-drive; the rest of
+        // the drive lives in an event pre-roll, followed by parked pre-roll
+        // clips after the car stopped. Driving clips chain in; parked ones
+        // never do, so the fill can't bleed into the parked sentry bloat.
+        let routes = vec![
+            test_route("RecentClips/2026-07-04/2026-07-04_20-42-50-front.mp4", vec![[37.0, -122.0]]),
+            test_route("RecentClips/2026-07-04/2026-07-04_20-43-50-front.mp4", vec![[37.001, -122.0]]),
+            // Trailing fill: drive continues in the pre-roll.
+            test_route("SentryClips/2026-07-04_20-55-50/2026-07-04_20-44-51-front.mp4", vec![[37.002, -122.0]]),
+            test_route("SentryClips/2026-07-04_20-55-50/2026-07-04_20-45-51-front.mp4", vec![[37.003, -122.0]]),
+            // Parked pre-roll clips after the car stopped → excluded.
+            park_route("SentryClips/2026-07-04_20-55-50/2026-07-04_20-46-52-front.mp4", 37.003),
+            park_route("SentryClips/2026-07-04_20-55-50/2026-07-04_20-47-52-front.mp4", 37.003),
+        ];
+        let groups = group_clips(routes);
+        assert_eq!(groups.len(), 1, "expected a single extended drive");
+        let files: Vec<&str> = groups[0].iter().map(|c| c.route.file.as_str()).collect();
+        assert_eq!(
+            files,
+            vec![
+                "RecentClips/2026-07-04/2026-07-04_20-42-50-front.mp4",
+                "RecentClips/2026-07-04/2026-07-04_20-43-50-front.mp4",
+                "SentryClips/2026-07-04_20-55-50/2026-07-04_20-44-51-front.mp4",
+                "SentryClips/2026-07-04_20-55-50/2026-07-04_20-45-51-front.mp4",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_gap_fill_leading_chain_admits_departure_footage() {
+        // Departure footage that only made an event pre-roll before the
+        // first RecentClips clip: chains backwards off the drive start.
+        let routes = vec![
+            test_route("SentryClips/2026-06-27_10-05-00/2026-06-27_09-58-10-front.mp4", vec![[37.0, -122.0]]),
+            test_route("SentryClips/2026-06-27_10-05-00/2026-06-27_09-59-10-front.mp4", vec![[37.001, -122.0]]),
+            test_route("RecentClips/2026-06-27/2026-06-27_10-00-10-front.mp4", vec![[37.002, -122.0]]),
+            test_route("RecentClips/2026-06-27/2026-06-27_10-01-10-front.mp4", vec![[37.003, -122.0]]),
+        ];
+        let groups = group_clips(routes);
+        assert_eq!(groups.len(), 1, "expected a single drive starting at the leading fill");
+        assert_eq!(groups[0].len(), 4);
+        assert_eq!(
+            groups[0][0].route.file,
+            "SentryClips/2026-06-27_10-05-00/2026-06-27_09-58-10-front.mp4"
+        );
+    }
+
+    #[test]
+    fn test_gap_fill_isolated_driving_cluster_stays_out() {
+        // Driving footage with NO adjacent RecentClips anchor (e.g. a
+        // weeks-old event cluster after the continuous footage rotated
+        // off) must stay out — proximity bound, independent of the
+        // driving gate.
+        let routes = vec![
+            test_route("RecentClips/2026-05-28/2026-05-28_10-00-00-front.mp4", vec![[37.0, -122.0]]),
+            test_route("SentryClips/2026-05-28_14-05-00/2026-05-28_14-00-00-front.mp4", vec![[37.1, -122.1]]),
+            test_route("SentryClips/2026-05-28_14-05-00/2026-05-28_14-01-00-front.mp4", vec![[37.1, -122.1]]),
+        ];
+        let groups = group_clips(routes);
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].len(), 1);
+        assert!(groups[0][0].route.file.starts_with("RecentClips/"));
+    }
+
+    #[test]
+    fn test_select_gap_fill_chain_cap_and_hop_window() {
+        let recent = vec![dts("2026-06-01 10:00:00")];
+        let mk = |s: &str| dts(s);
+        let files: Vec<(NaiveDateTime, String)> = vec![
+            // Chained trailing clips every ~61s...
+            (mk("2026-06-01 10:01:01"), "a"),
+            (mk("2026-06-01 10:02:02"), "b"),
+            // ...across a real-data intra-chain gap (~152s ≤ 3-min hop)...
+            (mk("2026-06-01 10:04:34"), "c"),
+            // ...far link still inside the 30-min cap...
+            (mk("2026-06-01 10:07:00"), "d"),
+            // Beyond a 3-min hop from anything → chain broken.
+            (mk("2026-06-01 10:12:00"), "e"),
+        ]
+        .into_iter()
+        .map(|(ts, n)| (ts, format!("SentryClips/2026-06-01_10-20-00/{}-front.mp4", n)))
+        .collect();
+        let cands: Vec<GapFillCandidate> = files
+            .iter()
+            .map(|(ts, f)| GapFillCandidate { ts: *ts, file: f.as_str(), driving: Some(true) })
+            .collect();
+        let picked = select_gap_fill(&recent, &cands);
+        assert_eq!(picked, vec![0, 1, 2, 3], "chain must stop at the broken hop");
+
+        // Cap: a chain of driving clips can't extend past GAP_FILL_MAX_MS
+        // from the nearest RecentClips clip.
+        let long: Vec<(NaiveDateTime, String)> = (1..=35)
+            .map(|m| {
+                (
+                    dts("2026-06-01 10:00:00") + chrono::Duration::seconds(m * 61),
+                    format!("SentryClips/2026-06-01_11-00-00/clip{:02}-front.mp4", m),
+                )
+            })
+            .collect();
+        let cands: Vec<GapFillCandidate> = long
+            .iter()
+            .map(|(ts, f)| GapFillCandidate { ts: *ts, file: f.as_str(), driving: Some(true) })
+            .collect();
+        let picked = select_gap_fill(&recent, &cands);
+        assert!(!picked.is_empty());
+        for &i in &picked {
+            assert!(
+                (cands[i].ts - recent[0]).num_milliseconds() <= GAP_FILL_MAX_MS,
+                "{} exceeds the chain cap",
+                cands[i].file
+            );
+        }
+        assert!(picked.len() < cands.len(), "cap must cut the tail of the chain");
+    }
+
+    #[test]
+    fn test_select_gap_fill_rejects_recent_twin_and_overlap_dup() {
+        // Tesla stamps the Saved/Sentry twin of an occupied segment 0-1 s
+        // after the RecentClips original (drive 236: 20:44:50 vs
+        // 20:44:51) — a duplicate, never a fill. A second candidate
+        // within the dup window of a kept one is an overlapping segment
+        // of the same footage — one winner.
+        let recent = vec![dts("2026-07-04 20:43:50"), dts("2026-07-04 20:44:50")];
+        let cands = vec![
+            GapFillCandidate {
+                ts: dts("2026-07-04 20:44:51"), // 1s after occupied slot → twin
+                file: "SentryClips/e/2026-07-04_20-44-51-front.mp4",
+                driving: Some(true),
+            },
+            GapFillCandidate {
+                ts: dts("2026-07-04 20:45:51"), // real trailing fill
+                file: "SentryClips/e/2026-07-04_20-45-51-front.mp4",
+                driving: Some(true),
+            },
+            GapFillCandidate {
+                ts: dts("2026-07-04 20:46:11"), // 20s after the kept fill → overlap dup
+                file: "SavedClips/e2/2026-07-04_20-46-11-front.mp4",
+                driving: Some(true),
+            },
+        ];
+        assert_eq!(select_gap_fill(&recent, &cands), vec![1]);
+    }
+
+    #[test]
+    fn test_select_gap_fill_events_superset_without_sei() {
+        // Processor-side scan has no SEI yet: trailing/leading candidates
+        // are selected on timestamps alone (the post-extraction driving
+        // gate discards the parked ones later); isolated clusters still
+        // never qualify.
+        let recent = vec![dts("2026-06-01 10:00:00"), dts("2026-06-01 10:01:00")];
+        let cands = vec![
+            (dts("2026-06-01 10:02:01"), "SentryClips/e/2026-06-01_10-02-01-front.mp4"),
+            (dts("2026-06-01 09:58:30"), "SentryClips/e/2026-06-01_09-58-30-front.mp4"),
+            (dts("2026-06-01 12:00:00"), "SentryClips/far/2026-06-01_12-00-00-front.mp4"),
+        ];
+        let mut picked = select_gap_fill_events(&recent, &cands);
+        picked.sort();
+        assert_eq!(picked, vec![0, 1], "trailing+leading in, isolated out");
+    }
+
+    #[test]
+    fn test_gap_fill_trailing_clip_park_tail_is_trimmed() {
+        // The last admitted trailing clip typically decelerates and parks
+        // mid-clip. The gear-state splitter must trim the drive at the
+        // Park transition — points from the parked tail don't survive.
+        let mut mixed = test_route(
+            "SentryClips/2026-07-04_20-55-50/2026-07-04_20-45-51-front.mp4",
+            (0..10).map(|i| [37.002 + i as f64 * 1e-4, -122.0]).collect(),
+        );
+        mixed.gear_runs = vec![
+            GearRun { gear: 1, frames: 30 },
+            GearRun { gear: GEAR_PARK, frames: 30 },
+        ];
+        mixed.gear_states = vec![1; 10];
+        mixed.speeds = vec![5.0; 10];
+        let routes = vec![
+            test_route("RecentClips/2026-07-04/2026-07-04_20-44-50-front.mp4", vec![[37.001, -122.0]]),
+            mixed,
+        ];
+        let groups = group_clips(routes);
+        assert_eq!(groups.len(), 1);
+        let fill = groups[0]
+            .iter()
+            .find(|c| c.route.file.starts_with("SentryClips/"))
+            .expect("trailing fill admitted");
+        assert_eq!(
+            fill.route.points.len(),
+            5,
+            "parked half of the trailing clip must be trimmed off"
+        );
+    }
+
+    #[test]
+    fn test_group_summary_clips_trailing_chain() {
+        let mk = |file: &str| RouteSummary {
+            file: file.to_string(),
+            date: "2026-07-04".to_string(),
+            raw_park_count: 0,
+            raw_frame_count: 60,
+            gear_runs: vec![GearRun { gear: 1, frames: 60 }],
+            aggregates: RouteAggregates::default(),
+            source: None,
+            external_signature: None,
+            telemetry: Default::default(),
+        };
+        let parked = |file: &str| RouteSummary {
+            file: file.to_string(),
+            date: "2026-07-04".to_string(),
+            raw_park_count: 60,
+            raw_frame_count: 60,
+            gear_runs: vec![GearRun { gear: GEAR_PARK, frames: 60 }],
+            aggregates: RouteAggregates::default(),
+            source: None,
+            external_signature: None,
+            telemetry: Default::default(),
+        };
+        let summaries = vec![
+            mk("2026-07-04/2026-07-04_20-43-50-front.mp4"),
+            mk("SentryClips/2026-07-04_20-55-50/2026-07-04_20-44-51-front.mp4"),
+            mk("SentryClips/2026-07-04_20-55-50/2026-07-04_20-45-51-front.mp4"),
+            parked("SentryClips/2026-07-04_20-55-50/2026-07-04_20-46-52-front.mp4"),
+        ];
+        let groups = group_summary_clips(&summaries);
+        assert_eq!(groups.len(), 1);
+        let files: Vec<&str> = groups[0].iter().map(|c| c.summary.file.as_str()).collect();
+        assert_eq!(
+            files,
+            vec![
+                "2026-07-04/2026-07-04_20-43-50-front.mp4",
+                "SentryClips/2026-07-04_20-55-50/2026-07-04_20-44-51-front.mp4",
+                "SentryClips/2026-07-04_20-55-50/2026-07-04_20-45-51-front.mp4",
             ]
         );
     }

--- a/crates/drives/src/grouper.rs
+++ b/crates/drives/src/grouper.rs
@@ -22,6 +22,10 @@ use crate::types::*;
 /// Time gap (ms) that splits clips into separate drives (5 minutes).
 const DRIVE_GAP_MS: i64 = 5 * 60 * 1000;
 
+/// Minimum gap (ms) between consecutive RecentClips timestamps that counts
+/// as a recording hole (≥1 missing minute-clip; normal spacing is ~60s).
+pub(crate) const GAP_FILL_MIN_MS: i64 = 90 * 1000;
+
 /// Minimum Park duration (seconds) that ends the current drive within a clip.
 const PARK_GAP_SECONDS: f64 = 2.0;
 
@@ -287,9 +291,79 @@ pub fn build_single_drive_from_clips(
 /// (`SavedClips/` or `SentryClips/`). The `replace('\\', "/")` handles
 /// drive-data.json imports that came from a Windows export (Sentry-Drive
 /// writes backslashes in its file paths).
-fn is_event_folder_path(file: &str) -> bool {
+pub(crate) fn is_event_folder_path(file: &str) -> bool {
     let norm = file.replace('\\', "/");
     norm.starts_with("SavedClips/") || norm.starts_with("SentryClips/")
+}
+
+// ---------------------------------------------------------------------------
+// Internal: event-clip gap-fill
+//
+// The processor only ingests RecentClips, so a hole in the continuous
+// recording becomes a hole in the drive route — even when the same minute
+// clips exist inside a SavedClips/SentryClips event folder (Tesla events
+// carry a ~10-minute pre-roll). Gap-fill admits exactly those event clips:
+// ones whose timestamp falls strictly inside a RecentClips hole within one
+// drive window. Everything else in the event folders (parked Sentry
+// recordings, duplicates of RecentClips clips) stays filtered.
+// ---------------------------------------------------------------------------
+
+/// Clip timestamp parsed from the FILENAME component only. Event paths
+/// embed the event-folder timestamp first (`SentryClips/<event_ts>/<clip_ts>-
+/// front.mp4`), which a left-to-right `parse_file_timestamp` would win.
+pub(crate) fn parse_clip_timestamp(file_path: &str) -> Option<NaiveDateTime> {
+    let norm = file_path.replace('\\', "/");
+    parse_file_timestamp(norm.rsplit('/').next().unwrap_or(&norm))
+}
+
+/// Holes in a SORTED continuous-clip timestamp sequence that qualify for
+/// event-clip gap-fill: wider than one missing minute-clip but within the
+/// drive-split threshold — a longer gap is a park/drive boundary the
+/// grouper already splits on, not a recording dropout.
+pub(crate) fn fillable_holes(sorted_ts: &[NaiveDateTime]) -> Vec<(NaiveDateTime, NaiveDateTime)> {
+    sorted_ts
+        .windows(2)
+        .filter(|w| {
+            let gap = (w[1] - w[0]).num_milliseconds();
+            gap > GAP_FILL_MIN_MS && gap <= DRIVE_GAP_MS
+        })
+        .map(|w| (w[0], w[1]))
+        .collect()
+}
+
+/// True when `ts` lies strictly inside one of `holes` (sorted,
+/// non-overlapping). Endpoints are occupied RecentClips slots and stay
+/// RecentClips-owned.
+pub(crate) fn ts_in_holes(holes: &[(NaiveDateTime, NaiveDateTime)], ts: NaiveDateTime) -> bool {
+    let i = holes.partition_point(|h| h.0 < ts);
+    i > 0 && ts < holes[i - 1].1
+}
+
+/// Select which event clips fill RecentClips holes. `recent_sorted_ts` is
+/// the sorted continuous-clip timeline; `candidates` are (clip timestamp,
+/// path) pairs. Returns indices into `candidates`: at most one per
+/// timestamp (lowest path wins, so SavedClips/SentryClips twins of the
+/// same minute never both land), and never a timestamp RecentClips covers
+/// (by construction no recent timestamp lies strictly inside a hole).
+pub(crate) fn select_gap_fill_events(
+    recent_sorted_ts: &[NaiveDateTime],
+    candidates: &[(NaiveDateTime, &str)],
+) -> Vec<usize> {
+    let holes = fillable_holes(recent_sorted_ts);
+    if holes.is_empty() || candidates.is_empty() {
+        return Vec::new();
+    }
+    let mut order: Vec<usize> = (0..candidates.len()).collect();
+    order.sort_by(|&a, &b| candidates[a].cmp(&candidates[b]));
+    let mut filled = std::collections::HashSet::new();
+    let mut out = Vec::new();
+    for i in order {
+        let (ts, _) = candidates[i];
+        if ts_in_holes(&holes, ts) && filled.insert(ts) {
+            out.push(i);
+        }
+    }
+    out
 }
 
 /// Dedup by normalized file path, parse timestamps, sort, split on 5-min gaps,
@@ -300,42 +374,38 @@ fn group_clips(routes: Vec<Route>) -> Vec<Vec<TimedRoute>> {
         return Vec::new();
     }
 
-    // Filter out routes that live under SavedClips/SentryClips event folders
-    // BEFORE dedup. These contain (a) clips that duplicate RecentClips data
-    // with a different path the dedup-by-path can't catch, and (b) parked
-    // Sentry-mode recordings the gear-state splitter would otherwise emit
-    // as a spurious "drive" bordering an actual trip. Mirrors the discovery
-    // filter in processor.rs::scan_dir and Sentry-Drive's process.js:91-94.
-    // Safety net for: pre-v5 DB rows the migration may have missed, and
-    // imports of a drive-data.json produced by an unfixed build.
+    // Partition off routes that live under SavedClips/SentryClips event
+    // folders BEFORE dedup. These contain (a) clips that duplicate
+    // RecentClips data with a different path the dedup-by-path can't catch,
+    // and (b) parked Sentry-mode recordings the gear-state splitter would
+    // otherwise emit as a spurious "drive" bordering an actual trip.
+    // Mirrors the discovery filter in processor.rs::scan_dir and
+    // Sentry-Drive's process.js:91-94. The only event routes admitted are
+    // gap-fills (see below); the rest are dropped exactly as before.
     let input_count = routes.len();
     let mut seen = HashMap::with_capacity(routes.len());
     let mut unique: Vec<Route> = Vec::with_capacity(routes.len());
+    let mut event_candidates: Vec<Route> = Vec::new();
     let mut filtered_event_folder = 0usize;
     for r in routes {
-        if is_event_folder_path(&r.file) {
-            filtered_event_folder += 1;
+        let norm = r.file.replace('\\', "/");
+        if seen.insert(norm, ()).is_some() {
             continue;
         }
-        let norm = r.file.replace('\\', "/");
-        if seen.insert(norm, ()).is_none() {
+        if is_event_folder_path(&r.file) {
+            event_candidates.push(r);
+        } else {
             unique.push(r);
         }
     }
     let unique_count = unique.len();
-    if filtered_event_folder > 0 {
-        info!(
-            "group_clips: filtered {} SavedClips/SentryClips route(s)",
-            filtered_event_folder
-        );
-    }
-    if unique_count + filtered_event_folder < input_count {
+    if unique_count + event_candidates.len() < input_count {
         warn!(
-            "group_clips: dedup dropped {} duplicate-path route(s) (input={} unique={} event_filtered={})",
-            input_count - unique_count - filtered_event_folder,
+            "group_clips: dedup dropped {} duplicate-path route(s) (input={} unique={} event_candidates={})",
+            input_count - unique_count - event_candidates.len(),
             input_count,
             unique_count,
-            filtered_event_folder,
+            event_candidates.len(),
         );
     }
 
@@ -374,6 +444,45 @@ fn group_clips(routes: Vec<Route>) -> Vec<Vec<TimedRoute>> {
     }
 
     timed.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
+
+    // Gap-fill: admit event routes whose CLIP timestamp (filename, not
+    // event-folder name) falls strictly inside a RecentClips hole — the
+    // missing minute exists only in the event pre-roll. One route per
+    // timestamp; everything else stays filtered.
+    if !event_candidates.is_empty() {
+        let recent_ts: Vec<NaiveDateTime> = timed.iter().map(|t| t.timestamp).collect();
+        let mut cands: Vec<(NaiveDateTime, Option<Route>)> = Vec::new();
+        for r in event_candidates {
+            match parse_clip_timestamp(&r.file) {
+                Some(ts) => cands.push((ts, Some(r))),
+                None => filtered_event_folder += 1,
+            }
+        }
+        let keys: Vec<(NaiveDateTime, &str)> = cands
+            .iter()
+            .map(|(ts, r)| (*ts, r.as_ref().unwrap().file.as_str()))
+            .collect();
+        let mut gap_filled = 0usize;
+        for i in select_gap_fill_events(&recent_ts, &keys) {
+            let (ts, r) = &mut cands[i];
+            timed.push(TimedRoute { route: r.take().unwrap(), timestamp: *ts });
+            gap_filled += 1;
+        }
+        filtered_event_folder += cands.iter().filter(|(_, r)| r.is_some()).count();
+        if gap_filled > 0 {
+            timed.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
+            info!(
+                "group_clips: gap-filled {} event route(s) into RecentClips holes",
+                gap_filled
+            );
+        }
+        if filtered_event_folder > 0 {
+            info!(
+                "group_clips: filtered {} SavedClips/SentryClips route(s)",
+                filtered_event_folder
+            );
+        }
+    }
     let timed_count = timed.len();
 
     // First pass: group by time gap
@@ -1741,11 +1850,21 @@ fn group_summary_clips<'a>(summaries: &'a [RouteSummary]) -> Vec<Vec<SubClipSumm
         return Vec::new();
     }
 
+    // Event-folder rows are partitioned off like `group_clips` does — the
+    // processor only ingests them as gap-fills, but a drive-data.json
+    // import from an unfixed build can carry arbitrary event rows, so the
+    // same hole-gated admission applies here.
     let mut seen = HashMap::with_capacity(summaries.len());
     let mut unique: Vec<&RouteSummary> = Vec::with_capacity(summaries.len());
+    let mut event_candidates: Vec<&RouteSummary> = Vec::new();
     for s in summaries {
         let norm = s.file.replace('\\', "/");
-        if seen.insert(norm, ()).is_none() {
+        if seen.insert(norm, ()).is_some() {
+            continue;
+        }
+        if is_event_folder_path(&s.file) {
+            event_candidates.push(s);
+        } else {
             unique.push(s);
         }
     }
@@ -1761,6 +1880,27 @@ fn group_summary_clips<'a>(summaries: &'a [RouteSummary]) -> Vec<Vec<SubClipSumm
         return Vec::new();
     }
     timed.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
+
+    // Gap-fill admission — see group_clips for the rationale. Clip
+    // timestamps come from the filename component (the event-folder name
+    // also matches the timestamp pattern and would win a full-path scan).
+    if !event_candidates.is_empty() {
+        let recent_ts: Vec<NaiveDateTime> = timed.iter().map(|t| t.timestamp).collect();
+        let cands: Vec<(NaiveDateTime, &RouteSummary)> = event_candidates
+            .into_iter()
+            .filter_map(|s| parse_clip_timestamp(&s.file).map(|ts| (ts, s)))
+            .collect();
+        let keys: Vec<(NaiveDateTime, &str)> =
+            cands.iter().map(|(ts, s)| (*ts, s.file.as_str())).collect();
+        let admitted = select_gap_fill_events(&recent_ts, &keys);
+        if !admitted.is_empty() {
+            for i in admitted {
+                let (ts, s) = cands[i];
+                timed.push(TimedSummary { summary: s, timestamp: ts });
+            }
+            timed.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
+        }
+    }
 
     // Time-gap split.
     let mut time_groups: Vec<Vec<TimedSummary>> = Vec::new();
@@ -2859,6 +2999,142 @@ mod tests {
                 clip.route.file
             );
         }
+    }
+
+    // ── Event-clip gap-fill tests ────────────────────────────────────
+
+    fn dts(s: &str) -> NaiveDateTime {
+        NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S").unwrap()
+    }
+
+    #[test]
+    fn test_parse_clip_timestamp_uses_filename_component() {
+        // Event paths embed the event-folder timestamp FIRST — a full-path
+        // scan would return 18:46:39 instead of the clip's 18:35:39.
+        assert_eq!(
+            parse_clip_timestamp("SentryClips/2026-05-17_18-46-39/2026-05-17_18-35-39-front.mp4"),
+            Some(dts("2026-05-17 18:35:39"))
+        );
+        assert_eq!(
+            parse_clip_timestamp("SavedClips\\2026-05-17_18-47-59\\2026-05-17_18-47-34-front.mp4"),
+            Some(dts("2026-05-17 18:47:34"))
+        );
+        assert_eq!(
+            parse_clip_timestamp("RecentClips/2026-05-17/2026-05-17_18-47-34-front.mp4"),
+            Some(dts("2026-05-17 18:47:34"))
+        );
+        assert_eq!(parse_clip_timestamp("SentryClips/2026-05-17_18-46-39/event.json"), None);
+    }
+
+    #[test]
+    fn test_fillable_holes_bounds() {
+        // Normal 60s spacing → no holes; a 3-min gap → hole; a 6-min gap
+        // is a park/drive boundary the grouper splits on → not a hole.
+        let seq = vec![
+            dts("2026-06-01 10:00:00"),
+            dts("2026-06-01 10:01:00"),
+            dts("2026-06-01 10:04:00"), // 3-min gap after 10:01
+            dts("2026-06-01 10:05:00"),
+            dts("2026-06-01 10:11:00"), // 6-min gap after 10:05
+        ];
+        let holes = fillable_holes(&seq);
+        assert_eq!(holes, vec![(dts("2026-06-01 10:01:00"), dts("2026-06-01 10:04:00"))]);
+        // Strict interior: endpoints are occupied RecentClips slots.
+        assert!(ts_in_holes(&holes, dts("2026-06-01 10:02:00")));
+        assert!(!ts_in_holes(&holes, dts("2026-06-01 10:01:00")));
+        assert!(!ts_in_holes(&holes, dts("2026-06-01 10:04:00")));
+        assert!(!ts_in_holes(&holes, dts("2026-06-01 10:07:00")));
+    }
+
+    #[test]
+    fn test_select_gap_fill_events_dedup() {
+        let recent = vec![
+            dts("2026-06-01 10:00:00"),
+            dts("2026-06-01 10:03:00"),
+        ];
+        // Same missing minute exists in both event folders (overlapping
+        // events) → exactly one winner, lowest path.
+        let cands = vec![
+            (dts("2026-06-01 10:01:00"), "SentryClips/2026-06-01_10-02-30/2026-06-01_10-01-00-front.mp4"),
+            (dts("2026-06-01 10:01:00"), "SavedClips/2026-06-01_10-02-30/2026-06-01_10-01-00-front.mp4"),
+            (dts("2026-06-01 10:02:00"), "SentryClips/2026-06-01_10-02-30/2026-06-01_10-02-00-front.mp4"),
+            // Outside any hole (parked recording) → rejected.
+            (dts("2026-06-01 09:30:00"), "SentryClips/2026-06-01_09-31-00/2026-06-01_09-30-00-front.mp4"),
+        ];
+        let mut picked: Vec<&str> =
+            select_gap_fill_events(&recent, &cands).into_iter().map(|i| cands[i].1).collect();
+        picked.sort();
+        assert_eq!(
+            picked,
+            vec![
+                "SavedClips/2026-06-01_10-02-30/2026-06-01_10-01-00-front.mp4",
+                "SentryClips/2026-06-01_10-02-30/2026-06-01_10-02-00-front.mp4",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_group_clips_gap_fills_event_route_into_hole() {
+        // RecentClips drive with one missing minute (10:01); the same
+        // minute exists in a SentryClips pre-roll. It must be admitted
+        // once; the duplicate of an occupied slot and the parked clip
+        // must stay filtered.
+        let routes = vec![
+            test_route("RecentClips/2026-06-01/2026-06-01_10-00-00-front.mp4", vec![[37.0, -122.0]]),
+            test_route("RecentClips/2026-06-01/2026-06-01_10-02-00-front.mp4", vec![[37.002, -122.0]]),
+            test_route("RecentClips/2026-06-01/2026-06-01_10-03-00-front.mp4", vec![[37.003, -122.0]]),
+            // Fills the hole.
+            test_route("SentryClips/2026-06-01_10-02-30/2026-06-01_10-01-00-front.mp4", vec![[37.001, -122.0]]),
+            // Duplicate of the occupied 10:02 slot → filtered.
+            test_route("SavedClips/2026-06-01_10-02-30/2026-06-01_10-02-00-front.mp4", vec![[37.002, -122.0]]),
+            // Parked recording hours earlier, no surrounding drive → filtered.
+            park_route("SentryClips/2026-06-01_02-00-00/2026-06-01_01-59-00-front.mp4", 37.0),
+        ];
+        let groups = group_clips(routes);
+        assert_eq!(groups.len(), 1, "expected a single gap-filled drive");
+        let files: Vec<&str> = groups[0].iter().map(|c| c.route.file.as_str()).collect();
+        assert_eq!(
+            files,
+            vec![
+                "RecentClips/2026-06-01/2026-06-01_10-00-00-front.mp4",
+                "SentryClips/2026-06-01_10-02-30/2026-06-01_10-01-00-front.mp4",
+                "RecentClips/2026-06-01/2026-06-01_10-02-00-front.mp4",
+                "RecentClips/2026-06-01/2026-06-01_10-03-00-front.mp4",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_group_summary_clips_gap_fill_and_event_filter() {
+        let mk = |file: &str| RouteSummary {
+            file: file.to_string(),
+            date: "2026-06-01".to_string(),
+            raw_park_count: 0,
+            raw_frame_count: 60,
+            gear_runs: vec![GearRun { gear: 1, frames: 60 }],
+            aggregates: RouteAggregates::default(),
+            source: None,
+            external_signature: None,
+            telemetry: Default::default(),
+        };
+        let summaries = vec![
+            mk("2026-06-01/2026-06-01_10-00-00-front.mp4"),
+            mk("2026-06-01/2026-06-01_10-02-00-front.mp4"),
+            mk("SentryClips/2026-06-01_10-02-30/2026-06-01_10-01-00-front.mp4"),
+            // Parked event row far from any drive → filtered.
+            mk("SentryClips/2026-06-01_02-00-00/2026-06-01_01-59-00-front.mp4"),
+        ];
+        let groups = group_summary_clips(&summaries);
+        assert_eq!(groups.len(), 1);
+        let files: Vec<&str> = groups[0].iter().map(|c| c.summary.file.as_str()).collect();
+        assert_eq!(
+            files,
+            vec![
+                "2026-06-01/2026-06-01_10-00-00-front.mp4",
+                "SentryClips/2026-06-01_10-02-30/2026-06-01_10-01-00-front.mp4",
+                "2026-06-01/2026-06-01_10-02-00-front.mp4",
+            ]
+        );
     }
 
     // ── Telemetry rollup tests ───────────────────────────────────────

--- a/crates/drives/src/grouper.rs
+++ b/crates/drives/src/grouper.rs
@@ -26,6 +26,14 @@ const DRIVE_GAP_MS: i64 = 5 * 60 * 1000;
 /// as a recording hole (≥1 missing minute-clip; normal spacing is ~60s).
 pub(crate) const GAP_FILL_MIN_MS: i64 = 90 * 1000;
 
+/// Max hole (ms) event clips may fill. Sentry-covered dropouts run long —
+/// the car parked, so the gap spans the arrival + a chain of ~10-min
+/// pre-roll events (real data: 9-19 min). Wider than DRIVE_GAP_MS on
+/// purpose; the coverage requirement (an event clip must exist for each
+/// filled minute) is what actually bounds the fill. Beyond this it's a
+/// genuine multi-drive boundary, not a recording dropout.
+pub(crate) const GAP_FILL_MAX_MS: i64 = 30 * 60 * 1000;
+
 /// Minimum Park duration (seconds) that ends the current drive within a clip.
 const PARK_GAP_SECONDS: f64 = 2.0;
 
@@ -325,7 +333,7 @@ pub(crate) fn fillable_holes(sorted_ts: &[NaiveDateTime]) -> Vec<(NaiveDateTime,
         .windows(2)
         .filter(|w| {
             let gap = (w[1] - w[0]).num_milliseconds();
-            gap > GAP_FILL_MIN_MS && gap <= DRIVE_GAP_MS
+            gap > GAP_FILL_MIN_MS && gap <= GAP_FILL_MAX_MS
         })
         .map(|w| (w[0], w[1]))
         .collect()
@@ -3028,22 +3036,35 @@ mod tests {
 
     #[test]
     fn test_fillable_holes_bounds() {
-        // Normal 60s spacing → no holes; a 3-min gap → hole; a 6-min gap
-        // is a park/drive boundary the grouper splits on → not a hole.
+        // Normal 60s spacing → no hole. A 3-min and a 6-min gap are both
+        // fillable holes: sentry-covered dropouts run long (the car parked,
+        // so the gap spans arrival + a chain of ~10-min pre-roll events —
+        // real data shows 9-19 min). A 35-min gap exceeds GAP_FILL_MAX_MS →
+        // a genuine multi-drive boundary, not a recording dropout.
         let seq = vec![
             dts("2026-06-01 10:00:00"),
             dts("2026-06-01 10:01:00"),
             dts("2026-06-01 10:04:00"), // 3-min gap after 10:01
             dts("2026-06-01 10:05:00"),
             dts("2026-06-01 10:11:00"), // 6-min gap after 10:05
+            dts("2026-06-01 10:46:00"), // 35-min gap after 10:11 (> GAP_FILL_MAX_MS)
         ];
         let holes = fillable_holes(&seq);
-        assert_eq!(holes, vec![(dts("2026-06-01 10:01:00"), dts("2026-06-01 10:04:00"))]);
+        assert_eq!(
+            holes,
+            vec![
+                (dts("2026-06-01 10:01:00"), dts("2026-06-01 10:04:00")),
+                (dts("2026-06-01 10:05:00"), dts("2026-06-01 10:11:00")),
+            ]
+        );
         // Strict interior: endpoints are occupied RecentClips slots.
         assert!(ts_in_holes(&holes, dts("2026-06-01 10:02:00")));
+        assert!(ts_in_holes(&holes, dts("2026-06-01 10:07:00"))); // inside the 6-min hole
         assert!(!ts_in_holes(&holes, dts("2026-06-01 10:01:00")));
         assert!(!ts_in_holes(&holes, dts("2026-06-01 10:04:00")));
-        assert!(!ts_in_holes(&holes, dts("2026-06-01 10:07:00")));
+        assert!(!ts_in_holes(&holes, dts("2026-06-01 10:11:00")));
+        // The 35-min gap is a drive boundary, never fillable.
+        assert!(!ts_in_holes(&holes, dts("2026-06-01 10:30:00")));
     }
 
     #[test]

--- a/crates/drives/src/grouper.rs
+++ b/crates/drives/src/grouper.rs
@@ -278,7 +278,13 @@ pub fn build_single_drive_from_clips(
     let mut timed: Vec<TimedRoute> = routes
         .iter()
         .filter_map(|r| {
-            parse_file_timestamp(&r.file).map(|ts| TimedRoute {
+            // parse_clip_timestamp (basename), NOT parse_file_timestamp:
+            // gap-fill routes are keyed at event-folder paths
+            // (SentryClips/<event-ts>/<clip-ts>-front.mp4) whose folder
+            // timestamp a left-to-right scan would win, placing the clip at
+            // the event time instead of its own — a phantom gap in the
+            // drive's point/speed timeline.
+            parse_clip_timestamp(&r.file).map(|ts| TimedRoute {
                 route: r.clone(),
                 timestamp: ts,
             })
@@ -425,7 +431,7 @@ fn group_clips(routes: Vec<Route>) -> Vec<Vec<TimedRoute>> {
     let mut dropped_total: usize = 0;
     let mut timed: Vec<TimedRoute> = unique
         .into_iter()
-        .filter_map(|r| match parse_file_timestamp(&r.file) {
+        .filter_map(|r| match parse_clip_timestamp(&r.file) {
             Some(ts) => Some(TimedRoute { route: r, timestamp: ts }),
             None => {
                 dropped_total += 1;
@@ -1880,7 +1886,7 @@ fn group_summary_clips<'a>(summaries: &'a [RouteSummary]) -> Vec<Vec<SubClipSumm
     let mut timed: Vec<TimedSummary> = unique
         .into_iter()
         .filter_map(|s| {
-            let ts = parse_file_timestamp(&s.file)?;
+            let ts = parse_clip_timestamp(&s.file)?;
             Some(TimedSummary { summary: s, timestamp: ts })
         })
         .collect();
@@ -2696,6 +2702,34 @@ mod tests {
         let groups = group_clips(routes);
         // 1 hour gap > 5 min => 2 groups
         assert_eq!(groups.len(), 2);
+    }
+
+    #[test]
+    fn test_build_single_drive_dates_gapfill_by_clip_not_event_folder() {
+        // Regression: a gap-fill clip lives at an event-folder path whose
+        // FOLDER timestamp (12:40:00) is 38 min after the clip's own time
+        // (12:02:00). build_single_drive_from_clips must date it by the clip
+        // (basename) time — a left-to-right path scan grabs the folder time
+        // first and drops the clip's points ~38 min late, blowing a phantom
+        // gap in the drive's speed timeline (real 4C+ bug, drive 241).
+        let native = test_route(
+            "RecentClips/2026-01-15/2026-01-15_12-00-00-front.mp4",
+            vec![[37.0, -122.0]],
+        );
+        let gapfill = test_route(
+            "SentryClips/2026-01-15_12-40-00/2026-01-15_12-02-00-front.mp4",
+            vec![[37.02, -122.0]],
+        );
+        let drive =
+            build_single_drive_from_clips(&[native, gapfill], 0, &HashMap::new()).expect("drive");
+        assert_eq!(drive.clip_count, 2);
+        let max_t = drive.points.iter().map(|p| p[2]).fold(0.0_f64, f64::max);
+        // Clip time (12:02) => ~120 000 ms. Event-folder time (12:40) =>
+        // ~2 280 000 ms. Anything past 5 min means the old path-scan bug.
+        assert!(
+            max_t < 300_000.0,
+            "gap-fill clip placed at {max_t} ms — expected ~120 000 (clip time), not the event-folder time",
+        );
     }
 
     #[test]

--- a/crates/drives/src/processor.rs
+++ b/crates/drives/src/processor.rs
@@ -179,6 +179,7 @@ impl Processor {
         let total = unprocessed.len();
         let mut routes_found: usize = 0;
         let mut files_with_gps: usize = 0;
+        let mut gap_fill_parked_skipped: usize = 0;
         let mut errors: Vec<String> = Vec::new();
         let mut error_count: usize = 0;
         info!("found {} unprocessed clip files", total);
@@ -218,6 +219,29 @@ impl Processor {
             // an owned String just to take a slice of it.
             let date: &str = file.split('/').next().unwrap_or("");
             match extract::extract_gps_from_file(&full_path) {
+                // Driving gate for gap-fill event clips: the
+                // pre-extraction scan is timestamp-only, so a parked
+                // car's sentry clips chained after a drive reach here
+                // too. A route row under SavedClips/SentryClips feeds
+                // gap_fill_files() → the playback manifest →
+                // RecentClips cross-links — exactly the parked bloat
+                // 60c5602 removed — so a no-driving event clip is never
+                // stored, only marked processed.
+                Ok(gps)
+                    if crate::grouper::is_event_folder_path(file)
+                        && !crate::grouper::telemetry_has_driving(
+                            &gps.gear_runs,
+                            &gps.gear_states,
+                            &gps.speeds,
+                            gps.raw_park_count,
+                            gps.raw_frame_count,
+                        ) =>
+                {
+                    gap_fill_parked_skipped += 1;
+                    if let Err(me) = self.store.mark_processed(file) {
+                        warn!("failed to mark {} processed: {}", file, me);
+                    }
+                }
                 Ok(gps) => {
                     if !gps.points.is_empty() {
                         files_with_gps += 1;
@@ -344,6 +368,12 @@ impl Processor {
             "processing complete: {} files processed, {} routes found, {} with GPS, {} errors",
             total, routes_found, files_with_gps, error_count
         );
+        if gap_fill_parked_skipped > 0 {
+            info!(
+                "gap-fill: {} event clip(s) skipped by the driving gate (parked pre-roll)",
+                gap_fill_parked_skipped
+            );
+        }
 
         // Wake the cloud-uploader if it's listening. Cheap; idempotent
         // (notify_one with no waiter is a no-op).
@@ -399,14 +429,23 @@ impl Processor {
         Ok(())
     }
 
-    /// Find Saved/Sentry event clips that fill RecentClips holes: the
-    /// continuous recording gapped mid-drive, but the same minute exists in
-    /// an event folder's ~10-minute pre-roll. Returns unprocessed relative
-    /// paths (kept at their real event-folder location — no copies or
-    /// symlinks). Selective by construction: a parked car's event clips
-    /// have no surrounding continuous footage, so they never fall inside a
-    /// hole and never qualify. One clip per missing timestamp
-    /// (grouper::select_gap_fill_events picks the winner).
+    /// Find Saved/Sentry event clips that fill RecentClips gaps: the
+    /// continuous recording gapped mid-drive (interior hole), or the drive
+    /// ran past its last RecentClips clip / started before its first one
+    /// and the footage only made an event folder's ~10-minute pre-roll
+    /// (trailing/leading chain). Returns unprocessed relative paths (kept
+    /// at their real event-folder location — no copies or symlinks).
+    ///
+    /// This is a timestamp-bounded SUPERSET of the final fill set: without
+    /// SEI in hand, a parked car's event clips chained shortly after a
+    /// drive can qualify here too. They are extracted once, rejected by
+    /// the driving gate in `do_process` (never stored, only marked
+    /// processed), and the chain cap (grouper::GAP_FILL_MAX_MS from the
+    /// nearest RecentClips clip) bounds that one-time waste to ~30 clips
+    /// per drive boundary on a sentry-heavy install. Isolated event
+    /// clusters with no adjacent continuous footage never qualify at all.
+    /// One clip per missing timestamp (grouper::select_gap_fill_events
+    /// picks the winner).
     fn scan_event_gap_fill(
         &self,
         recent_sorted_ts: &[chrono::NaiveDateTime],

--- a/crates/drives/src/processor.rs
+++ b/crates/drives/src/processor.rs
@@ -132,16 +132,49 @@ impl Processor {
         // query failure instead of silently treating everything as
         // unprocessed and re-ingesting the whole tree.
         let processed = self.store.processed_set()?;
+
+        // Continuous-recording timeline for gap-fill hole detection: the
+        // disk scan ∪ already-processed keys (clips rotated off disk still
+        // anchor historical holes). Event keys are excluded — a gap-filled
+        // clip must keep reading as a filled hole, not a new slot.
+        let mut recent_ts: Vec<chrono::NaiveDateTime> = files
+            .iter()
+            .filter_map(|f| crate::grouper::parse_clip_timestamp(f))
+            .collect();
+        recent_ts.extend(
+            processed
+                .iter()
+                .filter(|k| !crate::grouper::is_event_folder_path(k))
+                .filter_map(|k| crate::grouper::parse_clip_timestamp(k)),
+        );
+        recent_ts.sort();
+        recent_ts.dedup();
+
         // Membership must compare CANONICAL keys: the scan yields physical
         // paths (`RecentClips/YYYY-MM-DD/x.mp4` under the snapshot symlink
         // layout) while the store keys rows by `normalize_path` — which
         // strips that prefix. Comparing the raw scan path would miss every
         // stored row and re-extract the whole RecentClips tree each run.
         // The physical path is kept for the extraction read below.
-        let unprocessed: Vec<String> = files
+        let mut unprocessed: Vec<String> = files
             .into_iter()
             .filter(|f| !processed.contains(crate::db::normalize_path(f).as_str()))
             .collect();
+
+        // Gap-fill: append event clips that cover RecentClips holes. They
+        // ride the same extraction loop (throttle, progress, resume via
+        // processed_files) and land keyed at their real event-folder path.
+        match self.scan_event_gap_fill(&recent_ts, &processed) {
+            Ok(gap_fill) if !gap_fill.is_empty() => {
+                info!(
+                    "gap-fill: {} event clip(s) cover RecentClips holes",
+                    gap_fill.len()
+                );
+                unprocessed.extend(gap_fill);
+            }
+            Ok(_) => {}
+            Err(e) => warn!("gap-fill event scan failed: {}", e),
+        }
 
         let total = unprocessed.len();
         let mut routes_found: usize = 0;
@@ -312,6 +345,15 @@ impl Processor {
 
     /// Recursively scan for -front.mp4 files.
     fn scan_dir(&self, dir: &std::path::Path, files: &mut Vec<String>) -> Result<()> {
+        self.scan_dir_inner(dir, files, true)
+    }
+
+    fn scan_dir_inner(
+        &self,
+        dir: &std::path::Path,
+        files: &mut Vec<String>,
+        skip_event_dirs: bool,
+    ) -> Result<()> {
         let entries = std::fs::read_dir(dir)?;
         for entry in entries {
             let entry = entry?;
@@ -323,13 +365,16 @@ impl Processor {
                 // catch). SentryClips contains parked Sentry-mode recordings
                 // that the gear-state splitter emits as spurious "drives"
                 // bordering an actual trip. Matches Sentry-Drive's
-                // discoverFrontCameraFiles (process.js:91-94).
-                if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
-                    if is_event_folder(name) {
-                        continue;
+                // discoverFrontCameraFiles (process.js:91-94). The gap-fill
+                // scan (scan_event_gap_fill) walks these deliberately.
+                if skip_event_dirs {
+                    if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                        if is_event_folder(name) {
+                            continue;
+                        }
                     }
                 }
-                self.scan_dir(&path, files)?;
+                self.scan_dir_inner(&path, files, skip_event_dirs)?;
             } else if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
                 if name.ends_with("-front.mp4") {
                     // Store relative path from clip_dir
@@ -342,6 +387,41 @@ impl Processor {
             }
         }
         Ok(())
+    }
+
+    /// Find Saved/Sentry event clips that fill RecentClips holes: the
+    /// continuous recording gapped mid-drive, but the same minute exists in
+    /// an event folder's ~10-minute pre-roll. Returns unprocessed relative
+    /// paths (kept at their real event-folder location — no copies or
+    /// symlinks). Selective by construction: a parked car's event clips
+    /// have no surrounding continuous footage, so they never fall inside a
+    /// hole and never qualify. One clip per missing timestamp
+    /// (grouper::select_gap_fill_events picks the winner).
+    fn scan_event_gap_fill(
+        &self,
+        recent_sorted_ts: &[chrono::NaiveDateTime],
+        processed: &std::collections::HashSet<String>,
+    ) -> Result<Vec<String>> {
+        let mut event_files: Vec<String> = Vec::new();
+        for sub in ["SavedClips", "SentryClips"] {
+            let dir = std::path::Path::new(&self.clip_dir).join(sub);
+            if dir.is_dir() {
+                self.scan_dir_inner(&dir, &mut event_files, false)?;
+            }
+        }
+        event_files.sort();
+
+        let cands: Vec<(chrono::NaiveDateTime, &str)> = event_files
+            .iter()
+            .filter(|f| !processed.contains(crate::db::normalize_path(f).as_str()))
+            .filter_map(|f| {
+                crate::grouper::parse_clip_timestamp(f).map(|ts| (ts, f.as_str()))
+            })
+            .collect();
+        Ok(crate::grouper::select_gap_fill_events(recent_sorted_ts, &cands)
+            .into_iter()
+            .map(|i| cands[i].1.to_string())
+            .collect())
     }
 }
 

--- a/crates/drives/src/processor.rs
+++ b/crates/drives/src/processor.rs
@@ -294,6 +294,16 @@ impl Processor {
         // Final checkpoint on the way out.
         let _ = self.store.save();
 
+        // Refresh the gap-fill manifest the snapshot builder reads to
+        // cross-link driving-hole clips back into RecentClips for
+        // continuous playback. Rebuilt from the routes table every pass so
+        // it self-heals on already-processed devices (the fills are already
+        // rows) as well as fresh deploys. Best-effort — a manifest write
+        // failure only costs playback continuity, never drive data.
+        if let Err(e) = self.update_gapfill_manifest() {
+            warn!("gap-fill manifest update failed: {}", e);
+        }
+
         // Mirror drive data to a mounted CIFS/NFS archive — the counterpart
         // of post-archive-process.sh's rsync/rclone sync blocks (the Go
         // server did this in SyncToArchive; the call site was lost in the
@@ -422,6 +432,53 @@ impl Processor {
             .into_iter()
             .map(|i| cands[i].1.to_string())
             .collect())
+    }
+
+    /// Rewrite `<clip_dir>/../.gapfill_recent_links` — the manifest of
+    /// event-clip timestamps the snapshot builder cross-links back into
+    /// RecentClips for continuous drive playback. Derived from the routes
+    /// table (every Saved/Sentry route file is, by construction, a
+    /// hole-fill), so it converges to the correct set regardless of when
+    /// the fill happened. Skips the write when unchanged to avoid churn.
+    fn update_gapfill_manifest(&self) -> Result<()> {
+        let manifest = match std::path::Path::new(&self.clip_dir).parent() {
+            Some(p) => p.join(".gapfill_recent_links"),
+            None => return Ok(()),
+        };
+
+        // Reduce each gap-fill route file to its YYYY-MM-DD_HH-MM-SS stamp
+        // (shared by every camera of that minute), sorted + deduped.
+        let mut stamps: Vec<String> = self
+            .store
+            .gap_fill_files()?
+            .iter()
+            .filter_map(|f| {
+                f.rsplit('/')
+                    .next()
+                    .filter(|b| b.len() >= 19)
+                    .map(|b| b[..19].to_string())
+            })
+            .collect();
+        stamps.sort();
+        stamps.dedup();
+
+        let body = if stamps.is_empty() {
+            String::new()
+        } else {
+            format!("{}\n", stamps.join("\n"))
+        };
+
+        // No-op when the content is identical (the common case once the
+        // gap is filled) so we don't rewrite the file every archive cycle.
+        if std::fs::read_to_string(&manifest).unwrap_or_default() == body {
+            return Ok(());
+        }
+        std::fs::write(&manifest, body)?;
+        info!(
+            "gap-fill manifest: {} clip timestamp(s) flagged for RecentClips playback",
+            stamps.len()
+        );
+        Ok(())
     }
 }
 

--- a/crates/drives/src/schema.rs
+++ b/crates/drives/src/schema.rs
@@ -522,6 +522,9 @@ pub fn migrate(conn: &Connection) -> Result<()> {
     // scans wrote. Gated on the stored schema_version so we only pay the
     // table-scan cost during the one upgrade-to-v5 open. Fresh DBs
     // (schema_version = None) have no rows to delete and skip the work.
+    // NOTE: event rows can now be legitimate gap-fills
+    // (processor::scan_event_gap_fill) — future cleanups must not
+    // blanket-delete SavedClips/SentryClips rows.
     let stored_version_for_v5 = meta_get(conn, "schema_version")?;
     let needs_v5_cleanup = matches!(
         stored_version_for_v5.as_deref(),

--- a/crates/usb_gadget/src/snapshot.rs
+++ b/crates/usb_gadget/src/snapshot.rs
@@ -22,6 +22,7 @@
 //!   `[drive-map] RecentClips directory not found at /mutable/TeslaCam/RecentClips, skipping`
 //! every cycle and the iOS app sees an empty timeline.
 
+use std::collections::HashSet;
 use std::path::Path;
 use std::time::Duration;
 
@@ -39,6 +40,46 @@ const REBUILD_FLAG: &str = "/mutable/.rebuild_snapshot_symlinks";
 const PURGE_MARKER: &str = "/mutable/.recentclips_events_purged";
 
 const TESLACAM: &str = "/mutable/TeslaCam";
+
+/// Manifest of Saved/Sentry event clips the drive-map processor spliced
+/// into a drive to fill a genuine RecentClips recording hole (car was
+/// driving, an event triggered, and the footage landed in an event
+/// folder's pre-roll instead of RecentClips). One `YYYY-MM-DD_HH-MM-SS`
+/// timestamp per line. The drives crate rewrites it from the routes table
+/// on every process pass (self-healing). We consult it here so those
+/// clips — and ONLY those — are cross-linked back into RecentClips (for
+/// continuous drive playback) and exempted from the purge. Everything
+/// else stays out of RecentClips, so Chad's dedup (parked events no
+/// longer flood the Recent tab) is preserved.
+const GAPFILL_MANIFEST: &str = "/mutable/.gapfill_recent_links";
+
+/// Load the gap-fill manifest into a set of clip timestamps. Missing or
+/// unreadable ⇒ empty set (no cross-links, no exemptions — exactly the
+/// pre-manifest behaviour), so this is safe on boards that never had a
+/// drive-data gap.
+fn load_gapfill_stamps() -> HashSet<String> {
+    match std::fs::read_to_string(GAPFILL_MANIFEST) {
+        Ok(s) => s
+            .lines()
+            .map(|l| l.trim())
+            .filter(|l| !l.is_empty())
+            .map(|l| l.to_string())
+            .collect(),
+        Err(_) => HashSet::new(),
+    }
+}
+
+/// The `YYYY-MM-DD_HH-MM-SS` timestamp prefix of a clip filename, shared
+/// by every camera angle of the same minute. Matching on this (not the
+/// full basename) means one manifest entry cross-links all cameras of
+/// that minute together.
+fn clip_stamp(name: &str) -> Option<&str> {
+    if name.len() >= 19 && looks_like_dated_clip(name) {
+        Some(&name[..19])
+    } else {
+        None
+    }
+}
 
 /// Create a snapshot of the cam disk plus all the symlink/TOC work the
 /// car-touchscreen + drive-map UI need.
@@ -167,7 +208,8 @@ pub async fn make_snapshot(skip_fsck: bool) -> Result<Option<String>> {
     // Self-guarded by a persistent marker so it runs once per device after
     // the update that stopped creating them, then never again.
     if !Path::new(PURGE_MARKER).exists() {
-        if let Err(e) = purge_event_links_in(&Path::new(TESLACAM).join("RecentClips")) {
+        let gapfill = load_gapfill_stamps();
+        if let Err(e) = purge_event_links_in(&Path::new(TESLACAM).join("RecentClips"), &gapfill) {
             warn!("purge_event_links_in: {}", e);
         }
         let _ = std::fs::write(PURGE_MARKER, b"done\n");
@@ -392,6 +434,11 @@ fn make_links_for_snapshot(cur_mnt: &str, final_mnt: &str) -> Result<()> {
     let _ = std::fs::create_dir_all(&saved);
     let _ = std::fs::create_dir_all(&sentry);
 
+    // Timestamps of event clips that fill a genuine driving hole — these
+    // (and only these) also get cross-linked into RecentClips below so the
+    // drive plays back continuously. Empty on boards with no gap.
+    let gapfill = load_gapfill_stamps();
+
     info!("Making links for {}, retargeted to {}", cur_mnt, final_mnt);
 
     // RecentClips: flat directory; date-bucket each file under YYYY-MM-DD.
@@ -431,6 +478,11 @@ fn make_links_for_snapshot(cur_mnt: &str, final_mnt: &str) -> Result<()> {
                         let target = retarget_path(&clip.path(), cur_mnt, final_mnt);
                         let _ = std::os::unix::fs::symlink(&target, &link);
                     }
+                    // Exception: a clip the drive-map flagged as filling a
+                    // driving hole IS cross-linked into RecentClips, so the
+                    // drive's video is continuous. Scoped to the manifest —
+                    // parked-event clips never qualify.
+                    maybe_gapfill_recent_link(&clip.path(), cur_mnt, final_mnt, &gapfill);
                 }
             }
         }
@@ -463,6 +515,9 @@ fn make_links_for_snapshot(cur_mnt: &str, final_mnt: &str) -> Result<()> {
                         let target = retarget_path(&clip.path(), cur_mnt, final_mnt);
                         let _ = std::os::unix::fs::symlink(&target, &link);
                     }
+                    // Scoped RecentClips cross-link for driving-hole fills
+                    // (see the SavedClips loop for the rationale).
+                    maybe_gapfill_recent_link(&clip.path(), cur_mnt, final_mnt, &gapfill);
                 }
             }
         }
@@ -515,6 +570,45 @@ fn link_clip_into_recents(file: &Path, cur_mnt: &str, final_mnt: &str) {
     }
 }
 
+/// Cross-link an event clip into `RecentClips/<date>/` IFF its timestamp
+/// is in the gap-fill manifest — the drive-map flagged it as filling a
+/// genuine driving hole. Same link shape as [`link_clip_into_recents`]
+/// (retargeted symlink under the day bucket), so the Viewer and drive
+/// player treat it as continuous footage. No-op for every other event
+/// clip, which keeps parked-event footage out of RecentClips.
+#[cfg_attr(not(unix), allow(unused_variables))]
+fn maybe_gapfill_recent_link(
+    clip: &Path,
+    cur_mnt: &str,
+    final_mnt: &str,
+    gapfill: &HashSet<String>,
+) {
+    if gapfill.is_empty() {
+        return;
+    }
+    let filename = match clip.file_name().map(|s| s.to_string_lossy().to_string()) {
+        Some(f) => f,
+        None => return,
+    };
+    let stamp = match clip_stamp(&filename) {
+        Some(s) => s,
+        None => return,
+    };
+    if !gapfill.contains(stamp) {
+        return;
+    }
+    let filedate = &filename[..10];
+    let recents = format!("{}/RecentClips/{}", TESLACAM, filedate);
+    let _ = std::fs::create_dir_all(&recents);
+    let link = format!("{}/{}", recents, filename);
+    let _ = std::fs::remove_file(&link);
+    #[cfg(unix)]
+    {
+        let target = retarget_path(clip, cur_mnt, final_mnt);
+        let _ = std::os::unix::fs::symlink(&target, &link);
+    }
+}
+
 /// One-time cleanup mirroring the bash `purge_event_links_from_recentclips`.
 ///
 /// Earlier versions cross-linked every Saved/Sentry event clip into
@@ -527,7 +621,7 @@ fn link_clip_into_recents(file: &Path, cur_mnt: &str, final_mnt: &str) {
 /// through the autofs snapshot mount). Date folders left empty afterwards
 /// (days that held only events) are pruned. Idempotent: a second run finds
 /// nothing to remove.
-fn purge_event_links_in(recents_root: &Path) -> Result<()> {
+fn purge_event_links_in(recents_root: &Path, gapfill: &HashSet<String>) -> Result<()> {
     if !recents_root.is_dir() {
         return Ok(());
     }
@@ -547,6 +641,19 @@ fn purge_event_links_in(recents_root: &Path) -> Result<()> {
         if let Ok(clips) = std::fs::read_dir(&date_dir) {
             for clip in clips.flatten() {
                 let path = clip.path();
+                // A driving-hole fill is a legitimate RecentClips entry even
+                // though it targets an event folder — keep it (it's what
+                // makes the drive play back continuously). Everything else
+                // targeting Saved/Sentry is a stray cross-link.
+                if let Some(stamp) = path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .and_then(clip_stamp)
+                {
+                    if gapfill.contains(stamp) {
+                        continue;
+                    }
+                }
                 // Only symlinks are candidates. Read the stored target
                 // without resolving it (symlink_metadata avoids following).
                 let is_symlink = std::fs::symlink_metadata(&path)
@@ -830,7 +937,7 @@ mod tests {
         )
         .unwrap();
 
-        purge_event_links_in(recents).unwrap();
+        purge_event_links_in(recents, &HashSet::new()).unwrap();
 
         // Event-only day pruned entirely.
         assert!(!only_events.exists(), "event-only date folder should be removed");
@@ -863,15 +970,62 @@ mod tests {
         let recents = root.path().join("RecentClips");
 
         // Missing root: returns Ok with nothing to do.
-        purge_event_links_in(&recents).unwrap();
+        purge_event_links_in(&recents, &HashSet::new()).unwrap();
 
         // A real (non-symlink) clip file is left alone, and its folder
         // survives because it isn't empty.
         let day = recents.join("2026-06-22");
         std::fs::create_dir_all(&day).unwrap();
         std::fs::write(day.join("real.mp4"), b"x").unwrap();
-        purge_event_links_in(&recents).unwrap();
+        purge_event_links_in(&recents, &HashSet::new()).unwrap();
         assert!(day.join("real.mp4").exists());
+    }
+
+    /// A gap-fill cross-link (event target, but manifest-flagged as filling
+    /// a driving hole) must SURVIVE the purge, while an ordinary event
+    /// cross-link on the same day is still removed. This is what keeps the
+    /// drive's video continuous without re-flooding the Recent tab.
+    #[cfg(unix)]
+    #[test]
+    fn purge_event_links_in_keeps_gapfill_exempt_links() {
+        use std::os::unix::fs::symlink;
+        use tempfile::TempDir;
+
+        let root = TempDir::new().unwrap();
+        let recents = root.path();
+
+        let day = recents.join("2026-07-05");
+        std::fs::create_dir_all(&day).unwrap();
+
+        // Driving-hole fill: targets SentryClips but is in the manifest.
+        let gap_link = day.join("2026-07-05_16-03-46-front.mp4");
+        symlink(
+            "/backingfiles/snapshots/snap-000515/mnt/TeslaCam/SentryClips/2026-07-05_16-12-51/2026-07-05_16-03-46-front.mp4",
+            &gap_link,
+        )
+        .unwrap();
+
+        // Ordinary event cross-link the same day: NOT in the manifest.
+        let stray = day.join("2026-07-05_20-00-00-front.mp4");
+        symlink(
+            "/backingfiles/snapshots/snap-000515/mnt/TeslaCam/SentryClips/2026-07-05_20-00-00/2026-07-05_20-00-00-front.mp4",
+            &stray,
+        )
+        .unwrap();
+
+        let mut gapfill = HashSet::new();
+        gapfill.insert("2026-07-05_16-03-46".to_string());
+
+        purge_event_links_in(recents, &gapfill).unwrap();
+
+        assert!(
+            std::fs::symlink_metadata(&gap_link).is_ok(),
+            "manifest-flagged driving-hole fill must survive the purge",
+        );
+        assert!(
+            std::fs::symlink_metadata(&stray).is_err(),
+            "ordinary event cross-link must still be purged",
+        );
     }
 }
 


### PR DESCRIPTION
## Problem

When the car is driving and a Sentry/dashcam event triggers, Tesla writes that
stretch of footage into the event folder's ~10-minute pre-roll instead of
`RecentClips`. The result is a **hole in `RecentClips` in the middle of a drive** —
the continuous recording is missing those minutes even though the footage exists
in `SavedClips`/`SentryClips`.

Two things break for that drive:

1. **Map/route data** — the drive processor only reads `RecentClips`, so the
   route stops at the hole and the drive looks short (e.g. a 4-mile trip renders
   as 1 mile).
2. **Video playback** — the drive plays from the `RecentClips` timeline, so it
   cuts out for the whole gap.

The Recent-tab dedup in `60c5602` (correctly) stopped cross-linking every event
clip into `RecentClips`, but that also removed the links that were legitimately
filling these mid-drive holes — so drives with an in-drive event regressed on
both counts.

## Fix

Splice event clips back in — but **only real driving footage** adjacent to a
drive. Admission is **driving-gated** (the SEI must show non-Park gear or motion),
so parked-event clips never qualify no matter where they sit. Every shape of gap
is covered:

- **Interior hole** — drive → gap → drive resumes (RecentClips clip on both sides).
- **Trailing gap** — the drive runs *past* its last RecentClips clip into an event
  pre-roll, then parks (its arrival footage only made the sentry buffer).
- **Leading gap** — departure footage that only reached an event pre-roll before
  the first RecentClips clip.
- **Chains** of the above (≤3 min hops).

Scoped by construction: no duplicates, and the Recent tab stays free of
parked-event noise. The gear-state splitter trims each admitted run exactly at
its Park transition, so a drive ends at its last driving clip.

### 1. Drive data (`crates/drives`)
- `scan_event_gap_fill` / `select_gap_fill_events` walk `SavedClips`+`SentryClips`
  and select only clips whose timestamp lands in a hole inside a drive.
- Selected clips ride the normal extraction path, keyed at their real
  event-folder location (no copies, no symlinks in the DB).
- **Timeline correctness:** gap-fill routes live at event-folder paths
  (`SentryClips/<event-ts>/<clip-ts>-front.mp4`). The detail builder and the
  telemetry-window derivation dated routes with a left-to-right path scan,
  which grabbed the *event-folder* timestamp and dropped the clip's GPS/speed
  points minutes-to-tens-of-minutes late (map filled, but a phantom gap in the
  speed chart). Fixed by dating routes from the clip basename
  (`parse_clip_timestamp`) — the helper the gap-fill admission already used.

The admission is two-phase so parked footage can never be stored: a bounded
timestamp superset is extracted (capped per drive boundary, once), then a
post-extraction **driving gate** in `do_process` drops any event clip whose SEI
shows no movement — it's marked processed but **never becomes a route row**, so
it can't reach `gap_fill_files()` → the playback manifest → RecentClips. One
shared `row_has_driving` predicate is used by the gate, the grouper's admission,
and the manifest, so they never diverge (a parked row can't reach the manifest
even via a `drive-data.json` import from an older build).

### 2. Playback continuity (`crates/usb_gadget/snapshot.rs`)
- A manifest (`/mutable/.gapfill_recent_links`) lists exactly those hole-filling
  clip timestamps. It's **rebuilt from the routes table on every process pass**,
  so it self-heals on already-processed devices as well as fresh deploys.
- `make_links_for_snapshot` cross-links **only manifest clips** back into
  `RecentClips/<date>/` (all camera angles), so the drive plays continuously.
- `purge_event_links_in` **exempts only manifest clips** — every other event
  cross-link is still purged, so `60c5602`'s dedup is fully preserved.

## Why this doesn't reintroduce the Recent-tab dupes

- A gap-fill only ever targets an **empty** minute (a real hole) — filling an
  empty slot is not duplicating an existing one.
- Parked/standalone events are never inside a drive window, so they never enter
  the manifest and never re-enter the Recent tab.
- Empty manifest ⇒ `make_links`/purge behave exactly as before (no-op) — boards
  with no gap are unaffected.

## Safety / scope
- `SavedClips`/`SentryClips` event folders, `event.json`, and `TeslaTrackMode`
  are untouched — only additive `RecentClips` pointers.
- Idempotent (re-process = 0 files), and links survive snapshot rebuilds because
  `make_links` recreates them from the manifest each pass.
- No new dependencies; negligible cost on low-power boards.

## Testing
- Full workspace suite green (**430 tests**), incl. new tests for each gap shape
  (interior / trailing / leading / chain), the driving gate, twin/overlap dedup,
  park-tail trim, and parked-row-excluded-from-manifest.
- Validated live on an RK3399 board against a full drive history:
  - An interior-gap drive filled to its true route (matching an external GPS
    log), continuous playback, **zero duplicate clips**.
  - A **trailing-gap** drive whose arrival was truncated recovered end-to-end,
    trimmed exactly at the park transition; the neighbouring drive stayed split.
  - Whole-history audit: only genuinely-truncated drives changed, no
    over-merge, no new/spurious drives. The driving gate extracted the
    candidate superset and rejected every parked pre-roll clip (0 stored).
  - Event folders and `TeslaTrackMode` untouched; manifest stayed driving-only.

## Deployment
Auto-heals on the first process pass after deploy — the event clips were never
processed under the dedup, so the backfill picks them up across existing history.
No one-time script required.
