### PR TITLE
fix(rock4cplus): unblock WiFi at boot — WiFi is dead after setup on ROCK 4C+

### DIFF
--- a/crates/setup/src/readonly.rs
+++ b/crates/setup/src/readonly.rs
@@ -347,6 +347,40 @@ pub async fn make_readonly(env: &SetupEnv, emitter: &SetupEmitter) -> Result<boo
         "systemctl", &["enable", "rfkill-unblock-bluetooth.service"],
     ).await;
 
+    // ---- WiFi rfkill — ROCK 4C+ only ----
+    // Deliberately board-scoped: the 4C+ is the board whose WLAN boots
+    // soft-blocked (leaving WiFi-only users locked out after setup). Every
+    // other board keeps its current behaviour, so this can't switch a radio on
+    // anywhere it wasn't already.
+    if env.pi_model == crate::env::PiModel::Rock4CPlus {
+        emitter.progress("Installing WiFi rfkill-unblock boot service (ROCK 4C+)");
+        let _ = std::fs::create_dir_all("/usr/local/sbin");
+        // Helper before the unit, so a partial install can never leave a unit
+        // pointing at a script that doesn't exist.
+        if let Err(e) = std::fs::write("/usr/local/sbin/sentryusb-unblock-wifi", WIFI_UNBLOCK_HELPER)
+        {
+            emitter.progress(&format!("WiFi unblock helper write failed: {e}"));
+        } else {
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let _ = std::fs::set_permissions(
+                    "/usr/local/sbin/sentryusb-unblock-wifi",
+                    std::fs::Permissions::from_mode(0o755),
+                );
+            }
+            std::fs::write(
+                "/etc/systemd/system/rfkill-unblock-wifi.service",
+                WIFI_UNBLOCK_SERVICE,
+            )?;
+            let _ = sentryusb_shell::run(
+                "systemctl", &["enable", "rfkill-unblock-wifi.service"],
+            ).await;
+            // Unblock now as well, so WiFi works for the rest of setup.
+            let _ = sentryusb_shell::run("/usr/local/sbin/sentryusb-unblock-wifi", &[]).await;
+        }
+    }
+
     // ---- Reload NM config (dns=none + dispatcher) non-disruptively ----
     // A full restart would drop WiFi and kill SSH sessions mid-setup. The
     // reboot that follows will fully apply the new config.
@@ -817,4 +851,69 @@ ExecStart=/usr/sbin/rfkill unblock bluetooth
 
 [Install]
 WantedBy=multi-user.target
+"#;
+
+/// ROCK 4C+ only. Same idea as the Bluetooth unit above, for WiFi.
+///
+/// On the 4C+ (RK3399/Armbian) the WLAN radio comes up soft-blocked. Normally
+/// systemd-rfkill would restore the unblocked state saved from last boot — but
+/// `make_readonly` puts /var/lib/systemd/rfkill on tmpfs (so a stale block can
+/// never be restored), which also means there is nothing to restore the
+/// UNBLOCKED state from. Result: WiFi is dead on every boot after setup, and a
+/// WiFi-only 4C+ user is locked out of their appliance.
+///
+/// Ordered before `network-pre.target` (which NetworkManager declares
+/// `After=`) rather than `network.target` — NM declares `Before=network.target`
+/// itself, so ordering against that target would NOT guarantee running first.
+///
+/// Escape hatch for a 4C+ that should stay radio-silent (e.g. ethernet-only):
+///   echo off > /etc/sentryusb/wifi-radio
+const WIFI_UNBLOCK_SERVICE: &str = r#"[Unit]
+Description=Unblock WiFi RF-kill (ROCK 4C+)
+DefaultDependencies=no
+Wants=network-pre.target
+Before=network-pre.target NetworkManager.service
+After=sysinit.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/sbin/sentryusb-unblock-wifi
+
+[Install]
+WantedBy=multi-user.target
+"#;
+
+/// Unblocks WiFi unless the operator opted out. Also waits briefly for the
+/// WLAN rfkill device to appear: it can register after sysinit.target, and a
+/// oneshot that ran too early would silently do nothing until the next boot.
+const WIFI_UNBLOCK_HELPER: &str = r#"#!/bin/sh
+# Managed by SentryUSB setup (ROCK 4C+). Unblocks the WiFi radio at boot.
+# To keep this board radio-silent:  echo off > /etc/sentryusb/wifi-radio
+set -u
+
+OVERRIDE=/etc/sentryusb/wifi-radio
+if [ -r "$OVERRIDE" ]; then
+  case "$(tr -d '[:space:]' < "$OVERRIDE" | tr '[:upper:]' '[:lower:]')" in
+    off|0|false|disabled)
+      exit 0 ;;
+  esac
+fi
+
+# The WLAN rfkill device may not be registered yet this early in boot; a
+# type-wide unblock issued before it exists is a no-op that never retries
+# (Type=oneshot). Wait up to ~5s for it, then unblock regardless — the
+# type-wide op also sets the default for devices that appear later.
+i=0
+while [ "$i" -lt 25 ]; do
+  for d in /sys/class/rfkill/rfkill*; do
+    [ -r "$d/type" ] || continue
+    if [ "$(cat "$d/type" 2>/dev/null)" = "wlan" ]; then
+      exec /usr/sbin/rfkill unblock wifi
+    fi
+  done
+  i=$((i + 1))
+  sleep 0.2
+done
+exec /usr/sbin/rfkill unblock wifi
 "#;

--- a/setup/pi/apply-runtime-patches.sh
+++ b/setup/pi/apply-runtime-patches.sh
@@ -468,6 +468,107 @@ DISCONNECT_EOF
     log "archive-mount-lock: lock-aware connect/disconnect-archive.sh installed"
 }
 
+# ── WiFi rfkill unblock — ROCK 4C+ only ─────────────────────────────────
+#
+# On the 4C+ the WLAN radio boots soft-blocked. systemd-rfkill would normally
+# restore last boot's unblocked state, but make-root-fs-readonly puts
+# /var/lib/systemd/rfkill on tmpfs (so a stale block can't be restored) — which
+# also means the UNBLOCKED state has nothing to restore from. WiFi therefore
+# stays dead on every boot after setup, locking out WiFi-only users. Bluetooth
+# already has an equivalent boot service (BLE / Tesla key); this is the WiFi
+# twin. Existing installs can't get it from the setup scripts (those only run
+# at install time), so heal them here.
+#
+# Opt out on a board that should stay radio-silent:
+#   echo off > /etc/sentryusb/wifi-radio
+apply_rfkill_unblock_wifi() {
+    is_rock_4cplus || return 0
+
+    local unit=/etc/systemd/system/rfkill-unblock-wifi.service
+    local helper=/usr/local/sbin/sentryusb-unblock-wifi
+
+    # Marker: unit installed and pointing at an executable helper.
+    if grep -q "$helper" "$unit" 2>/dev/null && [ -x "$helper" ]; then
+        return 0
+    fi
+
+    # Root is read-only on a deployed unit: unlock, write, then lock back.
+    # Leaving root writable on a device that loses power when the car sleeps
+    # is what the read-only root exists to prevent.
+    local ro_before=no
+    findmnt -no OPTIONS / 2>/dev/null | grep -qE '(^|,)ro(,|$)' && ro_before=yes
+    if [ "$ro_before" = yes ]; then
+        [ -x /root/bin/remountfs_rw ] && /root/bin/remountfs_rw >/dev/null 2>&1 \
+            || mount -o remount,rw / 2>/dev/null || true
+    fi
+    _relock() {
+        [ "$ro_before" = yes ] || return 0
+        sync
+        mount -o remount,ro / 2>/dev/null || true
+    }
+
+    mkdir -p /usr/local/sbin /etc/systemd/system 2>/dev/null || true
+
+    cat > "$helper" << 'WIFIHELPER'
+#!/bin/sh
+# Managed by SentryUSB (ROCK 4C+). Unblocks the WiFi radio at boot.
+# To keep this board radio-silent:  echo off > /etc/sentryusb/wifi-radio
+set -u
+
+OVERRIDE=/etc/sentryusb/wifi-radio
+if [ -r "$OVERRIDE" ]; then
+  case "$(tr -d '[:space:]' < "$OVERRIDE" | tr '[:upper:]' '[:lower:]')" in
+    off|0|false|disabled)
+      exit 0 ;;
+  esac
+fi
+
+i=0
+while [ "$i" -lt 25 ]; do
+  for d in /sys/class/rfkill/rfkill*; do
+    [ -r "$d/type" ] || continue
+    if [ "$(cat "$d/type" 2>/dev/null)" = "wlan" ]; then
+      exec /usr/sbin/rfkill unblock wifi
+    fi
+  done
+  i=$((i + 1))
+  sleep 0.2
+done
+exec /usr/sbin/rfkill unblock wifi
+WIFIHELPER
+    chmod 755 "$helper" 2>/dev/null || true
+
+    cat > "$unit" << 'WIFIUNIT'
+[Unit]
+Description=Unblock WiFi RF-kill (ROCK 4C+)
+DefaultDependencies=no
+Wants=network-pre.target
+Before=network-pre.target NetworkManager.service
+After=sysinit.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/sbin/sentryusb-unblock-wifi
+
+[Install]
+WantedBy=multi-user.target
+WIFIUNIT
+
+    # A silent write failure would leave the bug unfixed while reporting success.
+    if ! grep -q "$helper" "$unit" 2>/dev/null || [ ! -x "$helper" ]; then
+        err "rfkill-wifi: install failed (read-only fs? check remountfs_rw)"
+        _relock
+        return 1
+    fi
+
+    systemctl enable rfkill-unblock-wifi.service 2>/dev/null || true
+    systemctl daemon-reload 2>/dev/null || true
+    "$helper" 2>/dev/null || true   # take effect now, not just next boot
+    _relock
+    log "rfkill-wifi: WiFi unblock boot service installed (ROCK 4C+)"
+}
+
 # ── Run all patches ─────────────────────────────────────────────────────
 
 apply_ble_nonfatal_adv
@@ -476,6 +577,7 @@ apply_eatt_disable
 apply_backingfiles_bfq
 apply_hardware_watchdog
 apply_archive_mount_lock_scripts
+apply_rfkill_unblock_wifi
 
 # Future patches that must survive an OTA update get appended here. Each
 # one self-checks board / precondition / marker so the whole script stays


### PR DESCRIPTION
## The bug

On a ROCK 4C+ the WLAN radio comes up soft-blocked. Normally `systemd-rfkill` restores the unblocked state saved from the previous boot — but `make_readonly` puts `/var/lib/systemd/rfkill` on tmpfs (so a *stale* soft-block can never be restored), which also means the **unblocked** state has nothing to be restored from.

Net effect: after setup finishes and the board reboots, WiFi is off on **every** boot, and a WiFi-only 4C+ user is locked out of their appliance.

Bluetooth already gets exactly this treatment (`rfkill-unblock-bluetooth.service`, for BLE / the Tesla key). This adds the WiFi twin.

## Confirmed on hardware

From a 4C+ owner running current `main` (thanks @pSyChO_aSyLuM in Discord, who reported it and did the digging):

```
root@sentryusb:~# rfkill list
0: hci0: Bluetooth
        Soft blocked: no      <-- our BT service unblocks this
        Hard blocked: no
1: phy0: Wireless LAN
        Soft blocked: yes     <-- nothing unblocks this
        Hard blocked: no
```

A clean A/B on the same board: the radio we have a service for is unblocked, the one we don't is blocked. It's a **soft** block, so `rfkill unblock wifi` clears it. Affected users have been hand-rolling their own unblock services to work around it.

## Scope

Deliberately limited to the ROCK 4C+ — `PiModel::Rock4CPlus` in the Rust path, `is_rock_4cplus()` in the patch script. The 4C+ is the board that boots WiFi soft-blocked, and scoping means this **cannot switch a radio on for any board where it wasn't already on**.

Purely additive: the existing Bluetooth unit is untouched, so there's no unit rename and no migration.

## Notes for review

- **Ordering.** The unit is `Wants=`/`Before=network-pre.target` rather than `Before=network.target`. NetworkManager declares `Before=network.target` itself, so ordering against that target would *not* guarantee running before NM; NM declares `After=network-pre.target`, so that's the sync point that does. (Also relevant: minimal Armbian images may have no NM at all — the `network-pre.target` ordering is still correct there.)

- **Late rfkill registration.** The WLAN rfkill device can register *after* `sysinit.target`. A type-wide unblock issued before it exists is a no-op, and `Type=oneshot` never retries — a silent failure until the next boot. The helper therefore waits up to ~5s for a device of type `wlan`, then unblocks regardless (the type-wide op also sets the default for devices that appear later).

- **Opt-out.** A 4C+ that should stay radio-silent (ethernet-only) can set:
  ```
  echo off > /etc/sentryusb/wifi-radio
  ```

- **Existing installs.** Setup scripts only run at install time, so the same logic is added to `apply-runtime-patches.sh` (the OTA bridge) — deployed boards heal on their next update instead of needing a reflash. That block remounts root rw to write and puts it **back read-only** afterwards (leaving root writable on a device that loses power when the car sleeps is what the read-only root exists to prevent), and verifies the write rather than reporting success blindly.

- **Not needed, FYI:** reporters were also adding `cfg80211.ieee80211_regdom=US` to `armbianEnv.txt`. On the same board `/proc/cmdline` has no such parameter yet `iw reg get` already reports `country US: DFS-FCC`, so that workaround appears incidental to this bug.

## Testing

Author has no 4C+ to test on (my board is ethernet-only DietPi), so this is logic-reviewed rather than hardware-verified end to end: builds clean, all touched shell passes `bash -n`, and the helper's opt-out / rfkill-wait paths were exercised against fixtures. **Field confirmation from a 4C+ owner before merge would be welcome** — @pSyChO_aSyLuM has a spare card and offered to test.