### PR TITLE
fix(away-mode): start AP on boot when Automatic mode is already away (#153)

### DIFF
--- a/crates/api/src/away_mode.rs
+++ b/crates/api/src/away_mode.rs
@@ -742,7 +742,7 @@ fn spawn_watcher(stop: std::sync::Arc<Notify>, my_epoch: u64) {
 pub fn restore_from_file() {
     // Mode is config-driven (the source of truth shared with the daemon).
     if read_auto_enabled_config() {
-        let (notify, epoch) = {
+        let (notify, epoch, seeded_away) = {
             let mut inner = mgr().lock().unwrap();
             inner.mode = "auto";
             inner.state = "idle"; // auto doesn't use the timer state
@@ -758,13 +758,26 @@ pub fn restore_from_file() {
             inner.pending_count = 0;
             inner.stop = std::sync::Arc::new(Notify::new());
             inner.epoch += 1;
-            (inner.stop.clone(), inner.epoch)
+            (inner.stop.clone(), inner.epoch, inner.last_is_home == Some(false))
         };
-        // Don't touch the flag file: it may exist from a prior "away"
-        // state (the dispatcher uses it to bring the AP up on boot). The
-        // first geofence tick re-derives home/away and reconciles the AP.
+        // Don't touch the flag file: it may exist from a prior "away" state.
         away_mode_log("Automatic Away Mode active on boot — geofence watcher started");
         info!("[away-mode] Automatic mode — geofence watcher started");
+        // Booted while away (flag file present ⟹ seeded away): actively bring
+        // the AP up. Neither of the two mechanisms that otherwise restore it
+        // fires in this case — the NetworkManager dispatcher only resurrects
+        // ap0 on a `wlan0 up` event, which never happens away from home WiFi;
+        // and the watcher's first tick is not a home/away *flip* (it's already
+        // seeded away), so `auto_eval_tick` won't call `start_ap_bg` either.
+        // Without this, a reboot while parked away leaves the AP down until the
+        // car returns home. Mirrors the Manual-mode restore below. If the car
+        // actually reached home during the reboot, the first confirmed home
+        // flip stops the AP again (~1 min) — a brief, self-healing flicker.
+        if seeded_away {
+            away_mode_log("Automatic: booted while away — starting AP");
+            info!("[away-mode] auto: booted while away → starting AP");
+            start_ap_bg();
+        }
         spawn_auto_watcher(notify, epoch);
         return;
     }

--- a/crates/api/src/away_mode.rs
+++ b/crates/api/src/away_mode.rs
@@ -329,6 +329,17 @@ fn auto_seed_decision(flag_exists: bool) -> Option<bool> {
     Some(!flag_exists)
 }
 
+/// Whether booting into Automatic mode should actively (re)start the AP.
+/// The seeded decision comes from the flag file (see `auto_seed_decision`):
+/// present ⟹ away ⟹ the AP must be up. On a boot while away neither the NM
+/// dispatcher (fires only on `wlan0 up`, which never happens off home WiFi)
+/// nor the watcher's first tick (not a home/away *flip*) brings it up — so
+/// `restore_from_file` must. Extracted as a pure fn so this boot-start rule
+/// is unit-tested without the surrounding singleton/filesystem/shell I/O.
+fn should_start_ap_on_boot(flag_exists: bool) -> bool {
+    auto_seed_decision(flag_exists) == Some(false)
+}
+
 /// The daemon's last GPS fix as `(lat, lon, age_sec)`, or `None` if the
 /// file is missing/unparseable or has no coordinates. `age_sec` is how
 /// long ago the fix was taken (clamped ≥ 0).
@@ -742,7 +753,8 @@ fn spawn_watcher(stop: std::sync::Arc<Notify>, my_epoch: u64) {
 pub fn restore_from_file() {
     // Mode is config-driven (the source of truth shared with the daemon).
     if read_auto_enabled_config() {
-        let (notify, epoch, seeded_away) = {
+        let flag_exists = std::path::Path::new(FLAG_FILE).exists();
+        let (notify, epoch) = {
             let mut inner = mgr().lock().unwrap();
             inner.mode = "auto";
             inner.state = "idle"; // auto doesn't use the timer state
@@ -753,12 +765,12 @@ pub fn restore_from_file() {
             // present ⟹ away/AP-up). With `None` instead, `status` would
             // report ap_on=false while the AP is physically up, and an
             // arrived-home reboot would hold the stale AP until a fresh fix.
-            inner.last_is_home = auto_seed_decision(std::path::Path::new(FLAG_FILE).exists());
+            inner.last_is_home = auto_seed_decision(flag_exists);
             inner.pending_is_home = None;
             inner.pending_count = 0;
             inner.stop = std::sync::Arc::new(Notify::new());
             inner.epoch += 1;
-            (inner.stop.clone(), inner.epoch, inner.last_is_home == Some(false))
+            (inner.stop.clone(), inner.epoch)
         };
         // Don't touch the flag file: it may exist from a prior "away" state.
         away_mode_log("Automatic Away Mode active on boot — geofence watcher started");
@@ -773,7 +785,7 @@ pub fn restore_from_file() {
         // car returns home. Mirrors the Manual-mode restore below. If the car
         // actually reached home during the reboot, the first confirmed home
         // flip stops the AP again (~1 min) — a brief, self-healing flicker.
-        if seeded_away {
+        if should_start_ap_on_boot(flag_exists) {
             away_mode_log("Automatic: booted while away — starting AP");
             info!("[away-mode] auto: booted while away → starting AP");
             start_ap_bg();
@@ -1259,6 +1271,16 @@ mod tests {
         // Seeding last_is_home from it must NOT invert this mapping.
         assert_eq!(auto_seed_decision(true), Some(false)); // flag present → away
         assert_eq!(auto_seed_decision(false), Some(true)); // no flag → home
+    }
+
+    #[test]
+    fn boot_starts_ap_only_when_away() {
+        // On boot, the AP must be (re)started iff the seeded state is away —
+        // i.e. the flag file exists. Guards against inverting the condition,
+        // which would either leave the AP down while parked away (the #153
+        // bug) or spuriously raise it at home.
+        assert!(should_start_ap_on_boot(true)); // flag present → away → start AP
+        assert!(!should_start_ap_on_boot(false)); // no flag → home → don't start
     }
 }
 


### PR DESCRIPTION
## What does this PR do?

Fixes **#153** — in Automatic (geofence) Away Mode, the WiFi AP was not brought back up after the Pi **reboots while the car is already parked away from home**, so the device stayed unreachable until the car returned home.

### Root cause

`restore_from_file()`'s Automatic-mode branch seeds `last_is_home` from the flag file (present ⟹ away) and starts the geofence watcher, but never calls `start_ap_bg()`. It relied on two mechanisms to restore the AP, **neither of which fires when booting while away from home**:

1. **The geofence watcher's first tick** — `auto_eval_tick` only acts on a *confirmed home/away flip*. Booted-already-away is not a flip (`fold_geofence` returns `None`), so it never calls `start_ap_bg`.
2. **The NetworkManager dispatcher `10-sentryusb-ap`** — it resurrects `ap0` only on a `wlan0 up` event, which never happens away from home WiFi (no home SSID to associate with).

The **Manual-mode** branch of the same function already calls `start_ap_bg()` on restore — this PR restores that symmetry for Automatic mode.

### The fix

When the flag file is present at boot (seeded state is away), actively call `start_ap_bg()`. If the car actually reached home during the reboot, the first confirmed home flip stops the AP again within ~1 min — a brief, self-healing flicker, consistent with Manual-mode behavior.

Because the dispatcher does not fire away from home, this does not reintroduce the ap0-creation race fixed in #140.

### Verification

Reproduced on-device (v3.14.1; also present in latest `v3.14.3`): a real drive-away correctly started the AP (`away from home — starting AP` → `AP started`, no EBUSY), but a mid-trip reboot left the AP down with no further AP activity until arrival home. Log evidence is in #153.

### Tests

`restore_from_file` shells out (`nmcli`/`iw` via `start_ap_bg`) and touches the `mgr()` singleton + filesystem, so it isn't unit-testable in this crate's pure-function harness (there's no shell seam to mock). I extracted the boot-start decision into a pure `should_start_ap_on_boot(flag_exists)` helper and added a unit test (`boot_starts_ap_only_when_away`) in the same style as the existing `auto_seed_decision` / `fold_geofence` tests. It pins the rule (flag present ⟹ away ⟹ start AP; no flag ⟹ home ⟹ don't), so a future inversion — which would reintroduce this bug or spuriously raise the AP at home — fails the test.

> Note: I don't have a Rust toolchain on this machine, so I couldn't run `cargo fmt`/`clippy`/`cargo test` locally — the change is minimal and mirrors the existing Manual-mode path. Please let CI verify the build and tests.

## Checklist

- [ ] I ran `cargo fmt --all` and `cargo clippy` <!-- unable to run locally; see note above -->
- [x] I have read and agree to the [Contributor License Agreement](../blob/main/CLA.md) (the CLA Assistant bot will prompt me to sign)
- [x] If this PR touches MIT-derived scripts listed in [NOTICE](../blob/main/NOTICE), I noted it above so the license boundary is preserved — it does not (single Rust file)
