### PR TITLE
BLE: gate advertising by RF-verified manifest, single-owner helper (supersedes #174)

### DIFF
--- a/install-pi.sh
+++ b/install-pi.sh
@@ -555,46 +555,51 @@ fi
 # "GATT 147 bond=BOND_NONE" symptom they can opt in with:
 #     sudo touch /mutable/force-ble-adv-helper
 # That sentinel forces install regardless of chip detection.
-is_known_broken_ble_chip() {
-    [ -f /mutable/force-ble-adv-helper ] && return 0   # operator override
-    local chips="BCM4345C0\|BCM43430B0\|BCM43438"
-    dmesg 2>/dev/null | grep -qE "hci0: ($chips)" && return 0
-    grep -qai 'rock-4c-plus\|rockpi4c-plus\|ROCK 4C+\|Raspberry Pi Zero 2 W\|Raspberry Pi 3 Model B\|Raspberry Pi Zero W' \
-        /proc/device-tree/model 2>/dev/null && return 0
-    return 1
-}
-if is_known_broken_ble_chip; then
-    info "Known-affected BLE chip detected — installing raw-HCI advertising helper..."
-    BLE_ADV_BASE_URL="https://raw.githubusercontent.com/${REPO}/main/setup/pi"
-    LOCAL_PI_DIR="$(dirname "${1:-/dev/null}")/setup/pi"
-    fetch_file() {
-        # $1 = filename, $2 = destination. Tries local repo first, then URL.
-        if [ -f "$LOCAL_PI_DIR/$1" ]; then
-            install -m 644 "$LOCAL_PI_DIR/$1" "$2"
-        elif curl -fsSL --max-time 15 "$BLE_ADV_BASE_URL/$1" -o "$2" 2>/dev/null; then
-            :
-        else
-            warn "Failed to fetch $1 — BLE LE advertising may not work"
-            return 1
-        fi
-        return 0
-    }
-    if fetch_file sentryusb-ble-adv.sh /usr/local/bin/sentryusb-ble-adv.sh; then
-        chmod +x /usr/local/bin/sentryusb-ble-adv.sh
-        fetch_file sentryusb-ble-adv.service /etc/systemd/system/sentryusb-ble-adv.service
-        fetch_file 99-sentryusb-ble-hci.rules /etc/udev/rules.d/99-sentryusb-ble-hci.rules
-        mkdir -p /etc/systemd/system/sentryusb-ble.service.d
-        fetch_file sentryusb-ble-wants-bluetooth.conf /etc/systemd/system/sentryusb-ble.service.d/wants-bluetooth.conf
-        # Retire any older single-purpose unit from earlier installs.
-        systemctl disable --now sentryusb-ble-le.service 2>/dev/null || true
-        rm -f /etc/systemd/system/sentryusb-ble-le.service 2>/dev/null
-        rm -rf /etc/systemd/system/sentryusb-ble-le.service.d 2>/dev/null
-        systemctl enable bluetooth.service >/dev/null 2>&1 || true
-        systemctl daemon-reload 2>/dev/null || true
-        udevadm control --reload-rules 2>/dev/null || true
-        systemctl enable sentryusb-ble-adv.service >/dev/null 2>&1 || true
-        ok "BLE legacy-advertising helper installed (script + service + hci0 udev rule)"
+# Install the BLE advertising selector + helper on EVERY board. No chip gate:
+# which advertiser runs is decided at boot by the mode marker
+# (select-ble-adv-mode.sh vs ble-native-manifest), never by chip. The old gate
+# force-installed the helper on the working Pi 5 and could not distinguish the
+# natively-working r03 from the 4C+ (identical bluetoothd binary). Staging is
+# inert — the helper self-stands-down on boards the manifest qualifies native.
+info "Installing BLE advertising selector + helper..."
+BLE_ADV_BASE_URL="https://raw.githubusercontent.com/${REPO}/main/setup/pi"
+LOCAL_PI_DIR="$(dirname "${1:-/dev/null}")/setup/pi"
+fetch_file() {
+    # $1 = filename, $2 = destination, $3 = mode (default 644). Local repo first, then URL.
+    local mode="${3:-644}"
+    # Create the parent dir first: some destinations (e.g.
+    # /usr/local/share/sentryusb/) don't exist yet, and `curl -o` to a missing
+    # directory fails (exit 23) — which under `set -eu` would abort the whole
+    # installer. `install -D` handles the local path, mkdir handles the curl one.
+    mkdir -p "$(dirname "$2")" 2>/dev/null || true
+    if [ -f "$LOCAL_PI_DIR/$1" ]; then
+        install -D -m "$mode" "$LOCAL_PI_DIR/$1" "$2"
+    elif curl -fsSL --max-time 15 "$BLE_ADV_BASE_URL/$1" -o "$2" 2>/dev/null; then
+        chmod "$mode" "$2" 2>/dev/null || true
+    else
+        warn "Failed to fetch $1 — BLE LE advertising may not work"
+        return 1
     fi
+    return 0
+}
+if fetch_file select-ble-adv-mode.sh /usr/local/bin/select-ble-adv-mode.sh 755 \
+   && fetch_file sentryusb-ble-adv.sh /usr/local/bin/sentryusb-ble-adv.sh 755; then
+    fetch_file ble-native-manifest /usr/local/share/sentryusb/ble-native-manifest 644
+    fetch_file sentryusb-ble-mode.service /etc/systemd/system/sentryusb-ble-mode.service 644
+    fetch_file sentryusb-ble-adv.service /etc/systemd/system/sentryusb-ble-adv.service 644
+    fetch_file 99-sentryusb-ble-hci.rules /etc/udev/rules.d/99-sentryusb-ble-hci.rules 644
+    mkdir -p /etc/systemd/system/sentryusb-ble.service.d
+    fetch_file sentryusb-ble-wants-bluetooth.conf /etc/systemd/system/sentryusb-ble.service.d/wants-bluetooth.conf 644
+    # Retire any older single-purpose unit from earlier installs.
+    systemctl disable --now sentryusb-ble-le.service 2>/dev/null || true
+    rm -f /etc/systemd/system/sentryusb-ble-le.service 2>/dev/null
+    rm -rf /etc/systemd/system/sentryusb-ble-le.service.d 2>/dev/null
+    systemctl enable bluetooth.service >/dev/null 2>&1 || true
+    systemctl daemon-reload 2>/dev/null || true
+    udevadm control --reload-rules 2>/dev/null || true
+    systemctl enable sentryusb-ble-mode.service >/dev/null 2>&1 || true
+    systemctl enable sentryusb-ble-adv.service >/dev/null 2>&1 || true
+    ok "BLE advertising selector + helper installed (mode gate + advertiser + hci0 udev rule)"
 fi
 
 # ── Step 4: Sample Config ───────────────────────────────────────────

--- a/server/ble/sentryusb-ble.py
+++ b/server/ble/sentryusb-ble.py
@@ -1278,8 +1278,20 @@ def wait_for_adapter(bus, preferred_hci=None, timeout_s=15, poll_interval_s=0.2)
         time.sleep(poll_interval_s)
     return None
 
-def enable_controller_advertising(adapter_path):
-    """Force connectable + bondable + advertising controller flags via btmgmt.
+def ble_adv_mode():
+    """'native' or 'helper' — who owns advertising. Written per boot by
+    select-ble-adv-mode.sh; absent marker => helper (fail-safe)."""
+    try:
+        with open('/run/sentryusb/ble-adv-mode') as f:
+            return 'native' if f.read().strip() == 'native' else 'helper'
+    except Exception:
+        return 'helper'
+
+
+def enable_controller_advertising(adapter_path, advertise=True):
+    """Set connectable + bondable (+ advertising if advertise=True) via btmgmt.
+    advertise=False leaves the global 'advertising' flag OFF so a D-Bus adv or
+    the raw-HCI helper is the sole advertiser.
 
     Kernel mgmt flags persist OFF after some restart paths (crash, manual
     restart, bond-dir reset). On Broadcom (BCM4345, BCM43436) the calls
@@ -1305,7 +1317,8 @@ def enable_controller_advertising(adapter_path):
         return
 
     base_cmd = ['btmgmt', '--index', idx]
-    required = ('connectable', 'bondable', 'advertising')
+    required = ('connectable', 'bondable', 'advertising') if advertise \
+        else ('connectable', 'bondable')
 
     def current_flags(timeout=3):
         try:
@@ -1384,7 +1397,33 @@ def enable_controller_advertising(adapter_path):
     if missing:
         log.warning(f'Controller flags incomplete on {hci}: missing {sorted(missing)}')
     else:
-        log.info(f'Controller flags fully set on {hci}: connectable + bondable + advertising')
+        log.info(f'Controller flags fully set on {hci}: {" + ".join(required)}')
+
+    # advertise=False: actively CLEAR the global 'advertising' flag (a leftover
+    # one — pre-OTA daemon, force-native->helper flip — would compete with the
+    # advertiser). Issue "advertising off" unconditionally (idempotent); a read
+    # returns empty on mgmt timeout, so only a NON-EMPTY read lacking it confirms.
+    if not advertise:
+        cleared = False
+        for attempt in range(1, 4):
+            try:
+                subprocess.run(base_cmd + ['advertising', 'off'], timeout=5,
+                               capture_output=True, check=False,
+                               stdin=subprocess.PIPE)
+            except Exception as e:
+                log.warning(f'btmgmt advertising off attempt {attempt}/3: {e}')
+            flags = current_flags()
+            if flags and 'advertising' not in flags:
+                cleared = True
+                break
+            if attempt < 3:
+                time.sleep(1)
+        if cleared:
+            log.info(f'Cleared advertising flag on {hci} '
+                     '(helper mode: raw-HCI helper is the sole advertiser)')
+        else:
+            log.warning(f'Could not confirm advertising cleared on {hci} — '
+                        'bluetoothd may compete with the raw-HCI helper')
 
 
 def register_ad_cb():
@@ -1589,9 +1628,13 @@ def main():
 
     log.info(f'Using adapter: {adapter_path}')
 
-    # Re-enable controller-level advertising now that BlueZ is provably up
-    # (was a unit ExecStartPre; moved here so the unit reaches active fast).
-    enable_controller_advertising(adapter_path)
+    # Re-enable controller-level flags now that BlueZ is provably up (was a unit
+    # ExecStartPre; moved here so the unit reaches active fast). In helper mode
+    # we set connectable + bondable but NOT advertising — the raw-HCI helper is
+    # the sole advertiser, so bluetoothd advertising here would fight it.
+    adv_mode = ble_adv_mode()
+    log.info(f'BLE advertising mode: {adv_mode}')
+    enable_controller_advertising(adapter_path, advertise=(adv_mode == 'native'))
 
     # Subscribe to BlueZ D-Bus signals so connection events are logged.
     # This makes it possible to see whether iOS actually connects to the Pi
@@ -1657,7 +1700,12 @@ def main():
             reply_handler=register_ad_cb,
             error_handler=register_ad_error_cb)
         return False
-    register_initial_adv()
+    # Helper mode: GATT only — the raw-HCI helper is the sole advertiser.
+    if adv_mode == 'native':
+        register_initial_adv()
+    else:
+        log.info('BLE adv mode=helper: not registering a BlueZ advertisement '
+                 '(sentryusb-ble-adv.sh is the sole advertiser); GATT stays up')
 
     log.info(f'SentryUSB BLE peripheral started: {ble_name}')
     log.info(f'WiFi Setup Service: {WIFI_SERVICE_UUID}')

--- a/setup/pi/apply-runtime-patches.sh
+++ b/setup/pi/apply-runtime-patches.sh
@@ -48,15 +48,24 @@ is_rock_4cplus() {
 # kernel logs on first BT probe (e.g. "Bluetooth: hci0: BCM43430B0 (002.001.012)").
 #
 # Currently:
-#   BCM4345C0 — Rock 4C+ (confirmed broken via field evidence)
+#   BCM4345C0 — Rock 4C+ (confirmed broken via field evidence) AND
+#     Raspberry Pi 4 Model B (confirmed broken via btmon trace 2026-07-25:
+#     "Add Extended Advertising Data (0x0055) → Invalid Parameters (0x0d)";
+#     without the helper only LE Set Advertising Parameters + Enable are
+#     issued — no Set Advertising Data (0x0008) — so the Pi advertises an
+#     EMPTY packet and is undiscoverable by name/UUID). Pi 4B's BT loads
+#     firmware brcm/BCM4345C0.raspberrypi,4-model-b.hcd — same silicon.
 #   BCM43430B0 — Pi Zero 2 W (confirmed broken via btmon trace 2026-06-20)
 #   BCM43438 — Pi 3B/3B+, Pi Zero W (same chip family / same firmware tree)
 #
 # DELIBERATELY EXCLUDED until tested:
-#   BCM43455 / CYW43455 — Pi 4 / Pi 5; their modern bluetoothd path is
-#   reported to work fine, and running our raw-HCI helper there would
-#   override their working ext-adv with legacy adv (regression). If a Pi
-#   4/5 user does hit "GATT 147 bond=BOND_NONE" they can opt in with:
+#   BCM43455 / CYW43455 — Pi 5; its modern bluetoothd path is reported to
+#   work fine, and running our raw-HCI helper there would override its
+#   working ext-adv with legacy adv (regression). (Note: Raspberry Pi 4
+#   Model B was previously excluded here on the assumption it uses
+#   BCM43455 — in the field its BT identifies as BCM4345C0 and rejects
+#   ext-adv, so it is now in the broken list above.) If an excluded board
+#   does hit "GATT 147 bond=BOND_NONE" the operator can opt in with:
 #       sudo touch /mutable/force-ble-adv-helper
 #   That sentinel forces install regardless of chip detection. The next OTA
 #   (or `sudo /usr/local/bin/sentryusb-apply-runtime-patches`) lands it.
@@ -67,9 +76,11 @@ is_known_broken_ble_chip() {
     local chips="BCM4345C0\|BCM43430B0\|BCM43438"
     dmesg 2>/dev/null | grep -qE "hci0: ($chips)" && return 0
     # dmesg may not retain that line on a long-running box; also check the
-    # board model as a backstop (4C+'s 4345C0 + Zero 2 W's 43430B0 are
-    # board-specific so model match is unambiguous).
-    grep -qai 'rock-4c-plus\|rockpi4c-plus\|ROCK 4C+\|Raspberry Pi Zero 2 W\|Raspberry Pi 3 Model B\|Raspberry Pi Zero W' \
+    # board model as a backstop (4C+'s 4345C0, Zero 2 W's 43430B0 and Pi 4B's
+    # 4345C0 are board-specific so model match is unambiguous). Without this,
+    # a Pi 4B whose boot-time "hci0: BCM4345C0" line has rotated out of dmesg
+    # fails detection and never gets the helper — advertising an empty packet.
+    grep -qai 'rock-4c-plus\|rockpi4c-plus\|ROCK 4C+\|Raspberry Pi Zero 2 W\|Raspberry Pi 3 Model B\|Raspberry Pi Zero W\|Raspberry Pi 4 Model B' \
         /proc/device-tree/model 2>/dev/null && return 0
     return 1
 }

--- a/setup/pi/apply-runtime-patches.sh
+++ b/setup/pi/apply-runtime-patches.sh
@@ -69,21 +69,13 @@ is_rock_4cplus() {
 #       sudo touch /mutable/force-ble-adv-helper
 #   That sentinel forces install regardless of chip detection. The next OTA
 #   (or `sudo /usr/local/bin/sentryusb-apply-runtime-patches`) lands it.
-is_known_broken_ble_chip() {
-    # Operator override — for chips we haven't detection-listed yet but
-    # field-confirmed need the helper.
-    [ -f /mutable/force-ble-adv-helper ] && { log "BLE adv: /mutable/force-ble-adv-helper present — forcing install"; return 0; }
-    local chips="BCM4345C0\|BCM43430B0\|BCM43438"
-    dmesg 2>/dev/null | grep -qE "hci0: ($chips)" && return 0
-    # dmesg may not retain that line on a long-running box; also check the
-    # board model as a backstop (4C+'s 4345C0, Zero 2 W's 43430B0 and Pi 4B's
-    # 4345C0 are board-specific so model match is unambiguous). Without this,
-    # a Pi 4B whose boot-time "hci0: BCM4345C0" line has rotated out of dmesg
-    # fails detection and never gets the helper — advertising an empty packet.
-    grep -qai 'rock-4c-plus\|rockpi4c-plus\|ROCK 4C+\|Raspberry Pi Zero 2 W\|Raspberry Pi 3 Model B\|Raspberry Pi Zero W\|Raspberry Pi 4 Model B' \
-        /proc/device-tree/model 2>/dev/null && return 0
-    return 1
-}
+# NOTE: the old is_known_broken_ble_chip() gate was removed here. It keyed on
+# the BT chip (BCM4345C0 et al.), which cannot classify these boards — the
+# working Pi 5, the broken 4C+, and the broken Pi 4B are all BCM4345C0. Whether
+# the helper runs is now decided per-boot by the RF-verified native manifest
+# (select-ble-adv-mode.sh + ble-native-manifest); apply_ble_adv_helper below
+# stages the files on every board and the mode marker gates the advertiser.
+# /mutable/force-ble-adv-helper still works — the selector honors it first.
 
 # ── BLE non-fatal-adv patch (all Broadcom Pi-family chips) ──────────────
 #
@@ -206,53 +198,104 @@ apply_eatt_disable() {
 # is only written when missing OR when the on-disk contents differ from the
 # current upstream version.
 #
-# Files installed:
+# Files installed (staged on every board; the mode marker gates the advertiser):
 #   /usr/local/bin/sentryusb-ble-adv.sh
+#   /usr/local/bin/select-ble-adv-mode.sh
+#   /usr/local/share/sentryusb/ble-native-manifest
 #   /etc/systemd/system/sentryusb-ble-adv.service
+#   /etc/systemd/system/sentryusb-ble-mode.service
 #   /etc/udev/rules.d/99-sentryusb-ble-hci.rules
 #   /etc/systemd/system/sentryusb-ble.service.d/wants-bluetooth.conf
+#   /root/bin/sentryusb-ble.py   (re-fetched whole so existing installs converge)
 apply_ble_adv_helper() {
-    # Gate to known-affected chips so Pi 4/5 (where bluetoothd's modern
-    # ext-adv works) don't get the raw-HCI helper overriding their good
-    # advertising. See is_known_broken_ble_chip above for the full list.
-    is_known_broken_ble_chip || { log "BLE adv: chip not in known-broken list — skipping helper install"; return 0; }
+    # No chip gate: stage everything on every board; the boot-time mode marker
+    # (select-ble-adv-mode.sh + ble-native-manifest) picks the advertiser.
     local repo="${REPO:-Sentry-Six/Sentry-USB-Rusty}"
     local base="https://raw.githubusercontent.com/${repo}/main/setup/pi"
-    local changed=0
+    local ble_base="https://raw.githubusercontent.com/${repo}/main/server/ble"
 
-    install_one() {
-        # $1 = source filename, $2 = destination path, $3 = mode
-        local src="$1" dst="$2" mode="$3"
-        local tmp; tmp="$(mktemp)" || { warn "BLE adv: mktemp failed"; return 1; }
-        if ! curl -fsSL --max-time 15 "$base/$src" -o "$tmp" 2>/dev/null; then
-            rm -f "$tmp"
-            warn "BLE adv: failed to fetch $src — leaving any existing copy alone"
-            return 1
-        fi
-        if [ -f "$dst" ] && cmp -s "$tmp" "$dst"; then
-            rm -f "$tmp"
-            return 0  # already up to date
-        fi
-        [ -x /root/bin/remountfs_rw ] && /root/bin/remountfs_rw >/dev/null 2>&1 || true
-        install -m "$mode" "$tmp" "$dst"
-        rm -f "$tmp"
-        changed=1
-        log "BLE adv: installed/refreshed $dst"
-    }
+    # (url, dst, mode) set. ble.py is re-fetched whole (the mode-gating adds
+    # three edit sites the old in-place patcher can't reliably reach; the repo
+    # copy is the source of truth and already carries the non-fatal-adv fix).
+    local specs=(
+        "$base/sentryusb-ble-adv.sh|/usr/local/bin/sentryusb-ble-adv.sh|755"
+        "$base/select-ble-adv-mode.sh|/usr/local/bin/select-ble-adv-mode.sh|755"
+        "$base/ble-native-manifest|/usr/local/share/sentryusb/ble-native-manifest|644"
+        "$base/sentryusb-ble-adv.service|/etc/systemd/system/sentryusb-ble-adv.service|644"
+        "$base/sentryusb-ble-mode.service|/etc/systemd/system/sentryusb-ble-mode.service|644"
+        "$base/99-sentryusb-ble-hci.rules|/etc/udev/rules.d/99-sentryusb-ble-hci.rules|644"
+        "$base/sentryusb-ble-wants-bluetooth.conf|/etc/systemd/system/sentryusb-ble.service.d/wants-bluetooth.conf|644"
+        "$ble_base/sentryusb-ble.py|/root/bin/sentryusb-ble.py|755"
+    )
 
-    install_one sentryusb-ble-adv.sh /usr/local/bin/sentryusb-ble-adv.sh 755 || return 0
-    install_one sentryusb-ble-adv.service /etc/systemd/system/sentryusb-ble-adv.service 644
-    install_one 99-sentryusb-ble-hci.rules /etc/udev/rules.d/99-sentryusb-ble-hci.rules 644
-    mkdir -p /etc/systemd/system/sentryusb-ble.service.d
-    install_one sentryusb-ble-wants-bluetooth.conf \
-                /etc/systemd/system/sentryusb-ble.service.d/wants-bluetooth.conf 644
+    # All-or-nothing: fetch everything to temp first; any fetch failure aborts
+    # untouched (a half-applied set can dark or dual-own the board).
+    local tmpdir; tmpdir="$(mktemp -d)" || { warn "BLE adv: mktemp -d failed"; return 0; }
+    local -a tmps dsts modes
+    local i=0 spec rest dst mode url
+    for spec in "${specs[@]}"; do
+        url="${spec%%|*}"; rest="${spec#*|}"; dst="${rest%%|*}"; mode="${rest##*|}"
+        if ! curl -fsSL --max-time 15 "$url" -o "$tmpdir/$i" 2>/dev/null; then
+            warn "BLE adv: fetch failed for ${url##*/} — aborting BLE update (no partial apply)"
+            rm -rf "$tmpdir"; return 0
+        fi
+        tmps[i]="$tmpdir/$i"; dsts[i]="$dst"; modes[i]="$mode"; i=$((i+1))
+    done
+
+    # Atomic install: back up changed files / track new ones, and on ANY install
+    # failure roll the whole set back (a mixed set would dark/dual-own on reboot).
+    local changed=0 install_failed=0 n=$i
+    [ -x /root/bin/remountfs_rw ] && /root/bin/remountfs_rw >/dev/null 2>&1 || true
+    local -a bak_files new_files
+    for (( i = 0; i < n; i++ )); do
+        [ -f "${dsts[i]}" ] && cmp -s "${tmps[i]}" "${dsts[i]}" && continue
+        if [ -f "${dsts[i]}" ]; then
+            # Back up before changing; if the backup fails, abort before the
+            # install (can't roll back an untracked change).
+            if cp -p "${dsts[i]}" "${dsts[i]}.subak" 2>/dev/null; then
+                bak_files+=("${dsts[i]}")
+            else
+                rm -f "${dsts[i]}.subak" 2>/dev/null
+                install_failed=1
+                warn "BLE adv: could not back up ${dsts[i]} — aborting before install"
+                break
+            fi
+        else
+            new_files+=("${dsts[i]}")
+        fi
+        if install -D -m "${modes[i]}" "${tmps[i]}" "${dsts[i]}"; then
+            changed=1
+            log "BLE adv: installed/refreshed ${dsts[i]}"
+        else
+            install_failed=1
+            warn "BLE adv: install failed for ${dsts[i]}"
+            break
+        fi
+    done
+    rm -rf "$tmpdir"
+
+    if [ "$install_failed" = "1" ]; then
+        warn "BLE adv: install failed — rolling back to the previous consistent set"
+        for f in "${bak_files[@]}"; do mv -f "$f.subak" "$f" 2>/dev/null || true; done
+        for f in "${new_files[@]}"; do rm -f "$f" 2>/dev/null || true; done
+        return 0
+    fi
+    # Success — discard the backups.
+    for f in "${bak_files[@]}"; do rm -f "$f.subak" 2>/dev/null || true; done
 
     if [ "$changed" = "1" ]; then
         systemctl daemon-reload 2>/dev/null || true
         udevadm control --reload-rules 2>/dev/null || true
-        systemctl enable sentryusb-ble-adv.service >/dev/null 2>&1 || true
+        systemctl enable sentryusb-ble-mode.service >/dev/null 2>&1 || true
+        systemctl enable sentryusb-ble-adv.service  >/dev/null 2>&1 || true
+        # ble.py reads the marker once at startup, so restart it on ANY BLE file
+        # change (a manifest/selector-only change can flip the mode).
+        systemctl restart sentryusb-ble-mode.service 2>/dev/null || \
+            /usr/local/bin/select-ble-adv-mode.sh 2>/dev/null || true
+        systemctl reset-failed sentryusb-ble.service 2>/dev/null || true
+        systemctl restart sentryusb-ble.service 2>/dev/null || true
         systemctl restart sentryusb-ble-adv.service 2>/dev/null || true
-        log "BLE adv: service enabled + restarted"
+        log "BLE adv: gate + advertiser refreshed; mode re-selected; daemons restarted"
     else
         log "BLE adv: all files current, nothing to do"
     fi

--- a/setup/pi/ble-native-manifest
+++ b/setup/pi/ble-native-manifest
@@ -1,0 +1,26 @@
+# SentryUSB BLE native-advertising manifest
+# ---------------------------------------------------------------------------
+# Boards listed here have been RF-VERIFIED to advertise their SentryUSB name
+# over the air using bluetoothd's own advertising (no raw-HCI helper needed).
+# A board NOT matched here runs the helper (fail-safe: discoverable > dark).
+#
+# Allow-list, not a chip gate: chip and BlueZ build both fail to classify these
+# boards (the working Pi 5 and helper-needing Pi 4B are the same chip + same
+# bluetoothd binary). Only board model + kernel family separates them.
+#
+# FORMAT:  <model-substring>|<kernel-family-substring>
+#   A board is NATIVE when /proc/device-tree/model contains <model-substring>
+#   AND `uname -r` contains <kernel-family-substring>. Substring (not exact
+#   version) so a kernel point-update on an existing install stays native.
+#   Lines starting with # and blank lines are ignored.
+#
+# Adding a board: RF-confirm on a second BLE receiver that it advertises the
+#   name with the helper OFF, then add its model + kernel-family here.
+#   Never add a bare chip or a family wildcard — that is the original bug.
+
+# Raspberry Pi 5 — rpt BlueZ build; RF-confirmed to advertise the name natively.
+Raspberry Pi 5|+rpt-rpi
+
+# Radxa ZERO 3 (AIC8800) — RF-confirmed native. (Separate AIC8800 dark-after-
+# restart quirk is handled by its own reboot-recovery path, not here.)
+Radxa ZERO 3|vendor-rk35xx

--- a/setup/pi/select-ble-adv-mode.sh
+++ b/setup/pi/select-ble-adv-mode.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# BLE advertising-mode selector — once per boot, writes /run/.../ble-adv-mode
+# (native|helper) read by sentryusb-ble.py + the helper. Positive allow-list
+# against ble-native-manifest (a controller probe can't classify — it reports
+# host-side success while radiating nothing). Read-only, safe pre-BLE-services.
+# Precedence: force-ble-adv-helper > force-ble-adv-native > manifest > helper.
+set -u
+
+MARKER_DIR=/run/sentryusb
+MARKER="$MARKER_DIR/ble-adv-mode"        # ephemeral: "native" | "helper"
+LAST=/mutable/ble-adv-gate.last          # human-readable audit trail
+FORCE_HELPER=/mutable/force-ble-adv-helper
+FORCE_NATIVE=/mutable/force-ble-adv-native
+MANIFEST="${BLE_NATIVE_MANIFEST:-/usr/local/share/sentryusb/ble-native-manifest}"
+
+log() { echo "ble-adv-gate: $*"; }
+
+mkdir -p "$MARKER_DIR" 2>/dev/null
+
+model="$(tr -d '\0' </proc/device-tree/model 2>/dev/null)"
+kernel="$(uname -r)"
+btd="$(command -v bluetoothd 2>/dev/null)"
+btd_sha="$( [ -n "$btd" ] && sha256sum "$btd" 2>/dev/null | cut -c1-16 )"
+
+decide() {
+    # 1) operator overrides win over everything, helper before native.
+    if [ -f "$FORCE_HELPER" ]; then echo "helper force-helper"; return; fi
+    if [ -f "$FORCE_NATIVE" ]; then echo "native force-native"; return; fi
+
+    # 2) positive manifest match: model-substring AND kernel-family-substring.
+    if [ -r "$MANIFEST" ]; then
+        while IFS= read -r line; do
+            case "$line" in ''|\#*) continue;; esac
+            local msub ksub
+            msub="${line%%|*}"
+            ksub="${line#*|}"
+            [ -z "$msub" ] || [ -z "$ksub" ] && continue
+            case "$model" in *"$msub"*)
+                case "$kernel" in *"$ksub"*)
+                    echo "native manifest:$msub|$ksub"; return;;
+                esac;;
+            esac
+        done < "$MANIFEST"
+    else
+        log "manifest $MANIFEST unreadable — defaulting to helper"
+    fi
+
+    # 3) fail-safe.
+    echo "helper default"
+}
+
+read -r mode reason <<<"$(decide)"
+[ -z "${mode:-}" ] && { mode=helper; reason=error-fallback; }   # never leave undecided
+
+# Atomic write; on failure fall back to remove-then-overwrite-helper so a stale
+# 'native' can't survive (absence => helper). Loud CRITICAL if /run is unwritable.
+tmp="$MARKER.tmp.$$"
+if printf '%s\n' "$mode" > "$tmp" 2>/dev/null && mv -f "$tmp" "$MARKER" 2>/dev/null; then
+    :
+else
+    rm -f "$tmp" 2>/dev/null
+    if rm -f "$MARKER" 2>/dev/null || printf 'helper\n' > "$MARKER" 2>/dev/null; then
+        log "marker write failed — forced fail-safe (absent or helper)"
+    else
+        log "CRITICAL: cannot write OR clear $MARKER — /run unwritable; a stale mode may persist until reboot"
+        exit 1
+    fi
+fi
+
+log "mode=$mode reason=$reason model='$model' kernel='$kernel' btd_sha=${btd_sha:-?}"
+# Best-effort audit copy on /mutable (never fatal on RO / missing mount).
+{ printf 'mode=%s reason=%s model=%s kernel=%s btd_sha=%s\n' \
+    "$mode" "$reason" "$model" "$kernel" "${btd_sha:-?}" > "$LAST"; } 2>/dev/null || true
+
+exit 0

--- a/setup/pi/sentryusb-ble-adv.service
+++ b/setup/pi/sentryusb-ble-adv.service
@@ -1,13 +1,16 @@
 [Unit]
-Description=SentryUSB: legacy LE advertising (Broadcom Pi-family chip workaround)
-After=bluetooth.service sentryusb-ble.service
+Description=SentryUSB: legacy LE advertising (raw-HCI advertiser for helper-mode boards)
+After=bluetooth.service sentryusb-ble.service sentryusb-ble-mode.service
 Wants=bluetooth.service
 BindsTo=sentryusb-ble.service
 
 [Service]
 Type=simple
 ExecStart=/usr/local/bin/sentryusb-ble-adv.sh
-Restart=always
+# on-failure, NOT always: the script exits 0 on native-mode boards (bluetoothd
+# owns advertising there). Restart=always would restart-loop that clean exit
+# every 10s. A crash still restarts; a clean native standdown stays stopped.
+Restart=on-failure
 RestartSec=10
 
 [Install]

--- a/setup/pi/sentryusb-ble-adv.sh
+++ b/setup/pi/sentryusb-ble-adv.sh
@@ -55,6 +55,19 @@ connect_in_flight() {
     [ "$age" -ge 0 ] && [ "$age" -lt "$CONNECTING_FLAG_MAX_AGE" ]
 }
 
+# True only when a central (a phone) is connected TO us — i.e. we hold a
+# PERIPHERAL-role LE link. The Tesla keep-awake link is the OPPOSITE: the Pi
+# dials out to the car, so it is a CENTRAL-role link. That link must NOT
+# suppress advertising, otherwise the Pi is undiscoverable to the phone the
+# whole time keep-awake holds the car connection (the in-app "connect over
+# Bluetooth" step then fails). The controller does advertising + an outbound
+# central link simultaneously without issue (field-verified: asserting adv
+# while the car link is up left the car link intact). hcitool reports the
+# LOCAL role as "lm PERIPHERAL" (older BlueZ: "lm SLAVE").
+peripheral_link_up() {
+    hcitool con 2>/dev/null | grep -qiE 'lm (PERIPHERAL|SLAVE)'
+}
+
 # Run the advertising loop ONLY when executed directly (the systemd ExecStart),
 # never when sourced — otherwise testing build_scanrsp() would loop forever.
 if [ "${BASH_SOURCE[0]}" != "${0}" ]; then
@@ -66,8 +79,12 @@ sleep 3   # let bluetoothd's (failing) ext-adv RegisterAdvertisement settle firs
 timeout 5 btmgmt le on >/dev/null 2>&1 || true
 timeout 5 btmgmt connectable on >/dev/null 2>&1 || true
 while true; do
-    # Re-assert only while IDLE and no central connect is in flight.
-    if ! connect_in_flight && ! timeout 3 btmgmt con 2>/dev/null | grep -q 'type LE'; then
+    # Re-assert while IDLE: skip only while a phone connect is in flight, or a
+    # phone is already connected (a PERIPHERAL-role link). Do NOT skip merely
+    # because an LE connection exists — the Tesla keep-awake is a CENTRAL-role
+    # link and must not silence advertising, or the phone can never discover us
+    # while the car is awake.
+    if ! connect_in_flight && ! peripheral_link_up; then
         assert_raw_adv
     fi
     sleep 5

--- a/setup/pi/sentryusb-ble-adv.sh
+++ b/setup/pi/sentryusb-ble-adv.sh
@@ -18,14 +18,21 @@ ADV_DATA="15 02 01 06 11 07 ${UUID_LE} 00 00 00 00 00 00 00 00 00 00 00 00 00"
 # Scan-response bytes = [len][0x09 Complete Local Name][name…]. Function is
 # defined before the run-guard so it's sourceable for unit-style testing.
 build_scanrsp() {
-    local name hex namebytes len
-    name=$(timeout 5 btmgmt info 2>/dev/null | sed -n 's/^[[:space:]]*name[[:space:]]*//p' | head -1)
+    local name hex namebytes adlen siglen pad i
+    # `printf '' |` closes stdin — under systemd a bare `btmgmt info` busy-loops
+    # on /dev/null and returns empty (→ hostname fallback). Closed pipe = EOF.
+    name=$(printf '' | timeout 5 btmgmt info 2>/dev/null | sed -n 's/^[[:space:]]*name[[:space:]]*//p' | head -1)
     [ -z "$name" ] && name=$(hostname)
     name=${name:0:29}                                   # scan-rsp budget: 31 - 2 (len+type)
     hex=$(printf '%s' "$name" | od -An -tx1 | tr -d ' \n')
     namebytes=$(( ${#hex} / 2 ))
-    len=$(( namebytes + 1 ))                             # +1 for the AD type byte
-    printf '%02x 09 %s' "$len" "$(echo "$hex" | sed 's/../& /g')"
+    adlen=$(( namebytes + 1 ))                           # AD length: type byte + name
+    siglen=$(( adlen + 1 ))                              # significant bytes in the 31-byte field
+    pad=$(( 31 - siglen ))                               # zero-fill the rest of the 31-byte field
+    # LE Set Scan Response Data needs EXACTLY 32 bytes: [siglen][31-byte data].
+    # Zero-pad by name length — a fixed pad overruns and strict controllers reject it.
+    printf '%02x %02x 09 %s' "$siglen" "$adlen" "$(echo "$hex" | sed 's/../& /g')"
+    local i; for (( i = 0; i < pad; i++ )); do printf ' 00'; done
 }
 
 # Program legacy ADV_IND directly via HCI (bypasses BlueZ mgmt):
@@ -39,7 +46,9 @@ assert_raw_adv() {
     local scanrsp; scanrsp=$(build_scanrsp)
     hcitool -i hci0 cmd 0x08 0x000a 00 >/dev/null 2>&1 || true
     hcitool -i hci0 cmd 0x08 0x0008 $ADV_DATA >/dev/null 2>&1 || true
-    hcitool -i hci0 cmd 0x08 0x0009 $scanrsp 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 >/dev/null 2>&1 || true
+    # build_scanrsp already emits the full 32 bytes (sig-length + 31-byte data,
+    # zero-padded) — do NOT append more zeros here or the param exceeds 32.
+    hcitool -i hci0 cmd 0x08 0x0009 $scanrsp >/dev/null 2>&1 || true
     hcitool -i hci0 cmd 0x08 0x0006 a0 00 a0 00 00 00 00 00 00 00 00 00 00 07 00 >/dev/null 2>&1 || true
     # Re-check right before enabling so we never re-arm advertising mid-connect.
     connect_in_flight && return 0
@@ -72,6 +81,15 @@ peripheral_link_up() {
 # never when sourced — otherwise testing build_scanrsp() would loop forever.
 if [ "${BASH_SOURCE[0]}" != "${0}" ]; then
     return 0 2>/dev/null || exit 0
+fi
+
+# Advertising-mode gate: on boards RF-qualified to advertise natively,
+# bluetoothd owns advertising and this helper must stand down or the two fight
+# over the controller. select-ble-adv-mode.sh writes the marker each boot;
+# absence means "helper" (fail-safe), so a missing marker still advertises.
+if [ "$(cat /run/sentryusb/ble-adv-mode 2>/dev/null)" = "native" ]; then
+    echo "sentryusb-ble-adv: native mode — bluetoothd owns advertising, standing down"
+    exit 0
 fi
 
 for i in $(seq 1 30); do busctl status org.bluez >/dev/null 2>&1 && break; sleep 1; done

--- a/setup/pi/sentryusb-ble-mode.service
+++ b/setup/pi/sentryusb-ble-mode.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=SentryUSB: select BLE advertising mode (native vs helper)
+# Reads only /proc/device-tree/model + uname; touches neither bluetoothd nor
+# the controller, so it needs nothing from bluetooth.service and can run early.
+# Must complete before either BLE service so the mode marker exists when they
+# start. The marker lives on /run (tmpfs) and is rebuilt every boot.
+DefaultDependencies=no
+After=local-fs.target
+Before=sentryusb-ble.service sentryusb-ble-adv.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/bin/select-ble-adv-mode.sh
+# Never block boot on a selector fault — absence of the marker means "helper",
+# which is the safe default, so a failure here still yields a discoverable Pi.
+SuccessExitStatus=0 1
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=sentryusb-ble-gate
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

Replaces the BLE advertising **chip-name install gate** with a positive,
RF-verified **native manifest**, and makes helper-mode boards single-owner
advertisers. Supersedes #174 — builds on its raw-HCI advertiser and keep-awake
fix (the two commits beneath).

## Why the chip gate is wrong

Behaviour across four boards:

| board | chip | BlueZ | advertises name natively? |
|-------|------|-------|---------------------------|
| Pi 5 | BCM4345C0 | rpt 5.82 | yes |
| Radxa ZERO 3 | AIC8800 | Radxa Debian 5.82 | yes |
| Rock 4C+ | BCM4345C0 | Radxa Debian 5.82 | no (0x0055 Success, name never emits) |
| Pi 4B | BCM4345C0 | rpt 5.82 | no (0x0055 → 0x0d) |

Neither chip nor BlueZ build classifies these boards. The Pi 5 and the Pi 4B are
both BCM4345C0 and ship the **identical bluetoothd binary** on the same kernel
family, yet only the Pi 5 advertises. The native Radxa ZERO 3 ships the identical
bluetoothd binary as the helper-needing 4C+. Only the whole stack — **board model
\+ kernel family** — separates them.

A runtime probe can't substitute: a board can accept `RegisterAdvertisement`,
program the name into the HCI scan-response, and return Success while radiating
nothing (observed on the 4C+). There is no HCI read-back of what the radio
actually transmitted. Hence a positive allow-list.

## What changes

- **`select-ble-adv-mode.sh`** writes a per-boot `/run` marker from
  **`ble-native-manifest`** (`sentryusb-ble-mode.service`, before the BLE
  services). `sentryusb-ble.py` and the helper read it. Fail-safe: no marker ⇒
  helper (discoverable beats dark). Overrides: `/mutable/force-ble-adv-helper`
  (kept) and `force-ble-adv-native` (new).
- **Single-owner:** helper-mode boards run bluetoothd GATT + connectable only —
  it skips the global advertising flag, clears a stale one, and skips
  `RegisterAdvertisement`; the raw-HCI helper is the sole advertiser. Native
  boards are unchanged.
- **`build_scanrsp`** reads the real controller name under systemd (closed
  stdin; was falling back to the hostname) and emits exactly 32 scan-response
  bytes (was a fixed pad that overran for some name lengths).
- Ships selector + manifest + helper on every board (inert on native);
  `apply-runtime-patches` deploys them all-or-nothing and re-fetches
  `sentryusb-ble.py` so existing installs converge on OTA. Removed the dead
  `is_known_broken_ble_chip`.

## Phone pairing

Advertising-side only. GATT services/characteristics, the device address, and
the advertised service UUID are unchanged, so already-paired phones reconnect
normally. Only the local-name presence and which process owns advertising change.

## Native manifest

- Raspberry Pi 5 — `Raspberry Pi 5` / `+rpt-rpi`
- Radxa ZERO 3 — `Radxa ZERO 3` / `vendor-rk35xx`

Everything else → helper. New native boards are added only after confirming on a
second receiver that the name reaches the air with the helper off.

## Testing

- Classifier buckets all four boards above correctly.
- `build_scanrsp` emits exactly 32 bytes for name lengths 1–29.
- Shell `bash -n` + `python -m py_compile` clean.
- Name emission confirmed on a live 4C+ (name on air; app connects over BLE).
