### PR TITLE
fix(temperature): reset peak temperature after each archive cycle

### DIFF
--- a/run/temperature_monitor
+++ b/run/temperature_monitor
@@ -84,6 +84,11 @@ do
       message="Temperature Monitor: $(readable "$raw_temp") (max=$(readable "$peak_temp") $peak_time)"
       /root/bin/send-push-message "$NOTIFICATION_TITLE:" "$message" "" temperature || log "Temperature Monitor: Failed to send push message."
     fi
+    # Start a fresh peak for the next cycle, after the message above has
+    # reported the one just ending. Sits outside the POSTARCHIVE check
+    # because interval logging needs the per-cycle reset too.
+    peak_temp=$raw_temp
+    peak_time=$timestamp
   fi
 
   sleep 60


### PR DESCRIPTION
## What does this PR do?

`run/temperature_monitor` reports a running peak temperature alongside each reading. That peak is seeded once before the sampling loop and only ever ratchets upward — nothing resets it. So after the first hot archive, every later report repeats the same since-boot maximum, and a cooler subsequent archive leaves no trace at all. That makes the `max=` field useless for the thing it exists for: comparing thermal load between idling and archiving.

`sentryusb.conf.sample` already documents the intended behavior — "The maximum value is held through the recording period and reset at the conclusion of the archiving/music sync process" — but no code implemented it. This adds the missing reset, bringing the code in line with the documented contract, so no doc change is needed.

Two placement details are deliberate:

- The reset runs **after** the push message is built, so that notification still reports the cycle just ending rather than the freshly-reset value.
- It sits **outside** the `TEMPERATURE_POSTARCHIVE` check, so interval logging (`TEMPERATURE_INTERVAL`) gets per-cycle maxima even when push notifications are disabled.

### Verification

Drove the script through two archive cycles against a stubbed thermal sensor and push helper with instant sleeps: idle at 45°C, a first archive peaking at 72°C, then a cooler second archive peaking at 65°C. The same scenario run against `main` and against this branch:

```
main:         PUSH: 46.0°C (max=72.0°C)
              PUSH: 47.0°C (max=72.0°C)   <- archive 2's real 65°C peak lost

this branch:  PUSH: 46.0°C (max=72.0°C)
              PUSH: 47.0°C (max=65.0°C)   <- archive 2 reports its own peak
```

The first notification is identical on both, confirming the first cycle is unchanged. Interval logging across the same run reads `45.0 → 72.0 → 72.0 → 65.0 → 65.0`. `bash -n` passes.

This was exercised off-Pi with the system paths stubbed — the logic under test is untouched, but it has not yet run on real hardware. The harness isn't included: this is a `run/` shell script and the repo has no shell test harness or shellcheck in CI.

### Not addressed here

Two known limitations of this monitor are deliberately left alone: sampling is once per 60s, and the post-archive reading can be up to ~2 minutes stale by the time the loop notices the flag — the same staleness that motivated the inline `soc_temperature()` capture in `archiveloop`. Both matter for fine-grained thermal profiling but are out of scope for this fix.

## Checklist

- [x] I ran `cargo fmt --all` and `cargo clippy` — **n/a**, this PR changes a shell script only, no Rust.
- [x] I have read and agree to the [Contributor License Agreement](../blob/main/CLA.md) (the CLA Assistant bot will prompt me to sign)
- [x] If this PR touches MIT-derived scripts listed in [NOTICE](../blob/main/NOTICE), I noted it above so the license boundary is preserved — checked: `run/temperature_monitor` is **not** listed in NOTICE, so it is original work under PolyForm Noncommercial. No license boundary is affected.
