### PR TITLE
fix(backup): mount CIFS/NFS archive before writing backups

### DIFF
--- a/crates/api/src/archive_mount_lock.rs
+++ b/crates/api/src/archive_mount_lock.rs
@@ -1,0 +1,105 @@
+//! Cross-process ownership of the `/mnt/archive` network mount.
+//!
+//! The archive share (CIFS/NFS) is mounted by two parties: archiveloop's
+//! connect-archive.sh at the start of each archive cycle, and the backup
+//! path in `backup.rs` when the user hits Backup Now with no cycle
+//! running. Both sides take an exclusive `flock` on
+//! [`ARCHIVE_MOUNT_LOCK_PATH`] around their mount/unmount transitions
+//! (archiveloop via `flock` on fd 210 in connect/disconnect-archive.sh;
+//! keep the path in sync with those scripts). Without it, archiveloop can
+//! adopt a mount the backup created and then have it unmounted mid-cycle,
+//! or its disconnect can `umount -f -l` a backup mid-write.
+//!
+//! Deliberately NOT held across a whole archive cycle: post-archive
+//! -process.sh curls the backup API while its cycle runs, so a
+//! cycle-scoped lock would deadlock that request — the same trap the
+//! gadget cycle_lock doc comment warns about. The lock covers only
+//! mount → use → unmount windows; a long rsync runs lock-free on a mount
+//! archiveloop owns.
+
+use std::fs::{File, OpenOptions};
+use std::io;
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+/// Must match `ARCHIVE_MOUNT_LOCK` in run/{cifs,nfs}_archive/
+/// connect-archive.sh and disconnect-archive.sh.
+pub const ARCHIVE_MOUNT_LOCK_PATH: &str = "/tmp/sentryusb_archive_mount.lock";
+
+/// Exclusive hold on the archive-mount lock; released on drop (the
+/// flock dies with the file handle).
+#[derive(Debug)]
+pub struct ArchiveMountGuard {
+    _file: File,
+}
+
+/// Acquire the archive-mount flock, waiting up to `timeout` for whoever
+/// holds it (archiveloop holds it for seconds around a mount/unmount).
+/// Polls `LOCK_NB` rather than parking in `flock(2)` so the wait is
+/// bounded. Blocking call — run it on a blocking thread.
+pub fn acquire(timeout: Duration) -> io::Result<ArchiveMountGuard> {
+    acquire_path(Path::new(ARCHIVE_MOUNT_LOCK_PATH), timeout)
+}
+
+fn acquire_path(path: &Path, timeout: Duration) -> io::Result<ArchiveMountGuard> {
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false) // content is irrelevant; the flock is the point
+        .open(path)?;
+    let deadline = Instant::now() + timeout;
+    loop {
+        if try_flock_exclusive(&file)? {
+            return Ok(ArchiveMountGuard { _file: file });
+        }
+        if Instant::now() >= deadline {
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                format!(
+                    "archive mount lock held elsewhere for over {}s (archive connect/disconnect in progress)",
+                    timeout.as_secs()
+                ),
+            ));
+        }
+        std::thread::sleep(Duration::from_millis(250));
+    }
+}
+
+#[cfg(unix)]
+fn try_flock_exclusive(file: &File) -> io::Result<bool> {
+    use std::os::unix::io::AsRawFd;
+    // Same primitive as shell `flock`: the lock lives on the open file
+    // description, so it also excludes other threads of this process and
+    // stays held across await points until the guard drops.
+    let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+    if rc == 0 {
+        return Ok(true);
+    }
+    let err = io::Error::last_os_error();
+    match err.raw_os_error() {
+        Some(libc::EWOULDBLOCK) | Some(libc::EINTR) => Ok(false),
+        _ => Err(err),
+    }
+}
+
+#[cfg(not(unix))]
+fn try_flock_exclusive(_file: &File) -> io::Result<bool> {
+    Ok(true) // no archiveloop to race on non-unix dev hosts
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn second_acquire_times_out_while_held_then_succeeds_after_drop() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("archive.lock");
+        let g1 = acquire_path(&path, Duration::from_millis(0)).unwrap();
+        let err = acquire_path(&path, Duration::from_millis(300)).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+        drop(g1);
+        let _g2 = acquire_path(&path, Duration::from_millis(0)).unwrap();
+    }
+}

--- a/crates/api/src/backup.rs
+++ b/crates/api/src/backup.rs
@@ -202,6 +202,28 @@ fn write_backup_to_dir(dir: &str, data: &BackupData) -> Result<(), String> {
     Ok(())
 }
 
+async fn ensure_archive_mounted_for_backup() -> Result<(), String> {
+    if !Path::new("/mnt/archive").exists() {
+        return Err("archive mount point /mnt/archive does not exist".to_string());
+    }
+
+    if sentryusb_shell::run("findmnt", &["--mountpoint", "/mnt/archive"])
+        .await
+        .is_ok()
+    {
+        return Ok(());
+    }
+
+    sentryusb_shell::run_with_timeout(Duration::from_secs(30), "mount", &["/mnt/archive"])
+        .await
+        .map_err(|e| format!("mount /mnt/archive: {}", e))?;
+
+    sentryusb_shell::run("findmnt", &["--mountpoint", "/mnt/archive"])
+        .await
+        .map(|_| ())
+        .map_err(|e| format!("archive not mounted at /mnt/archive after mount: {}", e))
+}
+
 async fn sync_backup_to_rsync(data: &BackupData) -> Result<(), String> {
     let config_path = sentryusb_config::find_config_path();
     let (active, _) = sentryusb_config::parse_file(config_path)
@@ -367,9 +389,7 @@ async fn ship_drive_data(location: &str, gz_path: &str, date: &str) -> Result<()
     let archive_system = active.get("ARCHIVE_SYSTEM").cloned().unwrap_or_default();
     match archive_system.as_str() {
         "cifs" | "nfs" => {
-            if !Path::new("/mnt/archive").exists() {
-                return Err("archive not mounted at /mnt/archive".to_string());
-            }
+            ensure_archive_mounted_for_backup().await?;
             let gz = gz_path.to_string();
             let dest = format!("{}/{}", ARCHIVE_BACKUP_DIR, filename);
             // Tens of MB onto a network mount — keep it off the runtime.
@@ -501,13 +521,11 @@ pub async fn create_backup(
             .and_then(|(active, _)| active.get("ARCHIVE_SYSTEM").cloned())
             .unwrap_or_default();
         match archive_system.as_str() {
-            "cifs" | "nfs" => {
-                if Path::new("/mnt/archive").exists() {
-                    write_backup_to_dir(ARCHIVE_BACKUP_DIR, &data)
-                } else {
-                    Err("archive not mounted at /mnt/archive".to_string())
-                }
+            "cifs" | "nfs" => async {
+                ensure_archive_mounted_for_backup().await?;
+                write_backup_to_dir(ARCHIVE_BACKUP_DIR, &data)
             }
+            .await,
             "rsync" => sync_backup_to_rsync(&data).await,
             "rclone" => sync_backup_to_rclone(&data).await,
             _ => {

--- a/crates/api/src/backup.rs
+++ b/crates/api/src/backup.rs
@@ -60,7 +60,7 @@ fn read_ssh_keypair() -> (String, String) {
     (String::new(), String::new())
 }
 
-#[derive(Serialize, Deserialize, Default)]
+#[derive(Serialize, Deserialize, Default, Clone)]
 struct BackupData {
     version: u32,
     date: String,
@@ -202,26 +202,99 @@ fn write_backup_to_dir(dir: &str, data: &BackupData) -> Result<(), String> {
     Ok(())
 }
 
-async fn ensure_archive_mounted_for_backup() -> Result<(), String> {
+/// Run `write` against a mounted `/mnt/archive`, owning the mount for
+/// the duration. Serialized against archiveloop's connect/disconnect
+/// scripts via the shared archive-mount flock, so a mount this creates
+/// can't be adopted by an archive cycle mid-write, and archiveloop's
+/// `umount -f -l` can't land under an in-flight backup.
+///
+/// If the share wasn't mounted, mounts it from fstab and unmounts it
+/// again before releasing the lock — a CIFS mount left up after the
+/// car drives away goes stale ("host is down") and wedges the next
+/// archive cycle, which is exactly what disconnect-archive.sh exists
+/// to prevent. A mount that was already up (an archive cycle's, whose
+/// post-archive step is what called us) is left alone; its owner
+/// unmounts it. The unmount runs even when `write` fails; an unmount
+/// failure is logged but doesn't mask the write result.
+///
+/// The whole transaction runs in its own spawned task: if the HTTP
+/// request future is cancelled (client disconnect), the lock guard must
+/// not drop mid-write and skip the unmount — the task detaches and
+/// finishes cleanup on its own.
+async fn with_archive_mounted<F, Fut>(write: F) -> Result<(), String>
+where
+    F: FnOnce() -> Fut + Send + 'static,
+    Fut: std::future::Future<Output = Result<(), String>> + Send + 'static,
+{
+    tokio::spawn(archive_mount_transaction(write))
+        .await
+        .map_err(|e| format!("archive write task: {}", e))?
+}
+
+async fn archive_mount_transaction<F, Fut>(write: F) -> Result<(), String>
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = Result<(), String>>,
+{
+    async fn is_mounted() -> bool {
+        sentryusb_shell::run("findmnt", &["--mountpoint", "/mnt/archive"])
+            .await
+            .is_ok()
+    }
+
     if !Path::new("/mnt/archive").exists() {
         return Err("archive mount point /mnt/archive does not exist".to_string());
     }
 
-    if sentryusb_shell::run("findmnt", &["--mountpoint", "/mnt/archive"])
-        .await
-        .is_ok()
-    {
-        return Ok(());
+    // Bounded wait: archiveloop holds this lock only for the seconds a
+    // mount/unmount transition takes, never across a whole cycle.
+    let guard = tokio::task::spawn_blocking(|| {
+        crate::archive_mount_lock::acquire(Duration::from_secs(60))
+    })
+    .await
+    .map_err(|e| format!("archive mount lock task: {}", e))?
+    .map_err(|e| format!("archive mount lock: {}", e))?;
+
+    let mut mounted_by_us = false;
+    if !is_mounted().await {
+        let mount_res = sentryusb_shell::run_with_timeout(
+            Duration::from_secs(30),
+            "mount",
+            &["/mnt/archive"],
+        )
+        .await;
+        // findmnt is ground truth, not mount's exit status: a timed-out
+        // mount(8) may still have completed the kernel transition, and
+        // that mount is ours to clean up.
+        if is_mounted().await {
+            mounted_by_us = true;
+        } else {
+            return match mount_res {
+                Err(e) => Err(format!("mount /mnt/archive: {}", e)),
+                Ok(_) => Err("archive not mounted at /mnt/archive after mount".to_string()),
+            };
+        }
     }
 
-    sentryusb_shell::run_with_timeout(Duration::from_secs(30), "mount", &["/mnt/archive"])
-        .await
-        .map_err(|e| format!("mount /mnt/archive: {}", e))?;
+    let result = write().await;
 
-    sentryusb_shell::run("findmnt", &["--mountpoint", "/mnt/archive"])
+    if mounted_by_us {
+        // Mirror disconnect-archive.sh: bounded, force+lazy so a dead
+        // share can't hang the API. On failure the mount lingers (same
+        // exposure as a crash mid-archive) — log and move on.
+        if let Err(e) = sentryusb_shell::run_with_timeout(
+            Duration::from_secs(15),
+            "umount",
+            &["-f", "-l", "/mnt/archive"],
+        )
         .await
-        .map(|_| ())
-        .map_err(|e| format!("archive not mounted at /mnt/archive after mount: {}", e))
+        {
+            warn!("[backup] failed to unmount /mnt/archive after backup: {}", e);
+        }
+    }
+
+    drop(guard);
+    result
 }
 
 async fn sync_backup_to_rsync(data: &BackupData) -> Result<(), String> {
@@ -389,19 +462,21 @@ async fn ship_drive_data(location: &str, gz_path: &str, date: &str) -> Result<()
     let archive_system = active.get("ARCHIVE_SYSTEM").cloned().unwrap_or_default();
     match archive_system.as_str() {
         "cifs" | "nfs" => {
-            ensure_archive_mounted_for_backup().await?;
             let gz = gz_path.to_string();
             let dest = format!("{}/{}", ARCHIVE_BACKUP_DIR, filename);
-            // Tens of MB onto a network mount — keep it off the runtime.
-            tokio::task::spawn_blocking(move || {
-                std::fs::create_dir_all(ARCHIVE_BACKUP_DIR)
-                    .map_err(|e| format!("create {}: {}", ARCHIVE_BACKUP_DIR, e))?;
-                let tmp = format!("{}.tmp", dest);
-                std::fs::copy(&gz, &tmp).map_err(|e| format!("copy to archive: {}", e))?;
-                std::fs::rename(&tmp, &dest).map_err(|e| format!("finalize: {}", e))
+            with_archive_mounted(move || async move {
+                // Tens of MB onto a network mount — keep it off the runtime.
+                tokio::task::spawn_blocking(move || {
+                    std::fs::create_dir_all(ARCHIVE_BACKUP_DIR)
+                        .map_err(|e| format!("create {}: {}", ARCHIVE_BACKUP_DIR, e))?;
+                    let tmp = format!("{}.tmp", dest);
+                    std::fs::copy(&gz, &tmp).map_err(|e| format!("copy to archive: {}", e))?;
+                    std::fs::rename(&tmp, &dest).map_err(|e| format!("finalize: {}", e))
+                })
+                .await
+                .map_err(|e| format!("copy task failed: {}", e))?
             })
             .await
-            .map_err(|e| format!("copy task failed: {}", e))?
         }
         "rsync" => {
             let server = active.get("RSYNC_SERVER").cloned().unwrap_or_default();
@@ -521,11 +596,15 @@ pub async fn create_backup(
             .and_then(|(active, _)| active.get("ARCHIVE_SYSTEM").cloned())
             .unwrap_or_default();
         match archive_system.as_str() {
-            "cifs" | "nfs" => async {
-                ensure_archive_mounted_for_backup().await?;
-                write_backup_to_dir(ARCHIVE_BACKUP_DIR, &data)
+            "cifs" | "nfs" => {
+                // Cloned: the write closure must be 'static so the
+                // transaction task can outlive a cancelled request.
+                let data = data.clone();
+                with_archive_mounted(move || async move {
+                    write_backup_to_dir(ARCHIVE_BACKUP_DIR, &data)
+                })
+                .await
             }
-            .await,
             "rsync" => sync_backup_to_rsync(&data).await,
             "rclone" => sync_backup_to_rclone(&data).await,
             _ => {

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -14,6 +14,7 @@ pub mod travel_mode;
 pub mod notifications;
 pub mod notification_center;
 pub mod setup;
+pub mod archive_mount_lock;
 pub mod backup;
 pub mod update;
 pub mod support;

--- a/run/cifs_archive/connect-archive.sh
+++ b/run/cifs_archive/connect-archive.sh
@@ -1,9 +1,34 @@
 #!/bin/bash -eu
 
+# Must match ARCHIVE_MOUNT_LOCK_PATH in crates/api/src/archive_mount_lock.rs
+# and disconnect-archive.sh.
+ARCHIVE_MOUNT_LOCK=/tmp/sentryusb_archive_mount.lock
+
 function mount_if_set() {
   local mount_point=$1
   [ -z "$mount_point" ] || ensure_mountpoint_is_mounted_with_retry "$mount_point"
 }
 
-mount_if_set "${ARCHIVE_MOUNT:-}"
+# The archive mount is shared with the API's backup path, which may
+# mount /mnt/archive itself for a Backup Now and unmount it when done.
+# Take the shared flock around the transition so we can't adopt a
+# backup-owned mount that's about to be unmounted from under us. The
+# API holds the lock for its whole mount+write+unmount (bounded well
+# under the wait here). Fail-closed on lock timeout: mounting without
+# the lock reopens the adoption race, and archiveloop already handles a
+# failed connect by skipping the cycle and retrying next time.
+function mount_archive_locked() {
+  local mount_point=$1
+  [ -z "$mount_point" ] && return 0
+  (
+    if ! flock -w 300 210
+    then
+      log "Archive mount lock busy for 300s — failing archive connect (retried next cycle)."
+      exit 1
+    fi
+    ensure_mountpoint_is_mounted_with_retry "$mount_point"
+  ) 210>"$ARCHIVE_MOUNT_LOCK"
+}
+
+mount_archive_locked "${ARCHIVE_MOUNT:-}"
 mount_if_set "${MUSIC_ARCHIVE_MOUNT:-}"

--- a/run/cifs_archive/disconnect-archive.sh
+++ b/run/cifs_archive/disconnect-archive.sh
@@ -4,8 +4,10 @@
 # state where the archive is reachable via the network, appears to be
 # mounted, but the mount is inoperable and any attempt to access it
 # results in a "host is down" message.
-# Run this in the background, since unmounting can hang, which would
-# block a return to archiveloop.
+
+# Must match ARCHIVE_MOUNT_LOCK_PATH in crates/api/src/archive_mount_lock.rs
+# and connect-archive.sh.
+ARCHIVE_MOUNT_LOCK=/tmp/sentryusb_archive_mount.lock
 
 unmount_if_set() {
   local mount_point=$1
@@ -25,5 +27,21 @@ unmount_if_set() {
   fi
 }
 
-unmount_if_set "${ARCHIVE_MOUNT:-}" &
+# Archive unmount runs in the FOREGROUND under the shared flock, so an
+# in-flight API backup (which holds the lock across its mount+write)
+# can't have the mount force-lazy-unmounted mid-write. Bounded: the
+# umount itself is capped at 10s and the lock wait at 60s, so this
+# can't wedge the return to archiveloop the way an uncapped unmount
+# once could. Fail-closed on lock timeout: unmounting without the lock
+# is exactly the mid-write teardown the lock exists to prevent — skip,
+# and the next cycle's disconnect gets another chance. Music has no
+# API writer, so it keeps the old backgrounded, lock-free path.
+(
+  if ! flock -w 60 210
+  then
+    log "Archive mount lock busy for 60s — skipping archive unmount this cycle."
+    exit 0
+  fi
+  unmount_if_set "${ARCHIVE_MOUNT:-}"
+) 210>"$ARCHIVE_MOUNT_LOCK"
 unmount_if_set "${MUSIC_ARCHIVE_MOUNT:-}" &

--- a/run/cifs_archive/disconnect-archive.sh
+++ b/run/cifs_archive/disconnect-archive.sh
@@ -30,16 +30,16 @@ unmount_if_set() {
 # Archive unmount runs in the FOREGROUND under the shared flock, so an
 # in-flight API backup (which holds the lock across its mount+write)
 # can't have the mount force-lazy-unmounted mid-write. Bounded: the
-# umount itself is capped at 10s and the lock wait at 60s, so this
+# umount itself is capped at 10s and the lock wait at 300s, so this
 # can't wedge the return to archiveloop the way an uncapped unmount
 # once could. Fail-closed on lock timeout: unmounting without the lock
 # is exactly the mid-write teardown the lock exists to prevent — skip,
 # and the next cycle's disconnect gets another chance. Music has no
 # API writer, so it keeps the old backgrounded, lock-free path.
 (
-  if ! flock -w 60 210
+  if ! flock -w 300 210
   then
-    log "Archive mount lock busy for 60s — skipping archive unmount this cycle."
+    log "Archive mount lock busy for 300s — skipping archive unmount this cycle."
     exit 0
   fi
   unmount_if_set "${ARCHIVE_MOUNT:-}"

--- a/run/nfs_archive/connect-archive.sh
+++ b/run/nfs_archive/connect-archive.sh
@@ -1,9 +1,34 @@
 #!/bin/bash -eu
 
+# Must match ARCHIVE_MOUNT_LOCK_PATH in crates/api/src/archive_mount_lock.rs
+# and disconnect-archive.sh.
+ARCHIVE_MOUNT_LOCK=/tmp/sentryusb_archive_mount.lock
+
 function mount_if_set() {
   local mount_point=$1
   [ -z "$mount_point" ] || ensure_mountpoint_is_mounted_with_retry "$mount_point"
 }
 
-mount_if_set "${ARCHIVE_MOUNT:-}"
+# The archive mount is shared with the API's backup path, which may
+# mount /mnt/archive itself for a Backup Now and unmount it when done.
+# Take the shared flock around the transition so we can't adopt a
+# backup-owned mount that's about to be unmounted from under us. The
+# API holds the lock for its whole mount+write+unmount (bounded well
+# under the wait here). Fail-closed on lock timeout: mounting without
+# the lock reopens the adoption race, and archiveloop already handles a
+# failed connect by skipping the cycle and retrying next time.
+function mount_archive_locked() {
+  local mount_point=$1
+  [ -z "$mount_point" ] && return 0
+  (
+    if ! flock -w 300 210
+    then
+      log "Archive mount lock busy for 300s — failing archive connect (retried next cycle)."
+      exit 1
+    fi
+    ensure_mountpoint_is_mounted_with_retry "$mount_point"
+  ) 210>"$ARCHIVE_MOUNT_LOCK"
+}
+
+mount_archive_locked "${ARCHIVE_MOUNT:-}"
 mount_if_set "${MUSIC_ARCHIVE_MOUNT:-}"

--- a/run/nfs_archive/disconnect-archive.sh
+++ b/run/nfs_archive/disconnect-archive.sh
@@ -1,5 +1,14 @@
 #!/bin/bash -eu
 
+# Unmount the archive. Without this, the archive mounts can get into a
+# state where the archive is reachable via the network, appears to be
+# mounted, but the mount is inoperable and any attempt to access it
+# results in a "host is down" message.
+
+# Must match ARCHIVE_MOUNT_LOCK_PATH in crates/api/src/archive_mount_lock.rs
+# and connect-archive.sh.
+ARCHIVE_MOUNT_LOCK=/tmp/sentryusb_archive_mount.lock
+
 unmount_if_set() {
   local mount_point=$1
   if [ -n "$mount_point" ]
@@ -18,5 +27,21 @@ unmount_if_set() {
   fi
 }
 
-unmount_if_set "${ARCHIVE_MOUNT:-}" &
+# Archive unmount runs in the FOREGROUND under the shared flock, so an
+# in-flight API backup (which holds the lock across its mount+write)
+# can't have the mount force-lazy-unmounted mid-write. Bounded: the
+# umount itself is capped at 10s and the lock wait at 60s, so this
+# can't wedge the return to archiveloop the way an uncapped unmount
+# once could. Fail-closed on lock timeout: unmounting without the lock
+# is exactly the mid-write teardown the lock exists to prevent — skip,
+# and the next cycle's disconnect gets another chance. Music has no
+# API writer, so it keeps the old backgrounded, lock-free path.
+(
+  if ! flock -w 60 210
+  then
+    log "Archive mount lock busy for 60s — skipping archive unmount this cycle."
+    exit 0
+  fi
+  unmount_if_set "${ARCHIVE_MOUNT:-}"
+) 210>"$ARCHIVE_MOUNT_LOCK"
 unmount_if_set "${MUSIC_ARCHIVE_MOUNT:-}" &

--- a/run/nfs_archive/disconnect-archive.sh
+++ b/run/nfs_archive/disconnect-archive.sh
@@ -30,16 +30,16 @@ unmount_if_set() {
 # Archive unmount runs in the FOREGROUND under the shared flock, so an
 # in-flight API backup (which holds the lock across its mount+write)
 # can't have the mount force-lazy-unmounted mid-write. Bounded: the
-# umount itself is capped at 10s and the lock wait at 60s, so this
+# umount itself is capped at 10s and the lock wait at 300s, so this
 # can't wedge the return to archiveloop the way an uncapped unmount
 # once could. Fail-closed on lock timeout: unmounting without the lock
 # is exactly the mid-write teardown the lock exists to prevent — skip,
 # and the next cycle's disconnect gets another chance. Music has no
 # API writer, so it keeps the old backgrounded, lock-free path.
 (
-  if ! flock -w 60 210
+  if ! flock -w 300 210
   then
-    log "Archive mount lock busy for 60s — skipping archive unmount this cycle."
+    log "Archive mount lock busy for 300s — skipping archive unmount this cycle."
     exit 0
   fi
   unmount_if_set "${ARCHIVE_MOUNT:-}"

--- a/setup/pi/apply-runtime-patches.sh
+++ b/setup/pi/apply-runtime-patches.sh
@@ -439,16 +439,16 @@ unmount_if_set() {
 # Archive unmount runs in the FOREGROUND under the shared flock, so an
 # in-flight API backup (which holds the lock across its mount+write)
 # can't have the mount force-lazy-unmounted mid-write. Bounded: the
-# umount itself is capped at 10s and the lock wait at 60s, so this
+# umount itself is capped at 10s and the lock wait at 300s, so this
 # can't wedge the return to archiveloop the way an uncapped unmount
 # once could. Fail-closed on lock timeout: unmounting without the lock
 # is exactly the mid-write teardown the lock exists to prevent — skip,
 # and the next cycle's disconnect gets another chance. Music has no
 # API writer, so it keeps the old backgrounded, lock-free path.
 (
-  if ! flock -w 60 210
+  if ! flock -w 300 210
   then
-    log "Archive mount lock busy for 60s — skipping archive unmount this cycle."
+    log "Archive mount lock busy for 300s — skipping archive unmount this cycle."
     exit 0
   fi
   unmount_if_set "${ARCHIVE_MOUNT:-}"

--- a/setup/pi/apply-runtime-patches.sh
+++ b/setup/pi/apply-runtime-patches.sh
@@ -338,6 +338,136 @@ RuntimeWatchdogSec=15'
     return 0
 }
 
+# ── Archive mount lock (CIFS/NFS connect/disconnect scripts) ────────────
+#
+# The API's backup path and archiveloop now coordinate /mnt/archive
+# ownership via a shared flock (/tmp/sentryusb_archive_mount.lock — see
+# crates/api/src/archive_mount_lock.rs). The lock-aware connect/
+# disconnect-archive.sh only land on disk at setup-wizard time
+# (crates/setup/src/archive.rs bakes them into the binary), so existing
+# CIFS/NFS installs need this refresh or archiveloop keeps running the
+# lock-free scripts and the coordination is one-sided.
+#
+# The heredocs below MUST stay byte-identical to
+# run/cifs_archive/{connect,disconnect}-archive.sh (the nfs copies are
+# the same files).
+apply_archive_mount_lock_scripts() {
+    # Only CIFS/NFS archives mount /mnt/archive from fstab; rsync/rclone
+    # (and archiveless) installs have nothing to lock.
+    if ! grep -qE '[[:space:]]/mnt/archive[[:space:]]+(cifs|nfs)[[:space:]]' /etc/fstab 2>/dev/null; then
+        log "archive-mount-lock: no CIFS/NFS /mnt/archive fstab entry — not applicable"
+        return 0
+    fi
+    if grep -q 'ARCHIVE_MOUNT_LOCK' /root/bin/connect-archive.sh 2>/dev/null \
+       && grep -q 'ARCHIVE_MOUNT_LOCK' /root/bin/disconnect-archive.sh 2>/dev/null; then
+        log "archive-mount-lock: already patched"
+        return 0
+    fi
+    [ -x /root/bin/remountfs_rw ] && /root/bin/remountfs_rw >/dev/null 2>&1 || true
+
+    # Staged + atomic rename: a power loss or disk-full mid-write must
+    # never leave a truncated live script (archiveloop may invoke these
+    # at any moment, and a half-written file containing the marker would
+    # make the next patch run report "already patched").
+    cat > /root/bin/connect-archive.sh.new <<'CONNECT_EOF'
+#!/bin/bash -eu
+
+# Must match ARCHIVE_MOUNT_LOCK_PATH in crates/api/src/archive_mount_lock.rs
+# and disconnect-archive.sh.
+ARCHIVE_MOUNT_LOCK=/tmp/sentryusb_archive_mount.lock
+
+function mount_if_set() {
+  local mount_point=$1
+  [ -z "$mount_point" ] || ensure_mountpoint_is_mounted_with_retry "$mount_point"
+}
+
+# The archive mount is shared with the API's backup path, which may
+# mount /mnt/archive itself for a Backup Now and unmount it when done.
+# Take the shared flock around the transition so we can't adopt a
+# backup-owned mount that's about to be unmounted from under us. The
+# API holds the lock for its whole mount+write+unmount (bounded well
+# under the wait here). Fail-closed on lock timeout: mounting without
+# the lock reopens the adoption race, and archiveloop already handles a
+# failed connect by skipping the cycle and retrying next time.
+function mount_archive_locked() {
+  local mount_point=$1
+  [ -z "$mount_point" ] && return 0
+  (
+    if ! flock -w 300 210
+    then
+      log "Archive mount lock busy for 300s — failing archive connect (retried next cycle)."
+      exit 1
+    fi
+    ensure_mountpoint_is_mounted_with_retry "$mount_point"
+  ) 210>"$ARCHIVE_MOUNT_LOCK"
+}
+
+mount_archive_locked "${ARCHIVE_MOUNT:-}"
+mount_if_set "${MUSIC_ARCHIVE_MOUNT:-}"
+CONNECT_EOF
+
+    cat > /root/bin/disconnect-archive.sh.new <<'DISCONNECT_EOF'
+#!/bin/bash -eu
+
+# Unmount the archive. Without this, the archive mounts can get into a
+# state where the archive is reachable via the network, appears to be
+# mounted, but the mount is inoperable and any attempt to access it
+# results in a "host is down" message.
+
+# Must match ARCHIVE_MOUNT_LOCK_PATH in crates/api/src/archive_mount_lock.rs
+# and connect-archive.sh.
+ARCHIVE_MOUNT_LOCK=/tmp/sentryusb_archive_mount.lock
+
+unmount_if_set() {
+  local mount_point=$1
+  if [ -n "$mount_point" ]
+  then
+    if findmnt --mountpoint "$mount_point" > /dev/null
+    then
+      if timeout 10 umount -f -l "$mount_point" >> "$LOG_FILE" 2>&1
+      then
+        log "Unmounted $mount_point."
+      else
+        log "Failed to unmount $mount_point."
+      fi
+    else
+      log "$mount_point already unmounted."
+    fi
+  fi
+}
+
+# Archive unmount runs in the FOREGROUND under the shared flock, so an
+# in-flight API backup (which holds the lock across its mount+write)
+# can't have the mount force-lazy-unmounted mid-write. Bounded: the
+# umount itself is capped at 10s and the lock wait at 60s, so this
+# can't wedge the return to archiveloop the way an uncapped unmount
+# once could. Fail-closed on lock timeout: unmounting without the lock
+# is exactly the mid-write teardown the lock exists to prevent — skip,
+# and the next cycle's disconnect gets another chance. Music has no
+# API writer, so it keeps the old backgrounded, lock-free path.
+(
+  if ! flock -w 60 210
+  then
+    log "Archive mount lock busy for 60s — skipping archive unmount this cycle."
+    exit 0
+  fi
+  unmount_if_set "${ARCHIVE_MOUNT:-}"
+) 210>"$ARCHIVE_MOUNT_LOCK"
+unmount_if_set "${MUSIC_ARCHIVE_MOUNT:-}" &
+DISCONNECT_EOF
+
+    chmod 755 /root/bin/connect-archive.sh.new /root/bin/disconnect-archive.sh.new
+    if ! bash -n /root/bin/connect-archive.sh.new || ! bash -n /root/bin/disconnect-archive.sh.new; then
+        err "archive-mount-lock: staged scripts failed bash -n — keeping existing scripts"
+        rm -f /root/bin/connect-archive.sh.new /root/bin/disconnect-archive.sh.new
+        return 1
+    fi
+    # The && marker check above heals a power loss between the renames.
+    mv /root/bin/connect-archive.sh.new /root/bin/connect-archive.sh
+    mv /root/bin/disconnect-archive.sh.new /root/bin/disconnect-archive.sh
+    log "archive-mount-lock: lock-aware connect/disconnect-archive.sh installed"
+}
+
 # ── Run all patches ─────────────────────────────────────────────────────
 
 apply_ble_nonfatal_adv
@@ -345,6 +475,7 @@ apply_ble_adv_helper
 apply_eatt_disable
 apply_backingfiles_bfq
 apply_hardware_watchdog
+apply_archive_mount_lock_scripts
 
 # Future patches that must survive an OTA update get appended here. Each
 # one self-checks board / precondition / marker so the whole script stays


### PR DESCRIPTION
Closes #144.

## Summary

Config Backup with Location=Archive Server only checked that `/mnt/archive` existed before writing `/mnt/archive/backups`. On the read-only appliance rootfs, `/mnt/archive` exists even when the CIFS/NFS share is not mounted, so Backup Now could fail with EROFS.

For CIFS/NFS archive backups, mount `/mnt/archive` from fstab before writing, then verify the mount with `findmnt`. This fixes both the JSON config backup and the drive DB snapshot path.

Rsync/rclone behavior is unchanged. This change does not add automatic unmounting.

## Manual test plan

```sh
sudo umount /mnt/archive 2>/dev/null || true
curl -fsS -X POST 'http://127.0.0.1:8080/api/system/backup?force=1'
findmnt /mnt/archive
ls -lh /mnt/archive/backups/
```

Expected:
No "Read-only file system" error, and the archive share contains the JSON backup and, when `drive-data.db` exists, the `.drive-data.db.gz` snapshot.

## Validation

- `cargo test -p sentryusb-api`
- `git diff --check`
