### PR TITLE
chore(deps): retarget dependabot to main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,15 @@
 # Dependency monitoring for Sentry-USB-Rusty.
 #
 # Weekly grouped PRs for minor + patch updates to keep noise down.
-# Version updates target main-dev (release flow: main-dev -> main).
-# Security advisories fire immediately as separate ungrouped PRs and
-# always target the default branch (Dependabot ignores target-branch
-# for security updates) — retarget those to main-dev before merging.
+# Everything targets main (main-dev is retired). Security advisories
+# fire immediately as separate ungrouped PRs against the default
+# branch.
 
 version: 2
 
 updates:
   - package-ecosystem: "cargo"
     directory: "/"
-    target-branch: "main-dev"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -32,7 +30,6 @@ updates:
 
   - package-ecosystem: "npm"
     directory: "/web"
-    target-branch: "main-dev"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -53,7 +50,6 @@ updates:
 
   - package-ecosystem: "github-actions"
     directory: "/"
-    target-branch: "main-dev"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
main-dev is retired; dependabot was still opening version-update PRs against it (which is how #141 landed on the wrong branch). Drop the target-branch overrides so all three ecosystems target the default branch (main), matching where security advisories already go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)