### PR TITLE
ble: helper honors BLE_ADAPTER (external BLE dongle no longer discoverable-but-unconnectable)

### DIFF
--- a/server/ble/sentryusb-ble.py
+++ b/server/ble/sentryusb-ble.py
@@ -1211,21 +1211,28 @@ def read_ble_adapter_from_config():
                     continue
                 key, _, value = line.partition('=')
                 if key.strip() == 'BLE_ADAPTER':
-                    val = value.strip().strip('"').strip("'")
-                    return val if val else None
+                    # Strip only ASCII whitespace to match the shell's C-locale
+                    # [[:space:]]; a unicode space (e.g. NBSP) then survives,
+                    # fails the hci/digit test, and falls to the hci0 default.
+                    _ws = ' \t\n\r\f\v'
+                    val = value.strip(_ws).strip('"').strip("'").strip(_ws)
+                    # ASCII-only so a unicode digit can't diverge the two.
+                    if val[:3] == 'hci' and val[3:].isascii() and val[3:].isdigit():
+                        return val
+                    if val.isascii() and val.isdigit():
+                        return 'hci' + val
+                    return None
     except (IOError, OSError):
         pass
     return None
 
 
-def find_adapter(bus, preferred_hci=None):
-    """Find a Bluetooth adapter that supports LE.
-
-    If `preferred_hci` (e.g. 'hci1') is set and that adapter exists
-    and supports LE, returns it. Otherwise falls back to the first
-    LE-capable adapter found. The fallback path means that if an
-    external dongle is unplugged after being configured, we don't
-    crash — we just quietly use the onboard radio instead.
+def find_adapter(bus, preferred_hci=None, allow_fallback=True):
+    """Find an LE-capable adapter. With preferred_hci set: return it if present;
+    else allow_fallback=True uses the first LE adapter (dongle unplugged, don't
+    crash), allow_fallback=False returns None so the caller waits for it. The
+    wait avoids splitting GATT from the raw-HCI helper (which pins the configured
+    adapter) across radios.
     """
     remote_om = dbus.Interface(
         bus.get_object(BLUEZ_SERVICE, '/'), DBUS_OM_IFACE)
@@ -1238,11 +1245,19 @@ def find_adapter(bus, preferred_hci=None):
         wanted = f'/org/bluez/{preferred_hci}'
         if wanted in le_paths:
             return wanted
+        if not allow_fallback:
+            return None
         log.warning(
             f'Preferred BLE adapter {preferred_hci} not found among '
             f'{[p.rsplit("/", 1)[-1] for p in le_paths]} — falling back'
         )
-    return le_paths[0] if le_paths else None
+        return le_paths[0] if le_paths else None
+    # No preference (unset or unparseable -> None): prefer hci0 deterministically
+    # so it matches the shell helper's hci0 default; a garbage config on a
+    # multi-radio board can't pin GATT to a different radio than the helper.
+    if not le_paths:
+        return None
+    return '/org/bluez/hci0' if '/org/bluez/hci0' in le_paths else le_paths[0]
 
 
 def wait_for_adapter(bus, preferred_hci=None, timeout_s=15, poll_interval_s=0.2):
@@ -1265,7 +1280,9 @@ def wait_for_adapter(bus, preferred_hci=None, timeout_s=15, poll_interval_s=0.2)
     last_log = 0.0
     while time.time() < deadline:
         try:
-            path = find_adapter(bus, preferred_hci=preferred_hci)
+            # Wait for the configured adapter (no fallback) so a late-enumerating
+            # dongle is used, not hci0.
+            path = find_adapter(bus, preferred_hci=preferred_hci, allow_fallback=False)
         except dbus.exceptions.DBusException:
             # org.bluez not on the bus yet — BlueZ still coming up.
             path = None
@@ -1276,6 +1293,8 @@ def wait_for_adapter(bus, preferred_hci=None, timeout_s=15, poll_interval_s=0.2)
             log.info(f'Waiting for BlueZ adapter... ({remaining}s remaining)')
             last_log = time.time()
         time.sleep(poll_interval_s)
+    # Timed out: return None (main exits -> systemd re-waits) rather than use a
+    # different adapter than configured. Onboard returned inside the loop already.
     return None
 
 def ble_adv_mode():

--- a/setup/pi/99-sentryusb-ble-hci.rules
+++ b/setup/pi/99-sentryusb-ble-hci.rules
@@ -1,6 +1,5 @@
-# Broadcom Pi-family chips: the UART BT controller attaches a few seconds into
-# boot, AFTER systemd checks bluetooth.service's ConditionPathIsDirectory, so
-# the BLE stack is skipped on a cold boot. Start it the moment hci0 appears
-# (condition now passes; the daemon's Wants= pulls bluetooth.service + the
-# advertising helper).
-ACTION=="add", SUBSYSTEM=="bluetooth", KERNEL=="hci0", TAG+="systemd", ENV{SYSTEMD_WANTS}+="sentryusb-ble.service"
+# The UART BT controller attaches a few seconds into boot, after systemd checks
+# bluetooth.service's condition, so the BLE stack is skipped on cold boot. Start
+# it when the controller appears. Match hci* so a USB dongle (hci1) triggers it
+# too, not just onboard hci0.
+ACTION=="add", SUBSYSTEM=="bluetooth", KERNEL=="hci*", TAG+="systemd", ENV{SYSTEMD_WANTS}+="sentryusb-ble.service"

--- a/setup/pi/sentryusb-ble-adv.sh
+++ b/setup/pi/sentryusb-ble-adv.sh
@@ -15,13 +15,33 @@ CONNECTING_FLAG_MAX_AGE=15   # seconds; ignore a stale flag a crashed connect le
 UUID_LE="9e ca dc 24 0e e5 a9 e0 93 f3 a3 b5 01 00 40 6e"   # 6e400001-b5a3-f393-e0a9-e50e24dcca9e, little-endian
 ADV_DATA="15 02 01 06 11 07 ${UUID_LE} 00 00 00 00 00 00 00 00 00 00 00 00 00"
 
+# Advertise on the adapter GATT uses: BLE_ADAPTER=hciN from sentryusb.conf,
+# default hci0. Normalized like ble.py's read_ble_adapter_from_config (first
+# line wins; "hciN" or bare "N" -> hciN; else hci0).
+_cfg=$(sed -n 's/^[[:space:]]*BLE_ADAPTER[[:space:]]*=[[:space:]]*//p' /root/sentryusb.conf 2>/dev/null | head -1)
+# Match ble.py's value.strip().strip('"').strip("'").strip(): trim edge
+# whitespace, then all edge " then all edge ' (each independently), then edge ws.
+_cfg=${_cfg%"${_cfg##*[![:space:]]}"}
+while case "$_cfg" in \"*) true ;; *) false ;; esac; do _cfg=${_cfg#\"}; done
+while case "$_cfg" in *\") true ;; *) false ;; esac; do _cfg=${_cfg%\"}; done
+while case "$_cfg" in \'*) true ;; *) false ;; esac; do _cfg=${_cfg#\'}; done
+while case "$_cfg" in *\') true ;; *) false ;; esac; do _cfg=${_cfg%\'}; done
+_cfg=${_cfg%"${_cfg##*[![:space:]]}"}   # trailing whitespace
+_cfg=${_cfg#"${_cfg%%[![:space:]]*}"}   # leading whitespace (ble.py's final .strip())
+case "$_cfg" in
+    hci[0-9]*) HCI="$_cfg" ;;
+    [0-9]*)    HCI="hci$_cfg" ;;
+    *)         HCI=hci0 ;;
+esac
+IDX="${HCI#hci}"; case "$IDX" in ''|*[!0-9]*) HCI=hci0; IDX=0 ;; esac
+
 # Scan-response bytes = [len][0x09 Complete Local Name][name…]. Function is
 # defined before the run-guard so it's sourceable for unit-style testing.
 build_scanrsp() {
     local name hex namebytes adlen siglen pad i
     # `printf '' |` closes stdin — under systemd a bare `btmgmt info` busy-loops
     # on /dev/null and returns empty (→ hostname fallback). Closed pipe = EOF.
-    name=$(printf '' | timeout 5 btmgmt info 2>/dev/null | sed -n 's/^[[:space:]]*name[[:space:]]*//p' | head -1)
+    name=$(printf '' | timeout 5 btmgmt --index "$IDX" info 2>/dev/null | sed -n 's/^[[:space:]]*name[[:space:]]*//p' | head -1)
     [ -z "$name" ] && name=$(hostname)
     name=${name:0:29}                                   # scan-rsp budget: 31 - 2 (len+type)
     hex=$(printf '%s' "$name" | od -An -tx1 | tr -d ' \n')
@@ -44,15 +64,15 @@ build_scanrsp() {
 # logging "GATT 147 bond=BOND_NONE" 10s into the attempt.
 assert_raw_adv() {
     local scanrsp; scanrsp=$(build_scanrsp)
-    hcitool -i hci0 cmd 0x08 0x000a 00 >/dev/null 2>&1 || true
-    hcitool -i hci0 cmd 0x08 0x0008 $ADV_DATA >/dev/null 2>&1 || true
+    hcitool -i "$HCI" cmd 0x08 0x000a 00 >/dev/null 2>&1 || true
+    hcitool -i "$HCI" cmd 0x08 0x0008 $ADV_DATA >/dev/null 2>&1 || true
     # build_scanrsp already emits the full 32 bytes (sig-length + 31-byte data,
     # zero-padded) — do NOT append more zeros here or the param exceeds 32.
-    hcitool -i hci0 cmd 0x08 0x0009 $scanrsp >/dev/null 2>&1 || true
-    hcitool -i hci0 cmd 0x08 0x0006 a0 00 a0 00 00 00 00 00 00 00 00 00 00 07 00 >/dev/null 2>&1 || true
+    hcitool -i "$HCI" cmd 0x08 0x0009 $scanrsp >/dev/null 2>&1 || true
+    hcitool -i "$HCI" cmd 0x08 0x0006 a0 00 a0 00 00 00 00 00 00 00 00 00 00 07 00 >/dev/null 2>&1 || true
     # Re-check right before enabling so we never re-arm advertising mid-connect.
     connect_in_flight && return 0
-    hcitool -i hci0 cmd 0x08 0x000a 01 >/dev/null 2>&1 || true
+    hcitool -i "$HCI" cmd 0x08 0x000a 01 >/dev/null 2>&1 || true
 }
 
 # True while a central connect is in flight (flag fresh within max-age).
@@ -74,7 +94,7 @@ connect_in_flight() {
 # while the car link is up left the car link intact). hcitool reports the
 # LOCAL role as "lm PERIPHERAL" (older BlueZ: "lm SLAVE").
 peripheral_link_up() {
-    hcitool con 2>/dev/null | grep -qiE 'lm (PERIPHERAL|SLAVE)'
+    hcitool -i "$HCI" con 2>/dev/null | grep -qiE 'lm (PERIPHERAL|SLAVE)'
 }
 
 # Run the advertising loop ONLY when executed directly (the systemd ExecStart),
@@ -94,8 +114,8 @@ fi
 
 for i in $(seq 1 30); do busctl status org.bluez >/dev/null 2>&1 && break; sleep 1; done
 sleep 3   # let bluetoothd's (failing) ext-adv RegisterAdvertisement settle first
-timeout 5 btmgmt le on >/dev/null 2>&1 || true
-timeout 5 btmgmt connectable on >/dev/null 2>&1 || true
+timeout 5 btmgmt --index "$IDX" le on >/dev/null 2>&1 || true
+timeout 5 btmgmt --index "$IDX" connectable on >/dev/null 2>&1 || true
 while true; do
     # Re-assert while IDLE: skip only while a phone connect is in flight, or a
     # phone is already connected (a PERIPHERAL-role link). Do NOT skip merely


### PR DESCRIPTION
Follow-up to #176/#177. A gap flagged during review of that merge: `sentryusb-ble-adv.sh` (the raw-HCI legacy advertiser) hardcoded `hci0` in every `hcitool`/`btmgmt` call, while `ble.py` honors `BLE_ADAPTER=hciN` from `/root/sentryusb.conf`.

**Symptom:** on a board with an external USB BLE dongle configured as `BLE_ADAPTER=hci1`, GATT ran on the dongle (hci1) but advertising went out on the onboard radio (hci0). The device showed up in a phone scan but connect attempts failed — discoverable but unconnectable.

### Fixes
- **Helper honors `BLE_ADAPTER`** — reads the same config value `ble.py` does, and uses `hcitool -i "$HCI"` / `btmgmt --index "$IDX"` everywhere instead of the hardcoded onboard radio.
- **Identical normalization on both sides** — the shell parse now mirrors `read_ble_adapter_from_config` step for step (first line wins; edge quotes and whitespace stripped; ASCII `hciN` or bare `N` → `hciN`; anything else → `hci0`). Both strip **ASCII whitespace only**, so a stray unicode space (e.g. a non-breaking space pasted into the config) fails the check on both sides and falls to the `hci0` default rather than resolving differently.
- **Deterministic default** — with no valid preference, adapter selection prefers `hci0` (was "first enumerated adapter"), matching the shell. A garbage config value on a multi-radio board can no longer pin GATT to a different radio than the advertiser.
- **udev rule widened** — `99-sentryusb-ble-hci.rules` matched `KERNEL=="hci0"` only; now `hci*`, so a dongle's `hci1` also triggers the boot-race service start.
- **No cross-radio fallback while waiting** — `find_adapter`/`wait_for_adapter` no longer fall back to `hci0` while waiting for a configured adapter, nor after timeout; `main()` exits and systemd re-waits, so GATT never lands on a different radio than the advertiser.

### Scope
Onboard-BT Pi fleet is unaffected: with `BLE_ADAPTER` unset both paths resolve to `hci0`, exactly as before. Only boards that set `BLE_ADAPTER=hciN` (external dongle) change behavior — and for them, from broken to working.

Parse agreement verified across the full edge matrix (valid, quoted, whitespace-wrapped, garbage, comment, and unicode-whitespace inputs) — shell and Python resolve every input to the same adapter.