### PR TITLE
ble: native mode retries advertisement registration (no more dark-until-restart)

### DIFF
--- a/server/ble/sentryusb-ble.py
+++ b/server/ble/sentryusb-ble.py
@@ -1178,12 +1178,23 @@ class Advertisement(dbus.service.Object):
                 error_handler=on_gatt_err)
 
         def on_reregister_error(error):
+            # A half-registered advert answers AlreadyExists — we ARE advertising.
+            if 'AlreadyExists' in str(error):
+                log.info('Advertisement already registered — treating as success')
+                on_success()
+                return
             if retry_count < max_retries:
                 delay = min(2000 * (2 ** retry_count), 30000)  # exponential backoff, max 30s
                 log.warning(f'Advertisement re-registration failed (attempt {retry_count + 1}/{max_retries + 1}): {error} — retrying in {delay}ms')
                 GLib.timeout_add(delay, self._reregister, retry_count + 1)
             else:
-                log.error(f'Advertisement re-registration failed after {max_retries + 1} attempts: {error} — GATT server still running but Pi is not discoverable')
+                # Keep retrying at 60s — never leave the board undiscoverable
+                # while the daemon lives.
+                if retry_count == max_retries:
+                    log.error(f'Advertisement re-registration failed after {max_retries + 1} attempts: {error} — retrying every 60s until it lands')
+                else:
+                    log.info(f'Advertisement re-registration still failing: {error} — next retry in 60s')
+                GLib.timeout_add(60000, self._reregister, retry_count + 1)
 
         self.ad_manager.RegisterAdvertisement(
             self.get_path(), {},
@@ -1447,14 +1458,6 @@ def enable_controller_advertising(adapter_path, advertise=True):
 def register_ad_cb():
     log.info('Advertisement registered')
 
-def register_ad_error_cb(error):
-    # BCM4345C0 (Rock 4C+): BlueZ uses EXTENDED advertising which this chip
-    # rejects ('Invalid Parameters 0x0d'). Do NOT exit (that tears down GATT
-    # and loops forever); keep GATT up. Legacy btmgmt advertising is enabled
-    # out-of-band by sentryusb-ble-adv.service.
-    log.warning(f'BlueZ advertisement registration failed ({error}); '
-                'using legacy btmgmt advertising instead; GATT stays up.')
-
 def register_app_cb():
     log.info('GATT application registered')
 
@@ -1713,10 +1716,15 @@ def main():
             log.info('Initial advertisement deferred: central connect in flight')
             GLib.timeout_add(1000, register_initial_adv)
             return False
+        def on_initial_error(error):
+            # Transient BlueZ failure at boot must not leave the board dark until
+            # a daemon restart — reuse the Release-path retry machinery.
+            log.warning(f'Initial advertisement registration failed ({error}) — scheduling retries; GATT stays up')
+            GLib.timeout_add(2000, adv._reregister)
         ad_manager.RegisterAdvertisement(
             adv.get_path(), {},
             reply_handler=register_ad_cb,
-            error_handler=register_ad_error_cb)
+            error_handler=on_initial_error)
         return False
     # Helper mode: GATT only — the raw-HCI helper is the sole advertiser.
     if adv_mode == 'native':

--- a/setup/pi/apply-runtime-patches.sh
+++ b/setup/pi/apply-runtime-patches.sh
@@ -98,6 +98,12 @@ apply_ble_nonfatal_adv() {
         log "BLE non-fatal-adv: already patched"
         return 0
     fi
+    # Newer ble.py removed register_ad_error_cb entirely (native mode retries
+    # registration itself) — nothing to patch.
+    if ! grep -q 'def register_ad_error_cb' "$f"; then
+        log "BLE non-fatal-adv: obsolete on this build (retry built in)"
+        return 0
+    fi
 
     # Make root RW for the write (no-op if already RW). Shipped by
     # install-pi.sh; safe to call here.

--- a/setup/pi/sentryusb-ble-adv.sh
+++ b/setup/pi/sentryusb-ble-adv.sh
@@ -9,6 +9,9 @@
 # local name MUST appear in the scan response (BlueZ doesn't include the
 # name in this path by default, hence the explicit scan-rsp builder below).
 # Fresh flag = a central connect is in flight; don't re-assert advertising then.
+# C locale so [[:space:]] and case classes stay ASCII-only, matching ble.py's
+# ASCII strip (under UTF-8 a NBSP in BLE_ADAPTER would diverge the two parsers).
+export LC_ALL=C
 CONNECTING_FLAG="/tmp/ble_connecting"
 CONNECTING_FLAG_MAX_AGE=15   # seconds; ignore a stale flag a crashed connect left behind
 


### PR DESCRIPTION
Follow-up to #176–#178 — the remaining item from that review series ("Issue B"): in native advertising mode, a **failed initial `RegisterAdvertisement` was terminal**. The error callback logged a stale helper-era warning and gave up, so a transient BlueZ failure at boot left the board undiscoverable until the daemon restarted. The `Release`-path retry machinery existed but hard-stopped after 5 attempts (~1 min) — same terminal darkness, one layer up.

### Changes
- **Initial registration errors route into the existing `_reregister` machinery** (connect-in-flight deferral, 2s→30s exponential backoff) instead of the give-up callback.
- **`_reregister` no longer gives up:** after the fast backoff it drops to a 60s cadence for as long as the daemon lives — one error-level line on entering slow mode, info-level after (≤1 line/min for journald). An undiscoverable board is never the steady state.
- **`AlreadyExists` on a retry = success** — a half-registered advert is an advertising advert. This also makes concurrent retry chains (initial-error + Release overlapping) self-terminating: the loser sees `AlreadyExists` and stops scheduling.
- **`register_ad_error_cb` removed**; its legacy OTA runtime patch in `apply-runtime-patches.sh` now no-ops cleanly when the function no longer exists (previously it would report "BOTH patch paths failed" on every new build).
- **`sentryusb-ble-adv.sh` pins `LC_ALL=C`** — closes the review footnote from #178: under a UTF-8 locale `[[:space:]]` matches a non-breaking space, diverging the shell's `BLE_ADAPTER` parse from the daemon's ASCII-only strip. Also keeps the 31-byte scan-response budget byte-oriented.

### Scope
Helper-mode boards (Pi 4B, Rock 4C+): zero behavior change — they never register a D-Bus advertisement, so neither the error path nor `Release` can fire. Native-mode boards (Pi 5, Radxa Zero 3) change from "dark until restart" to "retries until it lands."

Verified: dual-chain convergence via `AlreadyExists` (no registration storms), stable D-Bus object path per daemon run, the OTA guard against previously-patched and half-patched installs, and locale-pinned parsing byte-equivalence. `ast.parse`, `bash -n` on both scripts pass.