### PR TITLE
fix(ble): make SentryUSB discoverable over BLE on Raspberry Pi 4 Model B

### DIFF
--- a/setup/pi/apply-runtime-patches.sh
+++ b/setup/pi/apply-runtime-patches.sh
@@ -48,15 +48,24 @@ is_rock_4cplus() {
 # kernel logs on first BT probe (e.g. "Bluetooth: hci0: BCM43430B0 (002.001.012)").
 #
 # Currently:
-#   BCM4345C0 — Rock 4C+ (confirmed broken via field evidence)
+#   BCM4345C0 — Rock 4C+ (confirmed broken via field evidence) AND
+#     Raspberry Pi 4 Model B (confirmed broken via btmon trace 2026-07-25:
+#     "Add Extended Advertising Data (0x0055) → Invalid Parameters (0x0d)";
+#     without the helper only LE Set Advertising Parameters + Enable are
+#     issued — no Set Advertising Data (0x0008) — so the Pi advertises an
+#     EMPTY packet and is undiscoverable by name/UUID). Pi 4B's BT loads
+#     firmware brcm/BCM4345C0.raspberrypi,4-model-b.hcd — same silicon.
 #   BCM43430B0 — Pi Zero 2 W (confirmed broken via btmon trace 2026-06-20)
 #   BCM43438 — Pi 3B/3B+, Pi Zero W (same chip family / same firmware tree)
 #
 # DELIBERATELY EXCLUDED until tested:
-#   BCM43455 / CYW43455 — Pi 4 / Pi 5; their modern bluetoothd path is
-#   reported to work fine, and running our raw-HCI helper there would
-#   override their working ext-adv with legacy adv (regression). If a Pi
-#   4/5 user does hit "GATT 147 bond=BOND_NONE" they can opt in with:
+#   BCM43455 / CYW43455 — Pi 5; its modern bluetoothd path is reported to
+#   work fine, and running our raw-HCI helper there would override its
+#   working ext-adv with legacy adv (regression). (Note: Raspberry Pi 4
+#   Model B was previously excluded here on the assumption it uses
+#   BCM43455 — in the field its BT identifies as BCM4345C0 and rejects
+#   ext-adv, so it is now in the broken list above.) If an excluded board
+#   does hit "GATT 147 bond=BOND_NONE" the operator can opt in with:
 #       sudo touch /mutable/force-ble-adv-helper
 #   That sentinel forces install regardless of chip detection. The next OTA
 #   (or `sudo /usr/local/bin/sentryusb-apply-runtime-patches`) lands it.
@@ -67,9 +76,11 @@ is_known_broken_ble_chip() {
     local chips="BCM4345C0\|BCM43430B0\|BCM43438"
     dmesg 2>/dev/null | grep -qE "hci0: ($chips)" && return 0
     # dmesg may not retain that line on a long-running box; also check the
-    # board model as a backstop (4C+'s 4345C0 + Zero 2 W's 43430B0 are
-    # board-specific so model match is unambiguous).
-    grep -qai 'rock-4c-plus\|rockpi4c-plus\|ROCK 4C+\|Raspberry Pi Zero 2 W\|Raspberry Pi 3 Model B\|Raspberry Pi Zero W' \
+    # board model as a backstop (4C+'s 4345C0, Zero 2 W's 43430B0 and Pi 4B's
+    # 4345C0 are board-specific so model match is unambiguous). Without this,
+    # a Pi 4B whose boot-time "hci0: BCM4345C0" line has rotated out of dmesg
+    # fails detection and never gets the helper — advertising an empty packet.
+    grep -qai 'rock-4c-plus\|rockpi4c-plus\|ROCK 4C+\|Raspberry Pi Zero 2 W\|Raspberry Pi 3 Model B\|Raspberry Pi Zero W\|Raspberry Pi 4 Model B' \
         /proc/device-tree/model 2>/dev/null && return 0
     return 1
 }

--- a/setup/pi/sentryusb-ble-adv.sh
+++ b/setup/pi/sentryusb-ble-adv.sh
@@ -55,6 +55,19 @@ connect_in_flight() {
     [ "$age" -ge 0 ] && [ "$age" -lt "$CONNECTING_FLAG_MAX_AGE" ]
 }
 
+# True only when a central (a phone) is connected TO us — i.e. we hold a
+# PERIPHERAL-role LE link. The Tesla keep-awake link is the OPPOSITE: the Pi
+# dials out to the car, so it is a CENTRAL-role link. That link must NOT
+# suppress advertising, otherwise the Pi is undiscoverable to the phone the
+# whole time keep-awake holds the car connection (the in-app "connect over
+# Bluetooth" step then fails). The controller does advertising + an outbound
+# central link simultaneously without issue (field-verified: asserting adv
+# while the car link is up left the car link intact). hcitool reports the
+# LOCAL role as "lm PERIPHERAL" (older BlueZ: "lm SLAVE").
+peripheral_link_up() {
+    hcitool con 2>/dev/null | grep -qiE 'lm (PERIPHERAL|SLAVE)'
+}
+
 # Run the advertising loop ONLY when executed directly (the systemd ExecStart),
 # never when sourced — otherwise testing build_scanrsp() would loop forever.
 if [ "${BASH_SOURCE[0]}" != "${0}" ]; then
@@ -66,8 +79,12 @@ sleep 3   # let bluetoothd's (failing) ext-adv RegisterAdvertisement settle firs
 timeout 5 btmgmt le on >/dev/null 2>&1 || true
 timeout 5 btmgmt connectable on >/dev/null 2>&1 || true
 while true; do
-    # Re-assert only while IDLE and no central connect is in flight.
-    if ! connect_in_flight && ! timeout 3 btmgmt con 2>/dev/null | grep -q 'type LE'; then
+    # Re-assert while IDLE: skip only while a phone connect is in flight, or a
+    # phone is already connected (a PERIPHERAL-role link). Do NOT skip merely
+    # because an LE connection exists — the Tesla keep-awake is a CENTRAL-role
+    # link and must not silence advertising, or the phone can never discover us
+    # while the car is awake.
+    if ! connect_in_flight && ! peripheral_link_up; then
         assert_raw_adv
     fi
     sleep 5


### PR DESCRIPTION
**TL;DR** — On a Pi 4 Model B the BLE peripheral advertises with no name/UUID,
so the app's "connect over Bluetooth" step fails. (Wi-Fi/mDNS discovery still
works, which masks the bug.) Two causes: the raw-HCI adv helper isn't installed
on Pi 4B, and even when installed it goes silent while the Tesla keep-awake link
is up. This fixes both. Tested on a real Pi 4B; the keep-awake link is unaffected.

**Context:** Found while testing the **Android Sentry Connect public beta**. On a
Pi 4B, the device was reachable over Wi-Fi but the app's "also connect over
Bluetooth" step never completed.

> **Disclosure — please read before merging.** I don't have deep BLE/Bluetooth
> expertise. I built this PR with heavy AI assistance: I validated each
> hypothesis against my own SentryUSB (btmon traces, `hcitool con`, live app
> tests) and fed the results back to the AI over many iterations until it worked
> on my device. It fixes the issue on my Pi 4B, but it may still be wrong or
> incomplete — please review carefully before merging.

## Symptom
Phone and Pi on the same Wi-Fi. SentryUSB shows in Sentry Connect's
"Available Devices" (mDNS), but when the app offers to also connect over
Bluetooth, the BLE connection never completes.

## Root cause
Pi 4B's Bluetooth enumerates as **BCM4345C0** (`brcm/BCM4345C0.raspberrypi,4-model-b.hcd`)
and rejects BlueZ EXTENDED advertising with `Invalid Parameters (0x0d)` (btmon).
Discoverability therefore relies on the raw-HCI `sentryusb-ble-adv.sh` helper.
Two bugs kept that helper from making the Pi discoverable:

1. **Helper never installed on Pi 4B.** `is_known_broken_ble_chip()` matches
   BCM4345C0 in `dmesg`, but that boot line rotates out of the ring buffer on a
   long-running box, and the model backstop omitted "Raspberry Pi 4 Model B".
   With no helper, the daemon issues `LE Set Advertising Parameters` + `Enable`
   but **no `LE Set Advertising Data`** → empty advert (no name/UUID). The
   Android app scans for the `SentryUSB-` name prefix / `WIFI_SERVICE_UUID`, so
   it never sees the device.

2. **Helper goes silent during keep-awake.** It skipped advertising whenever ANY
   LE connection existed (`btmgmt con | grep 'type LE'`). That doesn't
   distinguish a phone connecting TO us (PERIPHERAL role) from the Pi's own
   outbound Tesla keep-awake link (CENTRAL role). Keep-awake holds the car link
   almost continuously, so the helper stayed muted.

## Changes
1. `apply-runtime-patches.sh`: add `Raspberry Pi 4 Model B` to the
   `is_known_broken_ble_chip()` model backstop; correct the "Pi 4/5 works fine"
   comment.
2. `sentryusb-ble-adv.sh`: gate the advertising loop on a PERIPHERAL-role link
   (`peripheral_link_up`) instead of any LE connection.

## Why this doesn't regress the boards you deliberately excluded
The exclusion assumes Pi 4/5 use BCM43455/CYW43455 where ext-adv works. This
Pi 4B's controller actually enumerates as **BCM4345C0** — the same chip as the
Rock 4C+ already on the broken list — and rejects ext-adv with `0x0d`. So:
- Pi 4B is added because it *is* a known-broken chip, not a working one.
- **Pi 5 stays excluded** (not tested here).
- The helper only ever replaces advertising that is already broken (ext-adv
  rejected → empty legacy adv), so there's nothing working to regress.

## Blast radius of the guard change
`sentryusb-ble-adv.sh` runs on every known-broken board (Rock 4C+, Zero 2 W,
Pi 3B, Pi 4B). The Tesla keep-awake is a permanent CENTRAL-role link on all of
them, so the old guard muted advertising on all of them; the fix helps all. The
original intent — don't re-arm advertising mid-*phone*-connect — is preserved by
the existing `connect_in_flight` flag; only the over-broad "any LE connection"
check is narrowed.

## Evidence (btmon, on the affected Pi 4B)
Before — ext-adv rejected, fallback advertises empty:

    Add Extended Advertising Data (0x0055) → Invalid Parameters (0x0d)
    LE Set Advertising Parameters (0x0006) → Success
    LE Set Advertise Enable (0x000a) Enabled → Success
    (no 0x0008 Advertising Data / 0x0009 Scan Response)

After — advertises name + UUID while the keep-awake (CENTRAL) link stays up:

    hcitool con: < LE F0:… lm CENTRAL      # car link intact
    LE Set Advertising Data (0x0008)        # NUS UUID
    LE Set Scan Response Data (0x0009)      # name SentryUSB-XXXX
    LE Set Advertise Enable → Enabled

## Testing
- Device: Raspberry Pi 4 Model B Rev 1.4, BCM4345C0, BlueZ 5.82.
- App: Android Sentry Connect (public beta).
- Helper auto-installs after the detection change (no manual sentinel).
- Advertises name/UUID while keep-awake holds the car link; car link stays
  connected — multi-role (advertise + outbound central) is stable here.
- Sentry Connect's "connect over Bluetooth" now succeeds.
- **Not tested:** other helper boards (Rock 4C+/Zero 2W/Pi 3B) with the guard
  change — the check is role-based and board-agnostic, but I only have a Pi 4B.
  Pi 5 untouched.

## Splitting
The two changes are independent (detection vs guard). Happy to split into two
PRs if you'd rather review/merge them separately — the detection fix is
Pi 4B-only and low-risk; the guard change is broader.
