### PR TITLE
fix(away-mode): wait for NetworkManager before boot AP start (avoid ifupdown fallback)

### DIFF
--- a/crates/api/src/away_mode.rs
+++ b/crates/api/src/away_mode.rs
@@ -42,6 +42,39 @@ fn use_networkmanager() -> bool {
         .unwrap_or(false)
 }
 
+/// Decide whether NetworkManager owns wifi, tolerating the early-boot window.
+///
+/// `use_networkmanager()` is a point-in-time `is-active` probe. `restore_from_file`
+/// starts the AP on boot (booted-while-away) *before* NetworkManager has finished
+/// activating — `sentryusb.service` has no ordering after it — so `is-active`
+/// returns false there and `start_ap_bg` would wrongly take the ifupdown path,
+/// which fails on a NM image (no /etc/hostapd/hostapd.conf, no `ifup`) and leaves
+/// the AP down after a reboot while away. Wait for NM to reach `active` before
+/// committing. On genuine ifupdown systems the NetworkManager unit is not enabled,
+/// so return immediately and never delay their path. Waiting on the required
+/// precondition (NM active) rather than the cause absorbs any transient early-boot
+/// reason for the false reading.
+async fn wait_for_networkmanager() -> bool {
+    // ifupdown image (NetworkManager not the manager) — don't wait.
+    let nm_managed = std::process::Command::new("systemctl")
+        .args(["--quiet", "is-enabled", "NetworkManager.service"])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    if !nm_managed {
+        return false;
+    }
+    // Enabled but possibly still activating at early boot — poll up to ~30s.
+    for _ in 0..60 {
+        if use_networkmanager() {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+    warn!("[away-mode] NetworkManager enabled but not active within timeout; using NM path anyway");
+    true
+}
+
 /// Parse `iw wlan0 info` for the current STA channel + band. On
 /// BCM43455-family chipsets (Pi 4/5, Pi Zero 2 W, Rock 4C+) STA and AP are
 /// constrained to the same channel — the AP must match wlan0's channel or
@@ -547,7 +580,7 @@ async fn wait_for_ap0_ready() -> bool {
 
 fn start_ap_bg() {
     tokio::spawn(async {
-        if use_networkmanager() {
+        if wait_for_networkmanager().await {
             // NetworkManager path (Pi OS / pi-gen).
             if let Err(e) = ensure_ap0().await {
                 away_mode_log(&format!("Failed to create ap0: {}", e));


### PR DESCRIPTION
Follow-up to #154 / #153.

#154 made Automatic mode start the AP on boot when the Pi boots already-away. That works, but it exposed a timing bug: `restore_from_file` runs very early in boot — and `sentryusb.service` has no ordering after NetworkManager (`After=` is only the mutable/backingfiles mounts), so it can start before `NetworkManager.service` has finished activating. `start_ap_bg` picks its path with `use_networkmanager()`, a point-in-time `systemctl is-active` check, which returns **false** at that moment. So on a NetworkManager image the boot AP start wrongly falls through to the **ifupdown** path and fails (no `/etc/hostapd/hostapd.conf`, no `ifup`), leaving the AP down for the rest of a trip after a reboot while away.

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/641dedfa-3a7c-4b4b-88a4-9b4e919a339f">
  <img alt="Boot race: the is-active probe fires before NM is active, misrouting the boot AP start to the ifupdown path; the fix waits until NM reaches active before choosing the path" src="https://github.com/user-attachments/assets/32da94f5-e4bf-4a5d-90d1-c6a89c91e11f">
</picture>

Field evidence (log from a real reboot while parked away):

```
[away-mode] Automatic: booted while away — starting AP
[away-mode] Failed to set hostapd channel: read /etc/hostapd/hostapd.conf: No such file or directory (os error 2)
[away-mode] ifup ap0 failed: failed to execute command: No such file or directory (os error 2)
```

The `booted while away — starting AP` (from #154) fired correctly, but it hit the ifupdown branch on a NM system and the AP never came up. (The two `hostapd.conf` / `ifup` messages are only reachable from the ifupdown branch, which proves `use_networkmanager()` returned false at that instant.)

**Fix:** before choosing the path in `start_ap_bg`, wait for NetworkManager to actually reach `active` (bounded, ~30s), via a new `wait_for_networkmanager()` helper:

- returns immediately as `false` on genuine ifupdown systems (the NetworkManager unit isn't enabled), so their path is unchanged and never delayed;
- on a NM system, polls until NM is active, then takes the NM path — so the early-boot race no longer misroutes to ifupdown.

It waits on the *required precondition* (NM active) rather than the cause, so any transient early-boot reason for the false reading is absorbed. The wait runs inside the spawned task, so it never blocks boot; if NM never activates within the timeout it logs a warning and takes the NM path anyway (a broken-NM system where the AP couldn't come up regardless). At runtime (normal home↔away flips) NM is already active, so the helper returns on the first probe with no added latency.