### PR TITLE
fix(archive): stop the dangling-link leak and the pending count it inflates

### DIFF
--- a/crates/sentryusb/src/main.rs
+++ b/crates/sentryusb/src/main.rs
@@ -88,6 +88,12 @@ enum SnapshotAction {
         /// Snapshot name passed through by the `release_snapshot.sh` wrapper.
         name: String,
     },
+    /// Delete /mutable/TeslaCam symlinks into snapshots that no longer exist.
+    Sweep {
+        /// Count what would be removed without deleting anything.
+        #[arg(long)]
+        dry_run: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -289,6 +295,23 @@ async fn main() {
     // preference). Detects a /backingfiles that failed to mount at boot
     // and runs the guarded xfs_repair ladder; see api::storage_repair.
     sentryusb_api::storage_repair::spawn_boot_check(hub.clone());
+    // Boot-time sweep of TeslaCam symlinks orphaned by past snapshot
+    // releases that skipped the link purge. Delayed off the boot path;
+    // internally guarded (snapshots visible, dir flock, no archive overlay)
+    // and idempotent, so a skipped run just retries next boot.
+    tokio::spawn(async {
+        tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+        match tokio::task::spawn_blocking(|| {
+            sentryusb_gadget::snapshot::sweep_dangling_links(false)
+        })
+        .await
+        {
+            Ok(Ok(0)) => {}
+            Ok(Ok(n)) => tracing::info!("Dangling-link sweep removed {} stale TeslaCam link(s)", n),
+            Ok(Err(e)) => tracing::info!("Dangling-link sweep skipped: {}", e),
+            Err(e) => tracing::warn!("Dangling-link sweep task failed: {}", e),
+        }
+    });
     phase!("startup_tasks_spawned");
 
     // Build the API router
@@ -492,6 +515,26 @@ async fn run_snapshot(action: SnapshotAction) -> i32 {
                 Ok(()) => 0,
                 Err(e) => {
                     eprintln!("snapshot release {}: {}", name, e);
+                    1
+                }
+            }
+        }
+        SnapshotAction::Sweep { dry_run } => {
+            let result = tokio::task::spawn_blocking(move || {
+                sentryusb_gadget::snapshot::sweep_dangling_links(dry_run)
+            })
+            .await;
+            match result {
+                Ok(Ok(n)) => {
+                    println!("{} dangling link(s) {}", n, if dry_run { "found" } else { "removed" });
+                    0
+                }
+                Ok(Err(e)) => {
+                    eprintln!("snapshot sweep: {}", e);
+                    1
+                }
+                Err(e) => {
+                    eprintln!("snapshot sweep task panicked: {}", e);
                     1
                 }
             }

--- a/crates/sentryusb/src/main.rs
+++ b/crates/sentryusb/src/main.rs
@@ -295,10 +295,9 @@ async fn main() {
     // preference). Detects a /backingfiles that failed to mount at boot
     // and runs the guarded xfs_repair ladder; see api::storage_repair.
     sentryusb_api::storage_repair::spawn_boot_check(hub.clone());
-    // Boot-time sweep of TeslaCam symlinks orphaned by past snapshot
-    // releases that skipped the link purge. Delayed off the boot path;
-    // internally guarded (snapshots visible, dir flock, no archive overlay)
-    // and idempotent, so a skipped run just retries next boot.
+    // Boot-time sweep of TeslaCam symlinks orphaned by releases that skipped the
+    // link purge. Delayed off the boot path; internally guarded and idempotent,
+    // so a skipped run just retries next boot.
     tokio::spawn(async {
         tokio::time::sleep(std::time::Duration::from_secs(60)).await;
         match tokio::task::spawn_blocking(|| {

--- a/crates/usb_gadget/src/cycle_lock.rs
+++ b/crates/usb_gadget/src/cycle_lock.rs
@@ -65,7 +65,7 @@ fn acquire_path(path: &Path, timeout: Duration) -> io::Result<CycleGuard> {
 }
 
 #[cfg(unix)]
-fn try_flock_exclusive(file: &File) -> io::Result<bool> {
+pub(crate) fn try_flock_exclusive(file: &File) -> io::Result<bool> {
     use std::os::unix::io::AsRawFd;
     // Same primitive as shell `flock`: the lock lives on the open file
     // description, so it also excludes other threads of this process and
@@ -82,7 +82,7 @@ fn try_flock_exclusive(file: &File) -> io::Result<bool> {
 }
 
 #[cfg(not(unix))]
-fn try_flock_exclusive(_file: &File) -> io::Result<bool> {
+pub(crate) fn try_flock_exclusive(_file: &File) -> io::Result<bool> {
     Ok(true) // no archiveloop to race on non-unix dev hosts
 }
 

--- a/crates/usb_gadget/src/snapshot.rs
+++ b/crates/usb_gadget/src/snapshot.rs
@@ -287,8 +287,129 @@ pub async fn release_snapshot(snap_name: &str) -> Result<()> {
     }
 
     std::fs::remove_dir_all(&snap_dir)?;
+    // Parity with bash release_snapshot.sh: drop every /mutable/TeslaCam
+    // symlink whose stored target points into this snapshot, then prune
+    // event/date dirs the removal emptied. Skipping this leaks broken links
+    // that inflate the archive pending count and clutter the Viewer.
+    let pruned = prune_links_into(&name);
+    if pruned > 0 {
+        info!("Pruned {} TeslaCam link(s) into {}", pruned, name);
+    }
     info!("Released snapshot: {}", name);
     Ok(())
+}
+
+/// Remove `/mutable/TeslaCam` symlinks targeting `snap_name` — the stored
+/// target string only, like bash `find -lname "*/NAME/*" -delete`. Never
+/// resolves a link, so autofs is never triggered.
+fn prune_links_into(snap_name: &str) -> usize {
+    let needle = format!("/{}/", snap_name);
+    prune_farm_links(Path::new(TESLACAM), &|target| target.contains(&needle), false)
+}
+
+/// Walk the farm (depth-capped), delete symlinks whose stored target `dead`
+/// matches, then remove dirs the deletion emptied — but never the top-level
+/// category dirs (bash used `find -mindepth 2`). `dry_run` counts only.
+fn prune_farm_links(farm: &Path, dead: &dyn Fn(&str) -> bool, dry_run: bool) -> usize {
+    fn walk(dir: &Path, depth: u8, dead: &dyn Fn(&str) -> bool, dry_run: bool, removed: &mut usize) {
+        if depth > 4 {
+            return;
+        }
+        let Ok(entries) = std::fs::read_dir(dir) else { return };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let Ok(ftype) = entry.file_type() else { continue };
+            if ftype.is_symlink() {
+                if let Ok(target) = std::fs::read_link(&path)
+                    && dead(&target.to_string_lossy())
+                    && (dry_run || std::fs::remove_file(&path).is_ok())
+                {
+                    *removed += 1;
+                }
+            } else if ftype.is_dir() {
+                walk(&path, depth + 1, dead, dry_run, removed);
+                // depth >= 1 here means `path` sits at farm depth >= 2
+                // (date/event dirs); rmdir fails harmlessly if non-empty.
+                if !dry_run && depth >= 1 {
+                    let _ = std::fs::remove_dir(&path);
+                }
+            }
+        }
+    }
+    let mut removed = 0;
+    walk(farm, 0, dead, dry_run, &mut removed);
+    removed
+}
+
+/// Delete farm symlinks whose target's `snap-NNNNNN` component no longer
+/// exists under the snapshots dir — cleanup for links leaked by releases
+/// that skipped the purge. String + directory-existence checks only; the
+/// link itself is never resolved. Returns how many were (or with `dry_run`,
+/// would be) removed.
+pub fn sweep_dangling_links(dry_run: bool) -> Result<usize> {
+    // Same flock bash holds on the snapshots dir (make_snapshot.sh,
+    // manage_free_space.sh): the sweep can't interleave with snapshot
+    // creation, slot reuse, or a low-space release.
+    let _lock = lock_snapshots_dir()?;
+    // A mounted archive overlay reads the farm as its lower dir; changing
+    // the lower under an active overlay is undefined. Skip and retry later.
+    if archive_overlay_active() {
+        bail!("archive overlay is mounted — sweep skipped");
+    }
+    sweep_dangling_links_in(Path::new(TESLACAM), Path::new(SNAPSHOTS_DIR), dry_run)
+}
+
+/// [`sweep_dangling_links`] over explicit roots (testable).
+fn sweep_dangling_links_in(farm: &Path, snapshots: &Path, dry_run: bool) -> Result<usize> {
+    // Refuse to judge links when no snapshots are visible at all: an
+    // unmounted /backingfiles would make every farm link look dead.
+    let any_snap = std::fs::read_dir(snapshots)
+        .map(|entries| {
+            entries.flatten().any(|e| {
+                e.file_name().to_string_lossy().starts_with("snap-") && e.path().is_dir()
+            })
+        })
+        .unwrap_or(false);
+    if !any_snap {
+        bail!("no snapshots visible under {} — sweep skipped", snapshots.display());
+    }
+    let dead = |target: &str| match snap_component(target) {
+        Some(name) => !snapshots.join(name).is_dir(),
+        None => false, // not snapshot-backed — never touch
+    };
+    Ok(prune_farm_links(farm, &dead, dry_run))
+}
+
+/// First path component of `target` that is exactly `snap-<digits>`.
+fn snap_component(target: &str) -> Option<&str> {
+    target.split('/').find(|c| {
+        c.strip_prefix("snap-")
+            .is_some_and(|d| !d.is_empty() && d.bytes().all(|b| b.is_ascii_digit()))
+    })
+}
+
+/// Advisory flock on the snapshots dir — the same lock `flock(1)` takes for
+/// bash make_snapshot.sh / manage_free_space.sh. Bounded wait, then bails.
+fn lock_snapshots_dir() -> Result<std::fs::File> {
+    let file = std::fs::File::open(SNAPSHOTS_DIR)?;
+    let deadline = std::time::Instant::now() + Duration::from_secs(30);
+    loop {
+        if crate::cycle_lock::try_flock_exclusive(&file)? {
+            return Ok(file);
+        }
+        if std::time::Instant::now() >= deadline {
+            bail!("snapshots dir lock busy — sweep skipped");
+        }
+        std::thread::sleep(Duration::from_millis(250));
+    }
+}
+
+/// True while archiveloop's archive overlay (lower = the TeslaCam farm) is
+/// mounted at /tmp/cam/merged.
+fn archive_overlay_active() -> bool {
+    std::fs::read_to_string("/proc/mounts")
+        .map(|m| m.lines().any(|l| l.split_whitespace().nth(1) == Some("/tmp/cam/merged")))
+        .unwrap_or(false)
 }
 
 /// List all snapshots.
@@ -1225,5 +1346,90 @@ mod tests {
             std::fs::symlink_metadata(&stray).is_err(),
             "ordinary event cross-link must still be purged",
         );
+    }
+
+    #[test]
+    fn snap_component_extracts_exact_names_only() {
+        assert_eq!(
+            snap_component("/backingfiles/snapshots/snap-000508/mnt/TeslaCam/x.mp4"),
+            Some("snap-000508"),
+        );
+        assert_eq!(snap_component("/tmp/snapshots/snap-000042/TeslaTrackMode/l.mp4"), Some("snap-000042"));
+        assert_eq!(snap_component("/backingfiles/snapshots/snap-000508.bak/x"), None);
+        assert_eq!(snap_component("/mutable/TeslaCam/RecentClips/a.mp4"), None);
+        assert_eq!(snap_component("snap-/x"), None);
+    }
+
+    #[cfg(unix)]
+    fn build_farm(farm: &std::path::Path) -> (std::path::PathBuf, std::path::PathBuf, std::path::PathBuf) {
+        use std::os::unix::fs::symlink;
+        let day = farm.join("RecentClips/2026-06-27");
+        let evt = farm.join("SentryClips/2026-06-27_13-16-28");
+        std::fs::create_dir_all(&day).unwrap();
+        std::fs::create_dir_all(&evt).unwrap();
+        let dead508 = day.join("a-front.mp4");
+        symlink("/backingfiles/snapshots/snap-000508/mnt/TeslaCam/RecentClips/a-front.mp4", &dead508).unwrap();
+        let live600 = day.join("b-front.mp4");
+        symlink("/backingfiles/snapshots/snap-000600/mnt/TeslaCam/RecentClips/b-front.mp4", &live600).unwrap();
+        let evt_dead = evt.join("c-back.mp4");
+        symlink("/backingfiles/snapshots/snap-000508/mnt/TeslaCam/SentryClips/2026-06-27_13-16-28/c-back.mp4", &evt_dead).unwrap();
+        (dead508, live600, evt_dead)
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn prune_farm_links_matches_target_string_and_prunes_emptied_dirs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let farm = tmp.path();
+        let (dead508, live600, evt_dead) = build_farm(farm);
+
+        let removed = prune_farm_links(farm, &|t| t.contains("/snap-000508/"), false);
+        assert_eq!(removed, 2);
+        assert!(std::fs::symlink_metadata(&dead508).is_err());
+        assert!(std::fs::symlink_metadata(&evt_dead).is_err());
+        assert!(std::fs::symlink_metadata(&live600).is_ok(), "non-matching link must survive");
+        // Emptied event dir pruned; category dirs and non-empty day dir kept.
+        assert!(!farm.join("SentryClips/2026-06-27_13-16-28").exists());
+        assert!(farm.join("SentryClips").exists());
+        assert!(farm.join("RecentClips/2026-06-27").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn sweep_removes_only_links_into_missing_snapshots() {
+        let tmp = tempfile::tempdir().unwrap();
+        let farm = tmp.path().join("TeslaCam");
+        let snaps = tmp.path().join("snapshots");
+        std::fs::create_dir_all(snaps.join("snap-000600")).unwrap();
+        let (dead508, live600, evt_dead) = build_farm(&farm);
+        // Non-snapshot-backed link must never be touched.
+        let foreign = farm.join("RecentClips/2026-06-27/d-front.mp4");
+        std::os::unix::fs::symlink("/somewhere/else/d-front.mp4", &foreign).unwrap();
+
+        let counted = sweep_dangling_links_in(&farm, &snaps, true).unwrap();
+        assert_eq!(counted, 2, "dry run must count without deleting");
+        assert!(std::fs::symlink_metadata(&dead508).is_ok());
+
+        let removed = sweep_dangling_links_in(&farm, &snaps, false).unwrap();
+        assert_eq!(removed, 2);
+        assert!(std::fs::symlink_metadata(&dead508).is_err());
+        assert!(std::fs::symlink_metadata(&evt_dead).is_err());
+        assert!(std::fs::symlink_metadata(&live600).is_ok());
+        assert!(std::fs::symlink_metadata(&foreign).is_ok());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn sweep_bails_when_no_snapshots_visible() {
+        let tmp = tempfile::tempdir().unwrap();
+        let farm = tmp.path().join("TeslaCam");
+        let snaps = tmp.path().join("snapshots");
+        std::fs::create_dir_all(&snaps).unwrap();
+        let (dead508, ..) = build_farm(&farm);
+
+        // Empty snapshots dir looks like an unmounted /backingfiles: bail,
+        // delete nothing.
+        assert!(sweep_dangling_links_in(&farm, &snaps, false).is_err());
+        assert!(std::fs::symlink_metadata(&dead508).is_ok());
     }
 }

--- a/crates/usb_gadget/src/snapshot.rs
+++ b/crates/usb_gadget/src/snapshot.rs
@@ -294,10 +294,9 @@ pub async fn release_snapshot(snap_name: &str) -> Result<()> {
     }
 
     std::fs::remove_dir_all(&snap_dir)?;
-    // Parity with bash release_snapshot.sh: drop every /mutable/TeslaCam
-    // symlink whose stored target points into this snapshot, then prune
-    // event/date dirs the removal emptied. Skipping this leaks broken links
-    // that inflate the archive pending count and clutter the Viewer.
+    // Parity with bash release_snapshot.sh: drop every /mutable/TeslaCam symlink
+    // whose stored target points into this snapshot, then prune event/date dirs the
+    // removal emptied. Skipping it leaks broken links into the pending count.
     let pruned = prune_links_into(&name);
     if pruned > 0 {
         info!("Pruned {} TeslaCam link(s) into {}", pruned, name);
@@ -314,12 +313,9 @@ fn prune_links_into(snap_name: &str) -> usize {
     prune_farm_links(Path::new(TESLACAM), &|_, target| target.contains(&needle), false)
 }
 
-/// Walk the farm (depth-capped), delete symlinks whose stored target `dead`
-/// matches, then remove dirs the deletion emptied — but never the top-level
-/// category dirs (bash used `find -mindepth 2`). `dry_run` counts only.
-///
-/// `dead` also receives the link's own path so a caller can re-verify at
-/// decision time (the call sits immediately before the unlink).
+/// Walk the farm (depth-capped), delete symlinks whose stored target `dead` matches,
+/// then remove dirs the deletion emptied, never the top-level category dirs.
+/// `dead` also gets the link path for re-verify; `dry_run` counts only.
 fn prune_farm_links(farm: &Path, dead: &dyn Fn(&Path, &str) -> bool, dry_run: bool) -> usize {
     fn walk(
         dir: &Path,
@@ -357,11 +353,9 @@ fn prune_farm_links(farm: &Path, dead: &dyn Fn(&Path, &str) -> bool, dry_run: bo
     removed
 }
 
-/// Delete farm symlinks whose target's `snap-NNNNNN` component no longer
-/// exists under the snapshots dir — cleanup for links leaked by releases
-/// that skipped the purge. String + directory-existence checks only; the
-/// link itself is never resolved. Returns how many were (or with `dry_run`,
-/// would be) removed.
+/// Delete farm symlinks whose target's `snap-NNNNNN` component no longer exists
+/// under the snapshots dir. String + directory-existence checks only; the link is
+/// never resolved. Returns how many were (with `dry_run`, would be) removed.
 pub fn sweep_dangling_links(dry_run: bool) -> Result<usize> {
     // A stale snap-* dir left on the root fs under an unmounted (or
     // mid-remount, see storage_repair) /backingfiles would satisfy every
@@ -421,12 +415,9 @@ fn sweep_dangling_links_in(
     Ok(prune_farm_links(farm, &dead, dry_run))
 }
 
-/// Snapshot name of a target in one of the two shapes the linkers in this
-/// file actually mint: `<snapshots>/snap-NNNNNN/mnt/<file…>` (retargeted
-/// clip links) and `<autofs>/snap-NNNNNN/<file…>` (un-retargeted TrackMode
-/// links). Everything else — including a merely-similar path, a foreign
-/// root, or a bare `snap-NNNNNN` filename — yields None so the sweep leaves
-/// it alone.
+/// Snapshot name of a target in the two shapes this file's linkers mint:
+/// `<snapshots>/snap-NNNNNN/mnt/<file…>` and `<autofs>/snap-NNNNNN/<file…>`.
+/// Anything else yields None so the sweep leaves it alone.
 fn owned_snap_component<'a>(target: &'a str, snapshots: &Path, autofs: &Path) -> Option<&'a str> {
     // Absolute and lexically clean only: `..`, `.` or `//` can walk a
     // producer-looking prefix back out to an unrelated file.

--- a/crates/usb_gadget/src/snapshot.rs
+++ b/crates/usb_gadget/src/snapshot.rs
@@ -109,7 +109,9 @@ fn clip_stamp(name: &str) -> Option<&str> {
 /// is byte-equivalent to the previous one (in which case we delete the
 /// reflink to avoid accumulating identical copies).
 pub async fn make_snapshot(skip_fsck: bool) -> Result<Option<String>> {
-    let _ = std::fs::create_dir_all(SNAPSHOTS_DIR);
+    // Serializes against the sweep and the other producers; nothing below
+    // re-acquires it.
+    let _lock = lock_snapshots_dir()?;
 
     if !Path::new(CAM_DISK).exists() {
         bail!("cam disk image not found at {}", CAM_DISK);
@@ -278,6 +280,13 @@ fn normalize_snap_name(input: &str) -> Option<String> {
 /// Release (delete) a snapshot. Accepts a bare `snap-NNNNNN` name or a full
 /// path under the snapshots dir (see [`normalize_snap_name`]).
 pub async fn release_snapshot(snap_name: &str) -> Result<()> {
+    let _lock = lock_snapshots_dir()?;
+    release_snapshot_locked(snap_name).await
+}
+
+/// Body of [`release_snapshot`] for callers already holding the snapshots-dir
+/// lock — taking it a second time in-process would deadlock against itself.
+pub(crate) async fn release_snapshot_locked(snap_name: &str) -> Result<()> {
     let name = match normalize_snap_name(snap_name) {
         Some(n) => n,
         None => bail!("invalid snapshot name: {}", snap_name),
@@ -311,17 +320,21 @@ pub async fn release_snapshot(snap_name: &str) -> Result<()> {
 fn prune_links_into(snap_name: &str) -> usize {
     let snapshots = Path::new(SNAPSHOTS_DIR);
     let autofs = Path::new(AUTOFS_SNAPSHOTS);
-    // Producer-shaped targets only, same predicate as the sweep: a bare
-    // substring match also deletes foreign links that merely happen to
-    // carry the released snapshot's name in their path.
-    let dead =
-        |_: &Path, target: &str| owned_snap_component(target, snapshots, autofs) == Some(snap_name);
+    let dead = |_: &Path, target: &str| released_link_is_dead(target, snap_name, snapshots, autofs);
     let (removed, aborted) =
         prune_farm_links(Path::new(TESLACAM), &dead, &backingfiles_mounted, false);
     if aborted {
         warn!("{} unmounted during prune of {}", BACKINGFILES, snap_name);
     }
     removed
+}
+
+/// Release-prune predicate. Producer-shaped targets naming `snap_name` only —
+/// a bare substring match would also delete foreign links — and only while
+/// that snapshot is provably gone, so links into a reused slot survive.
+fn released_link_is_dead(target: &str, snap_name: &str, snapshots: &Path, autofs: &Path) -> bool {
+    owned_snap_component(target, snapshots, autofs) == Some(snap_name)
+        && matches!(snapshot_state(snapshots, snap_name), SnapState::Gone)
 }
 
 /// Guard both prune paths re-check: the snapshots filesystem must stay
@@ -403,9 +416,8 @@ pub fn sweep_dangling_links(dry_run: bool) -> Result<usize> {
     if !is_mounted(Path::new(BACKINGFILES)) {
         bail!("{} is not a mount point — sweep skipped", BACKINGFILES);
     }
-    // Same flock bash holds on the snapshots dir (make_snapshot.sh,
-    // manage_free_space.sh). The Rust make/release/free-space paths do NOT
-    // yet take it, so the per-link re-verify below carries the real safety.
+    // Same flock the bash and Rust producers hold, so no producer can relink
+    // between this walk's re-verify and its unlink.
     let _lock = lock_snapshots_dir()?;
     // A mounted archive overlay reads the farm as its lower dir; changing
     // the lower under an active overlay is undefined. Skip and retry later.
@@ -510,7 +522,7 @@ fn owned_snap_component<'a>(target: &'a str, snapshots: &Path, autofs: &Path) ->
 
 /// True when `path` is a mount point. A readable /proc/mounts is the whole
 /// answer — no entry means NOT mounted. The st_dev comparison runs only
-/// when /proc/mounts is unreadable (a symlink across fs also trips it).
+/// when /proc/mounts is unreadable.
 fn is_mounted(path: &Path) -> bool {
     let want = path.to_string_lossy();
     if let Ok(mounts) = std::fs::read_to_string("/proc/mounts") {
@@ -521,9 +533,14 @@ fn is_mounted(path: &Path) -> bool {
     #[cfg(unix)]
     {
         use std::os::unix::fs::MetadataExt;
-        let (Ok(md), Some(parent)) = (std::fs::metadata(path), path.parent()) else {
+        // symlink_metadata, not metadata: a symlinked path lands on another
+        // device and would read as mounted while nothing is mounted here.
+        let (Ok(md), Some(parent)) = (std::fs::symlink_metadata(path), path.parent()) else {
             return false;
         };
+        if md.file_type().is_symlink() {
+            return false;
+        }
         std::fs::metadata(parent).is_ok_and(|p| p.dev() != md.dev())
     }
     #[cfg(not(unix))]
@@ -531,8 +548,10 @@ fn is_mounted(path: &Path) -> bool {
 }
 
 /// Advisory flock on the snapshots dir — the same lock `flock(1)` takes for
-/// bash make_snapshot.sh / manage_free_space.sh. Bounded wait, then bails.
-fn lock_snapshots_dir() -> Result<std::fs::File> {
+/// bash make_snapshot.sh / manage_free_space.sh, so every producer and the
+/// sweep serialize on one lock. Bounded wait, then bails without acting.
+pub(crate) fn lock_snapshots_dir() -> Result<std::fs::File> {
+    let _ = std::fs::create_dir_all(SNAPSHOTS_DIR);
     let file = std::fs::File::open(SNAPSHOTS_DIR)?;
     let deadline = std::time::Instant::now() + Duration::from_secs(30);
     loop {
@@ -540,7 +559,7 @@ fn lock_snapshots_dir() -> Result<std::fs::File> {
             return Ok(file);
         }
         if std::time::Instant::now() >= deadline {
-            bail!("snapshots dir lock busy — sweep skipped");
+            bail!("snapshots dir lock busy — skipped");
         }
         std::thread::sleep(Duration::from_millis(250));
     }
@@ -1700,6 +1719,47 @@ mod tests {
         std::fs::create_dir_all(snaps.join("snap-000508")).unwrap();
         assert_eq!(sweep_dangling_links_in(&farm, &snaps, &autofs, &|| true, false).unwrap(), 0);
         assert!(std::fs::symlink_metadata(&dead508).is_ok());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn release_prune_spares_links_into_a_reused_snapshot_slot() {
+        let tmp = tempfile::tempdir().unwrap();
+        let farm = tmp.path().join("TeslaCam");
+        let snaps = tmp.path().join("snapshots");
+        let autofs = tmp.path().join("autofs");
+        std::fs::create_dir_all(snaps.join("snap-000600")).unwrap();
+        let (dead508, live600, evt_dead) = build_farm(&farm, snaps.to_str().unwrap());
+        let dead = |_: &std::path::Path, t: &str| {
+            released_link_is_dead(t, "snap-000508", &snaps, &autofs)
+        };
+
+        // Slot 508 stays released: both its links go, the other survives.
+        let (removed, aborted) = prune_farm_links(&farm, &dead, &|| true, false);
+        assert_eq!((removed, aborted), (2, false));
+        assert!(std::fs::symlink_metadata(&dead508).is_err());
+        assert!(std::fs::symlink_metadata(&evt_dead).is_err());
+        assert!(std::fs::symlink_metadata(&live600).is_ok());
+
+        // A new snapshot reuses slot 508 partway through the walk; every link
+        // the prune has not yet reached must survive.
+        let farm2 = tmp.path().join("TeslaCam2");
+        let (dead508, _, evt_dead) = build_farm(&farm2, snaps.to_str().unwrap());
+        let calls = std::cell::Cell::new(0);
+        let guard = || {
+            calls.set(calls.get() + 1);
+            if calls.get() == 4 {
+                std::fs::create_dir_all(snaps.join("snap-000508")).unwrap();
+            }
+            true
+        };
+        let (removed, aborted) = prune_farm_links(&farm2, &dead, &guard, false);
+        assert_eq!((removed, aborted), (1, false), "only the pre-recreate dir may be pruned");
+        let survivors = [&dead508, &evt_dead]
+            .iter()
+            .filter(|p| std::fs::symlink_metadata(p).is_ok())
+            .count();
+        assert_eq!(survivors, 1, "the reused slot's remaining link must survive");
     }
 
     #[cfg(unix)]

--- a/crates/usb_gadget/src/snapshot.rs
+++ b/crates/usb_gadget/src/snapshot.rs
@@ -324,7 +324,10 @@ fn prune_links_into(snap_name: &str) -> usize {
     let (removed, aborted) =
         prune_farm_links(Path::new(TESLACAM), &dead, &backingfiles_mounted, false);
     if aborted {
-        warn!("{} unmounted during prune of {}", BACKINGFILES, snap_name);
+        warn!(
+            "{} unmounted during prune of {} — aborted after {} link(s)",
+            BACKINGFILES, snap_name, removed
+        );
     }
     removed
 }
@@ -345,7 +348,8 @@ fn backingfiles_mounted() -> bool {
 
 /// Walk the farm (depth-capped), delete symlinks whose stored target `dead` matches,
 /// then remove dirs the deletion emptied, never the top-level category dirs.
-/// `guard` re-checked per dir aborts the walk; returns `(removed, aborted)`.
+/// `guard` re-checked per dir AND immediately before each unlink aborts the
+/// walk outright; returns `(removed, aborted)`.
 fn prune_farm_links(
     farm: &Path,
     dead: &dyn Fn(&Path, &str) -> bool,
@@ -373,10 +377,16 @@ fn prune_farm_links(
             if ftype.is_symlink() {
                 if let Ok(target) = std::fs::read_link(&path) {
                     let target = target.to_string_lossy().to_string();
-                    if dead(&path, &target)
-                        && (dry_run || unlink_if_still_dead(&path, &target, dead))
-                    {
-                        *removed += 1;
+                    if dead(&path, &target) {
+                        // `dead` reads the snapshots dir, so an unmount since the
+                        // last check turns a healthy link into a false positive.
+                        // Re-prove immediately before acting on this one link.
+                        if !guard() {
+                            return false;
+                        }
+                        if dry_run || unlink_if_still_dead(&path, &target, dead) {
+                            *removed += 1;
+                        }
                     }
                 }
             } else if ftype.is_dir() {
@@ -1745,10 +1755,11 @@ mod tests {
         // the prune has not yet reached must survive.
         let farm2 = tmp.path().join("TeslaCam2");
         let (dead508, _, evt_dead) = build_farm(&farm2, snaps.to_str().unwrap());
-        let calls = std::cell::Cell::new(0);
+        let recreated = std::cell::Cell::new(false);
         let guard = || {
-            calls.set(calls.get() + 1);
-            if calls.get() == 4 {
+            let pruned = std::fs::symlink_metadata(&dead508).is_err()
+                || std::fs::symlink_metadata(&evt_dead).is_err();
+            if pruned && !recreated.replace(true) {
                 std::fs::create_dir_all(snaps.join("snap-000508")).unwrap();
             }
             true
@@ -1775,6 +1786,45 @@ mod tests {
         let err = sweep_dangling_links_in(&farm, &snaps, &autofs, &|| false, false).unwrap_err();
         assert!(err.to_string().contains("mount state changed"));
         assert!(std::fs::symlink_metadata(&dead508).is_ok());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn sweep_aborts_before_the_next_unlink_when_the_mount_drops_mid_directory() {
+        let tmp = tempfile::tempdir().unwrap();
+        let farm = tmp.path().join("TeslaCam");
+        let snaps = tmp.path().join("snapshots");
+        let autofs = tmp.path().join("autofs");
+        std::fs::create_dir_all(snaps.join("snap-000600")).unwrap();
+        let (dead508, live600, evt_dead) = build_farm(&farm, snaps.to_str().unwrap());
+
+        // Second dead link in the SAME directory as dead508: a guard checked
+        // only once per directory would delete both.
+        let sibling = farm.join("RecentClips/2026-06-27/z-front.mp4");
+        std::os::unix::fs::symlink(
+            format!("{}/snap-000508/mnt/TeslaCam/RecentClips/z-front.mp4", snaps.display()),
+            &sibling,
+        )
+        .unwrap();
+
+        // /backingfiles goes away the instant the first unlink lands.
+        let dropped = std::cell::Cell::new(false);
+        let deleted = |p: &std::path::Path| std::fs::symlink_metadata(p).is_err();
+        let guard = || {
+            if deleted(&dead508) || deleted(&sibling) || deleted(&evt_dead) {
+                dropped.set(true);
+            }
+            !dropped.get()
+        };
+
+        let err = sweep_dangling_links_in(&farm, &snaps, &autofs, &guard, false).unwrap_err();
+        assert!(err.to_string().contains("aborted after 1 link(s)"), "{err}");
+        let survivors = [&dead508, &sibling, &evt_dead]
+            .iter()
+            .filter(|p| std::fs::symlink_metadata(p).is_ok())
+            .count();
+        assert_eq!(survivors, 2, "the sweep must stop at the first dropped mount");
+        assert!(std::fs::symlink_metadata(&live600).is_ok());
     }
 
     /// An unreadable snapshots dir makes every source undeterminable: the

--- a/crates/usb_gadget/src/snapshot.rs
+++ b/crates/usb_gadget/src/snapshot.rs
@@ -29,7 +29,14 @@ use std::time::Duration;
 use anyhow::{bail, Result};
 use tracing::{info, warn};
 
+/// Filesystem carrying the snapshots; the sweep refuses to judge links
+/// unless this is genuinely mounted.
+const BACKINGFILES: &str = "/backingfiles";
 const SNAPSHOTS_DIR: &str = "/backingfiles/snapshots";
+
+/// Where autofs mounts a snapshot's image. `<SNAPSHOTS_DIR>/snap-NNNNNN/mnt`
+/// is a symlink here, and TrackMode links point at it directly.
+const AUTOFS_SNAPSHOTS: &str = "/tmp/snapshots";
 const CAM_DISK: &str = "/backingfiles/cam_disk.bin";
 const REBUILD_FLAG: &str = "/mutable/.rebuild_snapshot_symlinks";
 
@@ -304,14 +311,23 @@ pub async fn release_snapshot(snap_name: &str) -> Result<()> {
 /// resolves a link, so autofs is never triggered.
 fn prune_links_into(snap_name: &str) -> usize {
     let needle = format!("/{}/", snap_name);
-    prune_farm_links(Path::new(TESLACAM), &|target| target.contains(&needle), false)
+    prune_farm_links(Path::new(TESLACAM), &|_, target| target.contains(&needle), false)
 }
 
 /// Walk the farm (depth-capped), delete symlinks whose stored target `dead`
 /// matches, then remove dirs the deletion emptied — but never the top-level
 /// category dirs (bash used `find -mindepth 2`). `dry_run` counts only.
-fn prune_farm_links(farm: &Path, dead: &dyn Fn(&str) -> bool, dry_run: bool) -> usize {
-    fn walk(dir: &Path, depth: u8, dead: &dyn Fn(&str) -> bool, dry_run: bool, removed: &mut usize) {
+///
+/// `dead` also receives the link's own path so a caller can re-verify at
+/// decision time (the call sits immediately before the unlink).
+fn prune_farm_links(farm: &Path, dead: &dyn Fn(&Path, &str) -> bool, dry_run: bool) -> usize {
+    fn walk(
+        dir: &Path,
+        depth: u8,
+        dead: &dyn Fn(&Path, &str) -> bool,
+        dry_run: bool,
+        removed: &mut usize,
+    ) {
         if depth > 4 {
             return;
         }
@@ -321,7 +337,7 @@ fn prune_farm_links(farm: &Path, dead: &dyn Fn(&str) -> bool, dry_run: bool) -> 
             let Ok(ftype) = entry.file_type() else { continue };
             if ftype.is_symlink() {
                 if let Ok(target) = std::fs::read_link(&path)
-                    && dead(&target.to_string_lossy())
+                    && dead(&path, &target.to_string_lossy())
                     && (dry_run || std::fs::remove_file(&path).is_ok())
                 {
                     *removed += 1;
@@ -347,20 +363,36 @@ fn prune_farm_links(farm: &Path, dead: &dyn Fn(&str) -> bool, dry_run: bool) -> 
 /// link itself is never resolved. Returns how many were (or with `dry_run`,
 /// would be) removed.
 pub fn sweep_dangling_links(dry_run: bool) -> Result<usize> {
+    // A stale snap-* dir left on the root fs under an unmounted (or
+    // mid-remount, see storage_repair) /backingfiles would satisfy every
+    // later check while the real targets are gone. Prove the mount first.
+    if !is_mounted(Path::new(BACKINGFILES)) {
+        bail!("{} is not a mount point — sweep skipped", BACKINGFILES);
+    }
     // Same flock bash holds on the snapshots dir (make_snapshot.sh,
-    // manage_free_space.sh): the sweep can't interleave with snapshot
-    // creation, slot reuse, or a low-space release.
+    // manage_free_space.sh). The Rust make/release/free-space paths do NOT
+    // yet take it, so the per-link re-verify below carries the real safety.
     let _lock = lock_snapshots_dir()?;
     // A mounted archive overlay reads the farm as its lower dir; changing
     // the lower under an active overlay is undefined. Skip and retry later.
     if archive_overlay_active() {
         bail!("archive overlay is mounted — sweep skipped");
     }
-    sweep_dangling_links_in(Path::new(TESLACAM), Path::new(SNAPSHOTS_DIR), dry_run)
+    sweep_dangling_links_in(
+        Path::new(TESLACAM),
+        Path::new(SNAPSHOTS_DIR),
+        Path::new(AUTOFS_SNAPSHOTS),
+        dry_run,
+    )
 }
 
 /// [`sweep_dangling_links`] over explicit roots (testable).
-fn sweep_dangling_links_in(farm: &Path, snapshots: &Path, dry_run: bool) -> Result<usize> {
+fn sweep_dangling_links_in(
+    farm: &Path,
+    snapshots: &Path,
+    autofs: &Path,
+    dry_run: bool,
+) -> Result<usize> {
     // Refuse to judge links when no snapshots are visible at all: an
     // unmounted /backingfiles would make every farm link look dead.
     let any_snap = std::fs::read_dir(snapshots)
@@ -373,19 +405,75 @@ fn sweep_dangling_links_in(farm: &Path, snapshots: &Path, dry_run: bool) -> Resu
     if !any_snap {
         bail!("no snapshots visible under {} — sweep skipped", snapshots.display());
     }
-    let dead = |target: &str| match snap_component(target) {
-        Some(name) => !snapshots.join(name).is_dir(),
-        None => false, // not snapshot-backed — never touch
+    let dead = |link: &Path, target: &str| {
+        let Some(name) = owned_snap_component(target, snapshots, autofs) else {
+            return false; // not a link this codebase minted — never touch
+        };
+        if snapshots.join(name).is_dir() {
+            return false;
+        }
+        // Nothing locks out a concurrent snapshot create/relink, so re-read
+        // the link and re-check its snapshot right before unlinking: a link
+        // that turned valid since the walk read it must survive.
+        std::fs::read_link(link).is_ok_and(|t| t.to_string_lossy() == target)
+            && !snapshots.join(name).is_dir()
     };
     Ok(prune_farm_links(farm, &dead, dry_run))
 }
 
-/// First path component of `target` that is exactly `snap-<digits>`.
-fn snap_component(target: &str) -> Option<&str> {
-    target.split('/').find(|c| {
+/// Snapshot name of a target in one of the two shapes the linkers in this
+/// file actually mint: `<snapshots>/snap-NNNNNN/mnt/<file…>` (retargeted
+/// clip links) and `<autofs>/snap-NNNNNN/<file…>` (un-retargeted TrackMode
+/// links). Everything else — including a merely-similar path, a foreign
+/// root, or a bare `snap-NNNNNN` filename — yields None so the sweep leaves
+/// it alone.
+fn owned_snap_component<'a>(target: &'a str, snapshots: &Path, autofs: &Path) -> Option<&'a str> {
+    // Absolute and lexically clean only: `..`, `.` or `//` can walk a
+    // producer-looking prefix back out to an unrelated file.
+    if !target.starts_with('/')
+        || target[1..].split('/').any(|c| c.is_empty() || c == "." || c == "..")
+    {
+        return None;
+    }
+    let under = |root: &Path| -> Option<&'a str> {
+        target.strip_prefix(root.to_str()?)?.strip_prefix('/')
+    };
+    let is_snap = |c: &&str| {
         c.strip_prefix("snap-")
             .is_some_and(|d| !d.is_empty() && d.bytes().all(|b| b.is_ascii_digit()))
-    })
+    };
+    if let Some(rest) = under(snapshots) {
+        let mut parts = rest.split('/');
+        let name = parts.next().filter(is_snap)?;
+        // Retargeted links always go through the snapshot's `mnt` symlink.
+        return (parts.next() == Some("mnt") && parts.next().is_some()).then_some(name);
+    }
+    let mut parts = under(autofs)?.split('/');
+    let name = parts.next().filter(is_snap)?;
+    parts.next().is_some().then_some(name)
+}
+
+/// True when `path` is a mount point. /proc/mounts is authoritative (a bind
+/// mount shares its parent's device); the st_dev comparison only covers a
+/// missing /proc.
+fn is_mounted(path: &Path) -> bool {
+    let want = path.to_string_lossy();
+    if std::fs::read_to_string("/proc/mounts")
+        .map(|m| m.lines().any(|l| l.split_whitespace().nth(1) == Some(want.as_ref())))
+        .unwrap_or(false)
+    {
+        return true;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        let (Ok(md), Some(parent)) = (std::fs::metadata(path), path.parent()) else {
+            return false;
+        };
+        std::fs::metadata(parent).is_ok_and(|p| p.dev() != md.dev())
+    }
+    #[cfg(not(unix))]
+    false
 }
 
 /// Advisory flock on the snapshots dir — the same lock `flock(1)` takes for
@@ -1350,29 +1438,54 @@ mod tests {
 
     #[test]
     fn snap_component_extracts_exact_names_only() {
+        let snaps = Path::new("/backingfiles/snapshots");
+        let autofs = Path::new("/tmp/snapshots");
+        let owned = |t| owned_snap_component(t, snaps, autofs);
+
+        // The two shapes the linkers actually mint.
         assert_eq!(
-            snap_component("/backingfiles/snapshots/snap-000508/mnt/TeslaCam/x.mp4"),
+            owned("/backingfiles/snapshots/snap-000508/mnt/TeslaCam/x.mp4"),
             Some("snap-000508"),
         );
-        assert_eq!(snap_component("/tmp/snapshots/snap-000042/TeslaTrackMode/l.mp4"), Some("snap-000042"));
-        assert_eq!(snap_component("/backingfiles/snapshots/snap-000508.bak/x"), None);
-        assert_eq!(snap_component("/mutable/TeslaCam/RecentClips/a.mp4"), None);
-        assert_eq!(snap_component("snap-/x"), None);
+        assert_eq!(owned("/tmp/snapshots/snap-000042/TeslaTrackMode/l.mp4"), Some("snap-000042"));
+
+        assert_eq!(owned("/backingfiles/snapshots/snap-000508.bak/mnt/x"), None);
+        assert_eq!(owned("/mutable/TeslaCam/RecentClips/a.mp4"), None);
+        assert_eq!(owned("snap-/x"), None);
+        // Right root, wrong shape: no `mnt` level, or nothing under it.
+        assert_eq!(owned("/backingfiles/snapshots/snap-000508/snap.bin"), None);
+        assert_eq!(owned("/backingfiles/snapshots/snap-000508/mnt"), None);
+        // Foreign roots and relative targets that merely contain a snap name.
+        assert_eq!(owned("/somewhere/snap-000508/mnt/x.mp4"), None);
+        assert_eq!(owned("../snap-000123/x.mp4"), None);
+        assert_eq!(owned("/mutable/TeslaCam/RecentClips/snap-000123"), None);
+        // Traversal back out of a producer-owned prefix.
+        assert_eq!(owned("/backingfiles/snapshots/snap-000508/mnt/../../../etc/passwd"), None);
+        assert_eq!(owned("/backingfiles/snapshots//snap-000508/mnt/x.mp4"), None);
     }
 
     #[cfg(unix)]
-    fn build_farm(farm: &std::path::Path) -> (std::path::PathBuf, std::path::PathBuf, std::path::PathBuf) {
+    /// Farm with two links into snap-000508 and one into snap-000600, all
+    /// rooted at `snaps` so the sweep sees genuine producer-owned targets.
+    fn build_farm(
+        farm: &std::path::Path,
+        snaps: &str,
+    ) -> (std::path::PathBuf, std::path::PathBuf, std::path::PathBuf) {
         use std::os::unix::fs::symlink;
         let day = farm.join("RecentClips/2026-06-27");
         let evt = farm.join("SentryClips/2026-06-27_13-16-28");
         std::fs::create_dir_all(&day).unwrap();
         std::fs::create_dir_all(&evt).unwrap();
         let dead508 = day.join("a-front.mp4");
-        symlink("/backingfiles/snapshots/snap-000508/mnt/TeslaCam/RecentClips/a-front.mp4", &dead508).unwrap();
+        symlink(format!("{snaps}/snap-000508/mnt/TeslaCam/RecentClips/a-front.mp4"), &dead508).unwrap();
         let live600 = day.join("b-front.mp4");
-        symlink("/backingfiles/snapshots/snap-000600/mnt/TeslaCam/RecentClips/b-front.mp4", &live600).unwrap();
+        symlink(format!("{snaps}/snap-000600/mnt/TeslaCam/RecentClips/b-front.mp4"), &live600).unwrap();
         let evt_dead = evt.join("c-back.mp4");
-        symlink("/backingfiles/snapshots/snap-000508/mnt/TeslaCam/SentryClips/2026-06-27_13-16-28/c-back.mp4", &evt_dead).unwrap();
+        symlink(
+            format!("{snaps}/snap-000508/mnt/TeslaCam/SentryClips/2026-06-27_13-16-28/c-back.mp4"),
+            &evt_dead,
+        )
+        .unwrap();
         (dead508, live600, evt_dead)
     }
 
@@ -1381,9 +1494,9 @@ mod tests {
     fn prune_farm_links_matches_target_string_and_prunes_emptied_dirs() {
         let tmp = tempfile::tempdir().unwrap();
         let farm = tmp.path();
-        let (dead508, live600, evt_dead) = build_farm(farm);
+        let (dead508, live600, evt_dead) = build_farm(farm, "/backingfiles/snapshots");
 
-        let removed = prune_farm_links(farm, &|t| t.contains("/snap-000508/"), false);
+        let removed = prune_farm_links(farm, &|_, t| t.contains("/snap-000508/"), false);
         assert_eq!(removed, 2);
         assert!(std::fs::symlink_metadata(&dead508).is_err());
         assert!(std::fs::symlink_metadata(&evt_dead).is_err());
@@ -1400,22 +1513,55 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let farm = tmp.path().join("TeslaCam");
         let snaps = tmp.path().join("snapshots");
+        let autofs = tmp.path().join("autofs");
         std::fs::create_dir_all(snaps.join("snap-000600")).unwrap();
-        let (dead508, live600, evt_dead) = build_farm(&farm);
-        // Non-snapshot-backed link must never be touched.
-        let foreign = farm.join("RecentClips/2026-06-27/d-front.mp4");
-        std::os::unix::fs::symlink("/somewhere/else/d-front.mp4", &foreign).unwrap();
+        let (dead508, live600, evt_dead) = build_farm(&farm, snaps.to_str().unwrap());
 
-        let counted = sweep_dangling_links_in(&farm, &snaps, true).unwrap();
+        // Targets that name a missing snapshot but are NOT shapes this
+        // codebase mints: all must survive untouched.
+        let day = farm.join("RecentClips/2026-06-27");
+        let mut spared = Vec::new();
+        for (name, target) in [
+            ("d-front.mp4", "/somewhere/else/d-front.mp4".to_string()),
+            ("e-front.mp4", "/somewhere/snap-000508/mnt/x.mp4".to_string()),
+            ("f-front.mp4", "../snap-000508/mnt/x.mp4".to_string()),
+            ("g-front.mp4", format!("{}/snap-000508", snaps.display())),
+            ("h-front.mp4", format!("{}/snap-000508/mnt/../../x.mp4", snaps.display())),
+        ] {
+            let p = day.join(name);
+            std::os::unix::fs::symlink(&target, &p).unwrap();
+            spared.push(p);
+        }
+
+        let counted = sweep_dangling_links_in(&farm, &snaps, &autofs, true).unwrap();
         assert_eq!(counted, 2, "dry run must count without deleting");
         assert!(std::fs::symlink_metadata(&dead508).is_ok());
 
-        let removed = sweep_dangling_links_in(&farm, &snaps, false).unwrap();
+        let removed = sweep_dangling_links_in(&farm, &snaps, &autofs, false).unwrap();
         assert_eq!(removed, 2);
         assert!(std::fs::symlink_metadata(&dead508).is_err());
         assert!(std::fs::symlink_metadata(&evt_dead).is_err());
         assert!(std::fs::symlink_metadata(&live600).is_ok());
-        assert!(std::fs::symlink_metadata(&foreign).is_ok());
+        for p in &spared {
+            assert!(std::fs::symlink_metadata(p).is_ok(), "must not delete {}", p.display());
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn sweep_spares_a_link_that_became_valid_during_the_walk() {
+        let tmp = tempfile::tempdir().unwrap();
+        let farm = tmp.path().join("TeslaCam");
+        let snaps = tmp.path().join("snapshots");
+        let autofs = tmp.path().join("autofs");
+        std::fs::create_dir_all(snaps.join("snap-000600")).unwrap();
+        let (dead508, ..) = build_farm(&farm, snaps.to_str().unwrap());
+
+        // A concurrent snapshot reusing slot 508 recreates the dir; the
+        // per-link re-check must then leave its links alone.
+        std::fs::create_dir_all(snaps.join("snap-000508")).unwrap();
+        assert_eq!(sweep_dangling_links_in(&farm, &snaps, &autofs, false).unwrap(), 0);
+        assert!(std::fs::symlink_metadata(&dead508).is_ok());
     }
 
     #[cfg(unix)]
@@ -1425,11 +1571,12 @@ mod tests {
         let farm = tmp.path().join("TeslaCam");
         let snaps = tmp.path().join("snapshots");
         std::fs::create_dir_all(&snaps).unwrap();
-        let (dead508, ..) = build_farm(&farm);
+        let (dead508, ..) = build_farm(&farm, snaps.to_str().unwrap());
 
         // Empty snapshots dir looks like an unmounted /backingfiles: bail,
         // delete nothing.
-        assert!(sweep_dangling_links_in(&farm, &snaps, false).is_err());
+        let autofs = tmp.path().join("autofs");
+        assert!(sweep_dangling_links_in(&farm, &snaps, &autofs, false).is_err());
         assert!(std::fs::symlink_metadata(&dead508).is_ok());
     }
 }

--- a/crates/usb_gadget/src/snapshot.rs
+++ b/crates/usb_gadget/src/snapshot.rs
@@ -305,41 +305,71 @@ pub async fn release_snapshot(snap_name: &str) -> Result<()> {
     Ok(())
 }
 
-/// Remove `/mutable/TeslaCam` symlinks targeting `snap_name` — the stored
-/// target string only, like bash `find -lname "*/NAME/*" -delete`. Never
-/// resolves a link, so autofs is never triggered.
+/// Remove `/mutable/TeslaCam` symlinks targeting `snap_name`. Matches the
+/// stored target string only — never resolves a link, so autofs is never
+/// triggered.
 fn prune_links_into(snap_name: &str) -> usize {
-    let needle = format!("/{}/", snap_name);
-    prune_farm_links(Path::new(TESLACAM), &|_, target| target.contains(&needle), false)
+    let snapshots = Path::new(SNAPSHOTS_DIR);
+    let autofs = Path::new(AUTOFS_SNAPSHOTS);
+    // Producer-shaped targets only, same predicate as the sweep: a bare
+    // substring match also deletes foreign links that merely happen to
+    // carry the released snapshot's name in their path.
+    let dead =
+        |_: &Path, target: &str| owned_snap_component(target, snapshots, autofs) == Some(snap_name);
+    let (removed, aborted) =
+        prune_farm_links(Path::new(TESLACAM), &dead, &backingfiles_mounted, false);
+    if aborted {
+        warn!("{} unmounted during prune of {}", BACKINGFILES, snap_name);
+    }
+    removed
+}
+
+/// Guard both prune paths re-check: the snapshots filesystem must stay
+/// mounted for the whole walk, or every remaining link looks dead.
+fn backingfiles_mounted() -> bool {
+    is_mounted(Path::new(BACKINGFILES))
 }
 
 /// Walk the farm (depth-capped), delete symlinks whose stored target `dead` matches,
 /// then remove dirs the deletion emptied, never the top-level category dirs.
-/// `dead` also gets the link path for re-verify; `dry_run` counts only.
-fn prune_farm_links(farm: &Path, dead: &dyn Fn(&Path, &str) -> bool, dry_run: bool) -> usize {
+/// `guard` re-checked per dir aborts the walk; returns `(removed, aborted)`.
+fn prune_farm_links(
+    farm: &Path,
+    dead: &dyn Fn(&Path, &str) -> bool,
+    guard: &dyn Fn() -> bool,
+    dry_run: bool,
+) -> (usize, bool) {
     fn walk(
         dir: &Path,
         depth: u8,
         dead: &dyn Fn(&Path, &str) -> bool,
+        guard: &dyn Fn() -> bool,
         dry_run: bool,
         removed: &mut usize,
-    ) {
+    ) -> bool {
         if depth > 4 {
-            return;
+            return true;
         }
-        let Ok(entries) = std::fs::read_dir(dir) else { return };
+        if !guard() {
+            return false;
+        }
+        let Ok(entries) = std::fs::read_dir(dir) else { return true };
         for entry in entries.flatten() {
             let path = entry.path();
             let Ok(ftype) = entry.file_type() else { continue };
             if ftype.is_symlink() {
-                if let Ok(target) = std::fs::read_link(&path)
-                    && dead(&path, &target.to_string_lossy())
-                    && (dry_run || std::fs::remove_file(&path).is_ok())
-                {
-                    *removed += 1;
+                if let Ok(target) = std::fs::read_link(&path) {
+                    let target = target.to_string_lossy().to_string();
+                    if dead(&path, &target)
+                        && (dry_run || unlink_if_still_dead(&path, &target, dead))
+                    {
+                        *removed += 1;
+                    }
                 }
             } else if ftype.is_dir() {
-                walk(&path, depth + 1, dead, dry_run, removed);
+                if !walk(&path, depth + 1, dead, guard, dry_run, removed) {
+                    return false;
+                }
                 // depth >= 1 here means `path` sits at farm depth >= 2
                 // (date/event dirs); rmdir fails harmlessly if non-empty.
                 if !dry_run && depth >= 1 {
@@ -347,10 +377,20 @@ fn prune_farm_links(farm: &Path, dead: &dyn Fn(&Path, &str) -> bool, dry_run: bo
                 }
             }
         }
+        true
     }
     let mut removed = 0;
-    walk(farm, 0, dead, dry_run, &mut removed);
-    removed
+    let completed = walk(farm, 0, dead, guard, dry_run, &mut removed);
+    (removed, !completed)
+}
+
+/// Re-read the link and re-run `dead` right before unlinking, so a link a
+/// concurrent relink turned live survives. Residual window: the unlink is
+/// path-based, so a relink between this readlink and it still loses.
+fn unlink_if_still_dead(link: &Path, target: &str, dead: &dyn Fn(&Path, &str) -> bool) -> bool {
+    let Ok(fresh) = std::fs::read_link(link) else { return false };
+    let fresh = fresh.to_string_lossy().to_string();
+    fresh == target && dead(link, &fresh) && std::fs::remove_file(link).is_ok()
 }
 
 /// Delete farm symlinks whose target's `snap-NNNNNN` component no longer exists
@@ -376,15 +416,18 @@ pub fn sweep_dangling_links(dry_run: bool) -> Result<usize> {
         Path::new(TESLACAM),
         Path::new(SNAPSHOTS_DIR),
         Path::new(AUTOFS_SNAPSHOTS),
+        &backingfiles_mounted,
         dry_run,
     )
 }
 
-/// [`sweep_dangling_links`] over explicit roots (testable).
+/// [`sweep_dangling_links`] over explicit roots (testable). `guard` is
+/// re-checked throughout the walk; a false reading aborts it.
 fn sweep_dangling_links_in(
     farm: &Path,
     snapshots: &Path,
     autofs: &Path,
+    guard: &dyn Fn() -> bool,
     dry_run: bool,
 ) -> Result<usize> {
     // Refuse to judge links when no snapshots are visible at all: an
@@ -399,20 +442,41 @@ fn sweep_dangling_links_in(
     if !any_snap {
         bail!("no snapshots visible under {} — sweep skipped", snapshots.display());
     }
-    let dead = |link: &Path, target: &str| {
-        let Some(name) = owned_snap_component(target, snapshots, autofs) else {
-            return false; // not a link this codebase minted — never touch
-        };
-        if snapshots.join(name).is_dir() {
-            return false;
-        }
-        // Nothing locks out a concurrent snapshot create/relink, so re-read
-        // the link and re-check its snapshot right before unlinking: a link
-        // that turned valid since the walk read it must survive.
-        std::fs::read_link(link).is_ok_and(|t| t.to_string_lossy() == target)
-            && !snapshots.join(name).is_dir()
+    let dead = |_: &Path, target: &str| {
+        // Only links this codebase minted, and only when their snapshot is
+        // provably gone — an unreadable snapshots dir proves nothing.
+        owned_snap_component(target, snapshots, autofs)
+            .is_some_and(|name| matches!(snapshot_state(snapshots, name), SnapState::Gone))
     };
-    Ok(prune_farm_links(farm, &dead, dry_run))
+    let (removed, aborted) = prune_farm_links(farm, &dead, guard, dry_run);
+    if aborted {
+        bail!("mount state changed mid-sweep — aborted after {} link(s)", removed);
+    }
+    Ok(removed)
+}
+
+/// Whether a snapshot dir is present, provably gone, or undeterminable.
+enum SnapState {
+    Live,
+    Gone,
+    Unknown,
+}
+
+/// Classify `snapshots/<name>`. I/O errors other than NotFound — and a
+/// NotFound under an unreadable snapshots dir — are Unknown, never Gone.
+fn snapshot_state(snapshots: &Path, name: &str) -> SnapState {
+    match std::fs::metadata(snapshots.join(name)) {
+        Ok(md) if md.is_dir() => SnapState::Live,
+        Ok(_) => SnapState::Gone,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            if std::fs::metadata(snapshots).is_ok_and(|m| m.is_dir()) {
+                SnapState::Gone
+            } else {
+                SnapState::Unknown
+            }
+        }
+        Err(_) => SnapState::Unknown,
+    }
 }
 
 /// Snapshot name of a target in the two shapes this file's linkers mint:
@@ -444,16 +508,15 @@ fn owned_snap_component<'a>(target: &'a str, snapshots: &Path, autofs: &Path) ->
     parts.next().is_some().then_some(name)
 }
 
-/// True when `path` is a mount point. /proc/mounts is authoritative (a bind
-/// mount shares its parent's device); the st_dev comparison only covers a
-/// missing /proc.
+/// True when `path` is a mount point. A readable /proc/mounts is the whole
+/// answer — no entry means NOT mounted. The st_dev comparison runs only
+/// when /proc/mounts is unreadable (a symlink across fs also trips it).
 fn is_mounted(path: &Path) -> bool {
     let want = path.to_string_lossy();
-    if std::fs::read_to_string("/proc/mounts")
-        .map(|m| m.lines().any(|l| l.split_whitespace().nth(1) == Some(want.as_ref())))
-        .unwrap_or(false)
-    {
-        return true;
+    if let Ok(mounts) = std::fs::read_to_string("/proc/mounts") {
+        return mounts
+            .lines()
+            .any(|l| l.split_whitespace().nth(1) == Some(want.as_ref()));
     }
     #[cfg(unix)]
     {
@@ -857,7 +920,7 @@ pub fn backfill_gapfill_links() -> Result<()> {
         return Ok(());
     }
     let gapfill = load_gapfill_stamps();
-    let (made, skipped_dead) =
+    let (made, skipped_dead, retry) =
         backfill_gapfill_links_in(
             Path::new(TESLACAM),
             Path::new(SNAPSHOTS_DIR),
@@ -865,29 +928,34 @@ pub fn backfill_gapfill_links() -> Result<()> {
             &gapfill,
         );
     // Written AFTER the walk so a crash mid-pass re-runs it next snapshot.
-    std::fs::write(GAPFILL_APPLIED_MARKER, &manifest_body)?;
-    if made > 0 || skipped_dead > 0 {
+    // Withheld while any source was undeterminable: the manifest is the
+    // only retry trigger, so marking now would drop it permanently.
+    if retry == 0 {
+        std::fs::write(GAPFILL_APPLIED_MARKER, &manifest_body)?;
+    }
+    if made > 0 || skipped_dead > 0 || retry > 0 {
         info!(
-            "gap-fill backfill: created {} RecentClips link(s) for manifest clips ({} dead-target source(s) skipped)",
-            made, skipped_dead
+            "gap-fill backfill: created {} RecentClips link(s) for manifest clips ({} dead-target source(s) skipped, {} deferred to next pass)",
+            made, skipped_dead, retry
         );
     }
     Ok(())
 }
 
-/// [`backfill_gapfill_links`] over explicit roots (testable).
-/// Returns `(links created, dead-target sources skipped)`.
+/// [`backfill_gapfill_links`] over explicit roots (testable). Returns
+/// `(links created, dead-target sources skipped, sources needing retry)`.
 fn backfill_gapfill_links_in(
     teslacam: &Path,
     snapshots: &Path,
     autofs: &Path,
     gapfill: &HashSet<String>,
-) -> (usize, usize) {
+) -> (usize, usize, usize) {
     if gapfill.is_empty() {
-        return (0, 0);
+        return (0, 0, 0);
     }
     let mut made = 0usize;
     let mut skipped_dead = 0usize;
+    let mut retry = 0usize;
     for sub in ["SavedClips", "SentryClips"] {
         let Ok(events) = std::fs::read_dir(teslacam.join(sub)) else {
             continue;
@@ -903,13 +971,14 @@ fn backfill_gapfill_links_in(
                     {
                         BackfillOutcome::Made => made += 1,
                         BackfillOutcome::DeadTarget => skipped_dead += 1,
+                        BackfillOutcome::Retry => retry += 1,
                         BackfillOutcome::Skipped => {}
                     }
                 }
             }
         }
     }
-    (made, skipped_dead)
+    (made, skipped_dead, retry)
 }
 
 /// What [`backfill_recent_link`] did with one event-tree entry.
@@ -918,6 +987,9 @@ enum BackfillOutcome {
     /// Source link's target snapshot is gone — creating the cross-link
     /// would mint a permanently dangling entry.
     DeadTarget,
+    /// Undeterminable source or a failed symlink: leave the manifest
+    /// unapplied so a later pass reprocesses this entry.
+    Retry,
     Skipped,
 }
 
@@ -961,10 +1033,11 @@ fn backfill_recent_link(
     // The source link may itself be dangling (its snapshot already
     // released); copying its target would mint a born-dead link. Checked
     // by snapshot-dir name only — never resolved, so autofs stays idle.
-    if owned_snap_component(&target, snapshots, autofs)
-        .is_some_and(|s| !snapshots.join(s).is_dir())
-    {
-        return BackfillOutcome::DeadTarget;
+    match owned_snap_component(&target, snapshots, autofs).map(|s| snapshot_state(snapshots, s)) {
+        Some(SnapState::Gone) => return BackfillOutcome::DeadTarget,
+        // A transient unmount or metadata error is not proof of release.
+        Some(SnapState::Unknown) => return BackfillOutcome::Retry,
+        Some(SnapState::Live) | None => {}
     }
     let _ = std::fs::create_dir_all(&recents);
     #[cfg(unix)]
@@ -972,7 +1045,7 @@ fn backfill_recent_link(
         if std::os::unix::fs::symlink(&target, &link).is_ok() {
             BackfillOutcome::Made
         } else {
-            BackfillOutcome::Skipped
+            BackfillOutcome::Retry
         }
     }
     #[cfg(not(unix))]
@@ -1329,7 +1402,7 @@ mod tests {
 
         assert_eq!(
             backfill_gapfill_links_in(teslacam, &snaps, &autofs, &gapfill),
-            (1, 1),
+            (1, 1, 0),
         );
 
         // The missing manifest clip gained a link with the event link's target.
@@ -1360,7 +1433,7 @@ mod tests {
         // Empty manifest: no-op even with clips present.
         assert_eq!(
             backfill_gapfill_links_in(teslacam, &snaps, &autofs, &HashSet::new()),
-            (0, 0),
+            (0, 0, 0),
         );
     }
 
@@ -1561,8 +1634,8 @@ mod tests {
         let farm = tmp.path();
         let (dead508, live600, evt_dead) = build_farm(farm, "/backingfiles/snapshots");
 
-        let removed = prune_farm_links(farm, &|_, t| t.contains("/snap-000508/"), false);
-        assert_eq!(removed, 2);
+        let removed = prune_farm_links(farm, &|_, t| t.contains("/snap-000508/"), &|| true, false);
+        assert_eq!(removed, (2, false));
         assert!(std::fs::symlink_metadata(&dead508).is_err());
         assert!(std::fs::symlink_metadata(&evt_dead).is_err());
         assert!(std::fs::symlink_metadata(&live600).is_ok(), "non-matching link must survive");
@@ -1598,11 +1671,11 @@ mod tests {
             spared.push(p);
         }
 
-        let counted = sweep_dangling_links_in(&farm, &snaps, &autofs, true).unwrap();
+        let counted = sweep_dangling_links_in(&farm, &snaps, &autofs, &|| true, true).unwrap();
         assert_eq!(counted, 2, "dry run must count without deleting");
         assert!(std::fs::symlink_metadata(&dead508).is_ok());
 
-        let removed = sweep_dangling_links_in(&farm, &snaps, &autofs, false).unwrap();
+        let removed = sweep_dangling_links_in(&farm, &snaps, &autofs, &|| true, false).unwrap();
         assert_eq!(removed, 2);
         assert!(std::fs::symlink_metadata(&dead508).is_err());
         assert!(std::fs::symlink_metadata(&evt_dead).is_err());
@@ -1625,8 +1698,58 @@ mod tests {
         // A concurrent snapshot reusing slot 508 recreates the dir; the
         // per-link re-check must then leave its links alone.
         std::fs::create_dir_all(snaps.join("snap-000508")).unwrap();
-        assert_eq!(sweep_dangling_links_in(&farm, &snaps, &autofs, false).unwrap(), 0);
+        assert_eq!(sweep_dangling_links_in(&farm, &snaps, &autofs, &|| true, false).unwrap(), 0);
         assert!(std::fs::symlink_metadata(&dead508).is_ok());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn sweep_aborts_when_the_mount_guard_flips() {
+        let tmp = tempfile::tempdir().unwrap();
+        let farm = tmp.path().join("TeslaCam");
+        let snaps = tmp.path().join("snapshots");
+        let autofs = tmp.path().join("autofs");
+        std::fs::create_dir_all(snaps.join("snap-000600")).unwrap();
+        let (dead508, ..) = build_farm(&farm, snaps.to_str().unwrap());
+
+        let err = sweep_dangling_links_in(&farm, &snaps, &autofs, &|| false, false).unwrap_err();
+        assert!(err.to_string().contains("mount state changed"));
+        assert!(std::fs::symlink_metadata(&dead508).is_ok());
+    }
+
+    /// An unreadable snapshots dir makes every source undeterminable: the
+    /// backfill must defer them, never treat them as released.
+    #[cfg(unix)]
+    #[test]
+    fn backfill_defers_sources_it_cannot_verify() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let teslacam = tmp.path();
+        let snaps = tmp.path().join("gone-snapshots");
+        let autofs = tmp.path().join("autofs");
+        let evt = teslacam.join("SavedClips/2026-07-15_04-59-30");
+        std::fs::create_dir_all(&evt).unwrap();
+        symlink(
+            format!(
+                "{}/snap-000005/mnt/TeslaCam/SavedClips/2026-07-15_04-59-30/2026-07-15_04-50-00-front.mp4",
+                snaps.display()
+            ),
+            evt.join("2026-07-15_04-50-00-front.mp4"),
+        )
+        .unwrap();
+
+        let gapfill: HashSet<String> = ["2026-07-15_04-50-00".to_string()].into_iter().collect();
+        assert_eq!(
+            backfill_gapfill_links_in(teslacam, &snaps, &autofs, &gapfill),
+            (0, 0, 1),
+        );
+        assert!(
+            std::fs::symlink_metadata(
+                teslacam.join("RecentClips/2026-07-15/2026-07-15_04-50-00-front.mp4")
+            )
+            .is_err(),
+        );
     }
 
     #[cfg(unix)]
@@ -1641,7 +1764,7 @@ mod tests {
         // Empty snapshots dir looks like an unmounted /backingfiles: bail,
         // delete nothing.
         let autofs = tmp.path().join("autofs");
-        assert!(sweep_dangling_links_in(&farm, &snaps, &autofs, false).is_err());
+        assert!(sweep_dangling_links_in(&farm, &snaps, &autofs, &|| true, false).is_err());
         assert!(std::fs::symlink_metadata(&dead508).is_ok());
     }
 }

--- a/crates/usb_gadget/src/snapshot.rs
+++ b/crates/usb_gadget/src/snapshot.rs
@@ -866,25 +866,37 @@ pub fn backfill_gapfill_links() -> Result<()> {
         return Ok(());
     }
     let gapfill = load_gapfill_stamps();
-    let made = backfill_gapfill_links_in(Path::new(TESLACAM), &gapfill);
+    let (made, skipped_dead) =
+        backfill_gapfill_links_in(
+            Path::new(TESLACAM),
+            Path::new(SNAPSHOTS_DIR),
+            Path::new(AUTOFS_SNAPSHOTS),
+            &gapfill,
+        );
     // Written AFTER the walk so a crash mid-pass re-runs it next snapshot.
     std::fs::write(GAPFILL_APPLIED_MARKER, &manifest_body)?;
-    if made > 0 {
+    if made > 0 || skipped_dead > 0 {
         info!(
-            "gap-fill backfill: created {} RecentClips link(s) for manifest clips",
-            made
+            "gap-fill backfill: created {} RecentClips link(s) for manifest clips ({} dead-target source(s) skipped)",
+            made, skipped_dead
         );
     }
     Ok(())
 }
 
-/// [`backfill_gapfill_links`] over an explicit TeslaCam root (testable).
-/// Returns how many links were created.
-fn backfill_gapfill_links_in(teslacam: &Path, gapfill: &HashSet<String>) -> usize {
+/// [`backfill_gapfill_links`] over explicit roots (testable).
+/// Returns `(links created, dead-target sources skipped)`.
+fn backfill_gapfill_links_in(
+    teslacam: &Path,
+    snapshots: &Path,
+    autofs: &Path,
+    gapfill: &HashSet<String>,
+) -> (usize, usize) {
     if gapfill.is_empty() {
-        return 0;
+        return (0, 0);
     }
     let mut made = 0usize;
+    let mut skipped_dead = 0usize;
     for sub in ["SavedClips", "SentryClips"] {
         let Ok(events) = std::fs::read_dir(teslacam.join(sub)) else {
             continue;
@@ -896,14 +908,26 @@ fn backfill_gapfill_links_in(teslacam: &Path, gapfill: &HashSet<String>) -> usiz
             }
             if let Ok(clips) = std::fs::read_dir(&evt_path) {
                 for clip in clips.flatten() {
-                    if backfill_recent_link(teslacam, &clip.path(), gapfill) {
-                        made += 1;
+                    match backfill_recent_link(teslacam, snapshots, autofs, &clip.path(), gapfill)
+                    {
+                        BackfillOutcome::Made => made += 1,
+                        BackfillOutcome::DeadTarget => skipped_dead += 1,
+                        BackfillOutcome::Skipped => {}
                     }
                 }
             }
         }
     }
-    made
+    (made, skipped_dead)
+}
+
+/// What [`backfill_recent_link`] did with one event-tree entry.
+enum BackfillOutcome {
+    Made,
+    /// Source link's target snapshot is gone — creating the cross-link
+    /// would mint a permanently dangling entry.
+    DeadTarget,
+    Skipped,
 }
 
 /// Create the `RecentClips/<date>/` link for one event-tree entry IFF its
@@ -911,24 +935,30 @@ fn backfill_gapfill_links_in(teslacam: &Path, gapfill: &HashSet<String>) -> usiz
 /// link shape as [`maybe_gapfill_recent_link`], but sourced from the
 /// already-built event link instead of a snapshot mount.
 #[cfg_attr(not(unix), allow(unused_variables))]
-fn backfill_recent_link(teslacam: &Path, clip: &Path, gapfill: &HashSet<String>) -> bool {
+fn backfill_recent_link(
+    teslacam: &Path,
+    snapshots: &Path,
+    autofs: &Path,
+    clip: &Path,
+    gapfill: &HashSet<String>,
+) -> BackfillOutcome {
     let filename = match clip.file_name().map(|s| s.to_string_lossy().to_string()) {
         Some(f) => f,
-        None => return false,
+        None => return BackfillOutcome::Skipped,
     };
     let stamp = match clip_stamp(&filename) {
         Some(s) => s,
-        None => return false,
+        None => return BackfillOutcome::Skipped,
     };
     if !gapfill.contains(stamp) {
-        return false;
+        return BackfillOutcome::Skipped;
     }
     let recents = teslacam.join("RecentClips").join(&filename[..10]);
     let link = recents.join(&filename);
     // Never clobber: an existing entry is either genuine continuous
     // footage or a cross-link a snapshot pass already created.
     if std::fs::symlink_metadata(&link).is_ok() {
-        return false;
+        return BackfillOutcome::Skipped;
     }
     // The event entry is itself a symlink into <snapdir>/mnt/...; reuse
     // its stored target. A plain file (shouldn't occur in this tree)
@@ -937,13 +967,25 @@ fn backfill_recent_link(teslacam: &Path, clip: &Path, gapfill: &HashSet<String>)
         Ok(t) => t.to_string_lossy().to_string(),
         Err(_) => clip.to_string_lossy().to_string(),
     };
+    // The source link may itself be dangling (its snapshot already
+    // released); copying its target would mint a born-dead link. Checked
+    // by snapshot-dir name only — never resolved, so autofs stays idle.
+    if owned_snap_component(&target, snapshots, autofs)
+        .is_some_and(|s| !snapshots.join(s).is_dir())
+    {
+        return BackfillOutcome::DeadTarget;
+    }
     let _ = std::fs::create_dir_all(&recents);
     #[cfg(unix)]
     {
-        std::os::unix::fs::symlink(&target, &link).is_ok()
+        if std::os::unix::fs::symlink(&target, &link).is_ok() {
+            BackfillOutcome::Made
+        } else {
+            BackfillOutcome::Skipped
+        }
     }
     #[cfg(not(unix))]
-    false
+    BackfillOutcome::Skipped
 }
 
 /// One-time cleanup mirroring the bash `purge_event_links_from_recentclips`.
@@ -1239,8 +1281,8 @@ mod tests {
     /// Backfill creates a RecentClips link for a manifest clip that only
     /// exists in the (already-linked) event tree, reusing the event
     /// link's stored target; non-manifest clips are ignored and existing
-    /// RecentClips entries are never clobbered. Targets are dangling on
-    /// purpose — the pass reads link strings, never the files behind them.
+    /// RecentClips entries are never clobbered. The pass reads link
+    /// strings, never the files behind them.
     #[cfg(unix)]
     #[test]
     fn backfill_creates_missing_manifest_links_only() {
@@ -1248,22 +1290,39 @@ mod tests {
         use tempfile::TempDir;
 
         let root = TempDir::new().unwrap();
-        let teslacam = root.path();
+        let teslacam = root.path().join("TeslaCam");
+        let teslacam = teslacam.as_path();
+        let snaps = root.path().join("snapshots");
+        let autofs = root.path().join("autofs");
+        std::fs::create_dir_all(snaps.join("snap-000005")).unwrap();
         let evt = teslacam.join("SavedClips/2026-07-15_04-59-30");
         std::fs::create_dir_all(&evt).unwrap();
 
-        let target_a = "/backingfiles/snapshots/snap-000005/mnt/TeslaCam/SavedClips/2026-07-15_04-59-30/2026-07-15_04-50-00-front.mp4";
-        symlink(target_a, evt.join("2026-07-15_04-50-00-front.mp4")).unwrap();
+        let clip_target = |snap: &str, stamp: &str| {
+            format!(
+                "{}/{snap}/mnt/TeslaCam/SavedClips/2026-07-15_04-59-30/{stamp}-front.mp4",
+                snaps.display()
+            )
+        };
+        let target_a = clip_target("snap-000005", "2026-07-15_04-50-00");
+        symlink(&target_a, evt.join("2026-07-15_04-50-00-front.mp4")).unwrap();
         // In the manifest but already cross-linked → must not be clobbered.
         symlink(
-            "/backingfiles/snapshots/snap-000005/mnt/TeslaCam/SavedClips/2026-07-15_04-59-30/2026-07-15_04-55-00-front.mp4",
+            clip_target("snap-000005", "2026-07-15_04-55-00"),
             evt.join("2026-07-15_04-55-00-front.mp4"),
         )
         .unwrap();
         // Not in the manifest → must stay out of RecentClips.
         symlink(
-            "/backingfiles/snapshots/snap-000005/mnt/TeslaCam/SavedClips/2026-07-15_04-59-30/2026-07-15_04-58-00-front.mp4",
+            clip_target("snap-000005", "2026-07-15_04-58-00"),
             evt.join("2026-07-15_04-58-00-front.mp4"),
+        )
+        .unwrap();
+        // In the manifest, but its snapshot is already released: copying
+        // this target would mint a born-dead RecentClips link.
+        symlink(
+            clip_target("snap-000004", "2026-07-15_04-52-00"),
+            evt.join("2026-07-15_04-52-00-front.mp4"),
         )
         .unwrap();
 
@@ -1275,14 +1334,23 @@ mod tests {
         let mut gapfill = HashSet::new();
         gapfill.insert("2026-07-15_04-50-00".to_string());
         gapfill.insert("2026-07-15_04-55-00".to_string());
+        gapfill.insert("2026-07-15_04-52-00".to_string());
 
-        assert_eq!(backfill_gapfill_links_in(teslacam, &gapfill), 1);
+        assert_eq!(
+            backfill_gapfill_links_in(teslacam, &snaps, &autofs, &gapfill),
+            (1, 1),
+        );
 
         // The missing manifest clip gained a link with the event link's target.
         let made = day.join("2026-07-15_04-50-00-front.mp4");
         assert_eq!(
             std::fs::read_link(&made).unwrap().to_string_lossy(),
             target_a
+        );
+        // The released-snapshot source was skipped, not propagated.
+        assert!(
+            std::fs::symlink_metadata(day.join("2026-07-15_04-52-00-front.mp4")).is_err(),
+            "must not mint a link into a released snapshot",
         );
         // Existing entry untouched.
         assert_eq!(
@@ -1294,9 +1362,15 @@ mod tests {
             std::fs::symlink_metadata(day.join("2026-07-15_04-58-00-front.mp4")).is_err()
         );
         // Idempotent: second run creates nothing.
-        assert_eq!(backfill_gapfill_links_in(teslacam, &gapfill), 0);
+        assert_eq!(
+            backfill_gapfill_links_in(teslacam, &snaps, &autofs, &gapfill).0,
+            0,
+        );
         // Empty manifest: no-op even with clips present.
-        assert_eq!(backfill_gapfill_links_in(teslacam, &HashSet::new()), 0);
+        assert_eq!(
+            backfill_gapfill_links_in(teslacam, &snaps, &autofs, &HashSet::new()),
+            (0, 0),
+        );
     }
 
     /// The purge keys off each symlink's stored target: links into

--- a/crates/usb_gadget/src/space.rs
+++ b/crates/usb_gadget/src/space.rs
@@ -10,6 +10,10 @@ const MIN_FREE_PCT: f64 = 5.0; // Minimum free space percentage before cleanup
 
 /// Check if free space is below the threshold and release old snapshots if needed.
 pub async fn manage_free_space() -> Result<()> {
+    // Held across the whole release loop, matching manage_free_space.sh; the
+    // releases below therefore use the already-locked entry point.
+    let _lock = super::snapshot::lock_snapshots_dir()?;
+
     let (total, free) = get_space(BACKINGFILES)?;
     if total == 0 {
         return Ok(());
@@ -32,7 +36,7 @@ pub async fn manage_free_space() -> Result<()> {
 
     // Release oldest snapshots first until we're above the threshold
     for snap in &snapshots {
-        if let Err(e) = super::snapshot::release_snapshot(snap).await {
+        if let Err(e) = super::snapshot::release_snapshot_locked(snap).await {
             warn!("Failed to release {}: {}", snap, e);
             continue;
         }

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -981,16 +981,32 @@ function archive_teslacam_clips () {
   # a crafted filename on the cam volume would have been EXECUTED.
   # `-d '\n'` keeps each line one path; broken symlinks just drop out
   # (stat errors to /dev/null), matching the old find -L behavior.
+  # The same stat pass also records every readable entry, so entries whose
+  # source is gone (dangling symlinks into deleted snapshots) can be
+  # dropped from the pending count below.
+  local -r presentlist=/tmp/present_files
   if [ -s "${sentrylist}" ]
   then
     (cd "$overlaymerged"; xargs -a "${sentrylist}" -d '\n' stat -L --format='%s %n' 2>/dev/null) \
-      | awk '$1 < 100000 { sub(/^[0-9]+ /, ""); if (/\.mp4$/) print }' > "${ignorelist}"
+      | awk -v ignore="${ignorelist}" -v present="${presentlist}" '
+          BEGIN { printf "" > ignore; printf "" > present }
+          { line = $0; sub(/^[0-9]+ /, "", line); print line > present
+            if ($1 < 100000 && line ~ /\.mp4$/) print line > ignore }'
   else
     true > "${ignorelist}"
+    true > "${presentlist}"
   fi
 
   # remove the short files from the list of files to be archived
   prunefile "${sentrylist}" "${ignorelist}"
+
+  # Drop entries whose source no longer exists: rsync --ignore-missing-args
+  # skips them silently, so counting them reports files that will never
+  # move (e.g. clips the car relocated into an event folder).
+  local stale_count
+  stale_count=$(wc -l < "${sentrylist}")
+  intersect "${sentrylist}" "${presentlist}"
+  stale_count=$((stale_count - $(wc -l < "${sentrylist}")))
 
   # apply custom removals/additions
   filterfile "${sentrylist}"
@@ -1008,6 +1024,10 @@ function archive_teslacam_clips () {
 
   log "There are $event_count event folder(s) with $sentry_count file(s) and $trackmode_count track mode file(s) to move." \
       " $ignore_count short recording(s) will be skipped."
+  if [ "$stale_count" -gt 0 ]
+  then
+    log "Ignoring $stale_count stale list entry(s) whose source files no longer exist"
+  fi
 
   local archive_success=true
   if [[ "$total_count" -gt 0 ]]

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -756,6 +756,18 @@ function prunefile {
   mv /tmp/prune_tmp.$$ "$1"
 }
 
+# True while /backingfiles is a mount point. One fork-free read so the loop
+# below can re-prove the mount cheaply. Only the mountpoint field can be a
+# space-delimited path (/proc escapes spaces); unreadable proves nothing.
+function backingfiles_is_mounted () {
+  local mounts
+  mounts=$(</proc/self/mounts) || return 1
+  case "$mounts" in
+    *" /backingfiles "*) return 0 ;;
+  esac
+  return 1
+}
+
 # Classify list entries the stat pass could not read: only entries whose
 # source is provably gone are written to $2. Any ambiguous error (EIO,
 # ESTALE, permission, mount outage) is left out so it stays counted.
@@ -764,14 +776,24 @@ function classify_missing_entries () {
   local -r outfile="$2"
   local -r root="$3"
   local entry err target snap
+  local checked=0
   true > "$outfile"
   # A stale directory under an unmounted /backingfiles would look like proof
   # that every snapshot is gone, suppressing the whole backlog. Without a
   # proven mount, drop nothing.
-  findmnt --mountpoint /backingfiles > /dev/null 2>&1 || return 0
+  backingfiles_is_mounted || return 0
   while IFS= read -r entry
   do
     [ -n "$entry" ] || continue
+    # Re-prove the mount every 32 entries: an unmount part-way through would
+    # make every later entry look absent. The outage may predate any entry
+    # already classified, so discard the whole run rather than trust it.
+    checked=$((checked + 1))
+    if [ $((checked % 32)) -eq 0 ] && ! backingfiles_is_mounted
+    then
+      true > "$outfile"
+      return 0
+    fi
     # Readable again since the batch pass: nothing to drop.
     err=$(LC_ALL=C stat -L --format='%s' "${root}/${entry}" 2>&1 >/dev/null) && continue
     # stat prints "stat: cannot stat '<path>': <errno>"; keep only the text
@@ -803,6 +825,11 @@ function classify_missing_entries () {
         ;;
     esac
   done < "$listfile"
+  # Final batch: without this an unmount in the last <32 entries goes unseen.
+  if ! backingfiles_is_mounted
+  then
+    true > "$outfile"
+  fi
 }
 
 function intersect {

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -765,13 +765,19 @@ function classify_missing_entries () {
   local -r root="$3"
   local entry err target snap
   true > "$outfile"
+  # A stale directory under an unmounted /backingfiles would look like proof
+  # that every snapshot is gone, suppressing the whole backlog. Without a
+  # proven mount, drop nothing.
+  findmnt --mountpoint /backingfiles > /dev/null 2>&1 || return 0
   while IFS= read -r entry
   do
     [ -n "$entry" ] || continue
     # Readable again since the batch pass: nothing to drop.
-    err=$(stat -L --format='%s' "${root}/${entry}" 2>&1 >/dev/null) && continue
-    case "$err" in
-      *"No such file or directory"*) ;;
+    err=$(LC_ALL=C stat -L --format='%s' "${root}/${entry}" 2>&1 >/dev/null) && continue
+    # stat prints "stat: cannot stat '<path>': <errno>"; keep only the text
+    # after the last ": " so a path containing an errno phrase cannot match.
+    case "${err##*: }" in
+      "No such file or directory"*) ;;
       *) continue ;;
     esac
     target=""
@@ -786,12 +792,8 @@ function classify_missing_entries () {
         snap=${snap%%/*}
         if [ ! -d "/backingfiles/snapshots/${snap}" ]
         then
-          # A missing snapshot only proves absence when the snapshots
-          # directory itself is readable (i.e. /backingfiles is mounted).
-          if [ -d /backingfiles/snapshots ]
-          then
-            echo "$entry" >> "$outfile"
-          fi
+          # The mount is proven above, so an absent snapshot dir is real.
+          echo "$entry" >> "$outfile"
         elif [ -d "/backingfiles/snapshots/${snap}/mnt/TeslaCam" ]
         then
           # Snapshot present and mounted, so the clip itself is gone

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -756,6 +756,53 @@ function prunefile {
   mv /tmp/prune_tmp.$$ "$1"
 }
 
+# Classify list entries the stat pass could not read: only entries whose
+# source is provably gone are written to $2. Any ambiguous error (EIO,
+# ESTALE, permission, mount outage) is left out so it stays counted.
+function classify_missing_entries () {
+  local -r listfile="$1"
+  local -r outfile="$2"
+  local -r root="$3"
+  local entry err target snap
+  true > "$outfile"
+  while IFS= read -r entry
+  do
+    [ -n "$entry" ] || continue
+    # Readable again since the batch pass: nothing to drop.
+    err=$(stat -L --format='%s' "${root}/${entry}" 2>&1 >/dev/null) && continue
+    case "$err" in
+      *"No such file or directory"*) ;;
+      *) continue ;;
+    esac
+    target=""
+    if [ -L "${root}/${entry}" ]
+    then
+      target=$(readlink "${root}/${entry}" || true)
+    fi
+    case "$target" in
+      /backingfiles/snapshots/snap-*|/tmp/snapshots/snap-*)
+        snap=${target#/backingfiles/snapshots/}
+        snap=${snap#/tmp/snapshots/}
+        snap=${snap%%/*}
+        if [ ! -d "/backingfiles/snapshots/${snap}" ]
+        then
+          # A missing snapshot only proves absence when the snapshots
+          # directory itself is readable (i.e. /backingfiles is mounted).
+          if [ -d /backingfiles/snapshots ]
+          then
+            echo "$entry" >> "$outfile"
+          fi
+        elif [ -d "/backingfiles/snapshots/${snap}/mnt/TeslaCam" ]
+        then
+          # Snapshot present and mounted, so the clip itself is gone
+          # (e.g. the car moved it into an event folder).
+          echo "$entry" >> "$outfile"
+        fi
+        ;;
+    esac
+  done < "$listfile"
+}
+
 function intersect {
   sortfile "$1"
   sortfile "$2"
@@ -981,9 +1028,9 @@ function archive_teslacam_clips () {
   # a crafted filename on the cam volume would have been EXECUTED.
   # `-d '\n'` keeps each line one path; broken symlinks just drop out
   # (stat errors to /dev/null), matching the old find -L behavior.
-  # The same stat pass also records every readable entry, so entries whose
-  # source is gone (dangling symlinks into deleted snapshots) can be
-  # dropped from the pending count below.
+  # The same stat pass also records every readable entry; the unreadable
+  # remainder is re-checked one by one below, since a failed stat alone
+  # does not prove the source is gone.
   local -r presentlist=/tmp/present_files
   if [ -s "${sentrylist}" ]
   then
@@ -1000,13 +1047,24 @@ function archive_teslacam_clips () {
   # remove the short files from the list of files to be archived
   prunefile "${sentrylist}" "${ignorelist}"
 
-  # Drop entries whose source no longer exists: rsync --ignore-missing-args
+  # Drop entries whose source is PROVABLY gone: rsync --ignore-missing-args
   # skips them silently, so counting them reports files that will never
-  # move (e.g. clips the car relocated into an event folder).
-  local stale_count
+  # move (e.g. clips the car relocated into an event folder). Entries that
+  # merely failed to stat stay counted — under-counting hides real work.
+  local -r missinglist=/tmp/missing_files
+  local -r absentlist=/tmp/absent_files
+  cp "${sentrylist}" "${missinglist}"
+  prunefile "${missinglist}" "${presentlist}"
+  true > "${absentlist}"
+  if [ -s "${missinglist}" ]
+  then
+    classify_missing_entries "${missinglist}" "${absentlist}" "${overlaymerged}"
+  fi
+  local stale_count unknown_count
   stale_count=$(wc -l < "${sentrylist}")
-  intersect "${sentrylist}" "${presentlist}"
+  prunefile "${sentrylist}" "${absentlist}"
   stale_count=$((stale_count - $(wc -l < "${sentrylist}")))
+  unknown_count=$(($(wc -l < "${missinglist}") - $(wc -l < "${absentlist}")))
 
   # apply custom removals/additions
   filterfile "${sentrylist}"
@@ -1027,6 +1085,10 @@ function archive_teslacam_clips () {
   if [ "$stale_count" -gt 0 ]
   then
     log "Ignoring $stale_count stale list entry(s) whose source files no longer exist"
+  fi
+  if [ "$unknown_count" -gt 0 ]
+  then
+    log "Keeping $unknown_count list entry(s) counted: source status could not be determined"
   fi
 
   local archive_success=true

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -818,9 +818,13 @@ function classify_missing_entries () {
           echo "$entry" >> "$outfile"
         elif [ -d "/backingfiles/snapshots/${snap}/mnt/TeslaCam" ]
         then
-          # Snapshot present and mounted, so the clip itself is gone
-          # (e.g. the car moved it into an event folder).
-          echo "$entry" >> "$outfile"
+          # That probe triggers the autofs mount, so the first stat may have
+          # failed only because it had not mounted yet. Re-stat the clip and
+          # drop it only if it is still absent.
+          err=$(LC_ALL=C stat -L --format='%s' "${root}/${entry}" 2>&1 >/dev/null) && continue
+          case "${err##*: }" in
+            "No such file or directory"*) echo "$entry" >> "$outfile" ;;
+          esac
         fi
         ;;
     esac


### PR DESCRIPTION
# fix(archive): stop the dangling-link leak and the pending count it inflates

## Problem

Archive notifications report far more files than they archive:

```
Archive started:  Archiving 377 file(s)
Archive complete: Archived 8 files in 7s
```

This is not a stalled archive and no footage is lost. `/mutable/TeslaCam` is a farm of
symlinks into snapshots under `/backingfiles/snapshots`. When a snapshot is released, links
pointing into it are supposed to be purged. Two paths leave them behind, so they accumulate
as permanently dangling links. `find -type l` counts them, rsync `--ignore-missing-args`
skips them, and the post-pass never marks them archived — so they are counted, skipped, and
re-counted every cycle, forever.

Arithmetic signature: `to_move − archived == missing`, stable across cycles.

On one unit: **11,073 of 21,512 links dangling**, referencing 120 released snapshots.

## Two producers

1. **`release_snapshot()` omits the link purge** that `release_snapshot.sh` performs
   (`find /mutable/TeslaCam -lname "*/NAME/*" -delete`). Installs using the Rust wrapper leak
   from first release onward.
2. **Gap-fill cross-links** copy a source link's target via `read_link` without checking it
   resolves, minting born-dead links.

Normal use produces these without any failure: a car away from network for days cannot
archive; the car relocates `RecentClips` into `SentryClips` event folders; snapshot rotation
then deletes the snapshots holding the old paths.

## Changes

| commit | change |
|---|---|
| `1b6ae00` | `archiveloop`: exclude provably-absent sources from the pending count |
| `3ff05ba` | purge farm links on Rust release; add a boot-time sweep for links already orphaned |
| `6ad26f1` | harden the sweep before it deletes: strict predicate, proven mount, re-verify |
| `c5adc46` | gap-fill skips sources whose snapshot was released |
| `afdba3d` | close slot-reuse, symlink-mount, locale and lock races |
| `4a157a4` | re-prove the `/backingfiles` mount before each destructive step |

### Deletion safety

The sweep deletes symlinks, so it is written to refuse rather than guess:

- **Strict predicate** — `owned_snap_component()` matches only the two shapes the linkers in
  this file mint: `<snapshots>/snap-NNNNNN/mnt/<file…>` and `<autofs>/snap-NNNNNN/<file…>`.
  Targets must be absolute and lexically clean; any `..`, `.` or empty component
  disqualifies. A foreign root, a merely-similar path, or a bare `snap-NNNNNN` filename is
  left alone.
- **Proven mount, re-proved before every unlink** — `/backingfiles` must be a real mount point
  (`/proc/mounts`; the `st_dev` fallback runs only when `/proc` is unreadable, and rejects
  symlinks). A stale directory under an unmounted mountpoint would otherwise make every
  snapshot look absent, turning healthy links into false positives. The check runs per
  directory *and* immediately before each individual unlink; if the mount drops, the walk
  aborts at once and reports how many links were removed before aborting. This matters
  because `storage_repair` unmounts `/backingfiles` without taking the snapshots lock, so
  locking alone does not exclude it.
- **Tri-state classification** — `SnapState{Live, Gone, Unknown}`. Only `Gone` permits
  removal; an unreadable snapshots dir yields `Unknown`, never `Gone`.
- **Slot reuse** — release-time purge requires the named snapshot be `Gone`, so links into a
  reused snapshot number survive.
- **One lock** — the Rust `make_snapshot` / `release_snapshot` / `manage_free_space` paths now
  take the same `flock` on the snapshots dir that the shell producers and the sweep take,
  acquired at the outermost entry point only.

### Pending count

Fails safe toward over-counting. Only entries whose source is provably absent are excluded;
any ambiguous error (EIO, ESTALE, permission, mount outage) stays counted. `LC_ALL=C` is
pinned and only the errno portion after the last `": "` is matched, so a locale change or a
pathname containing an errno phrase cannot misclassify. The mount is re-proved per entry via
a fork-free `/proc/self/mounts` read; if it ever becomes unproven, classification stops and
nothing further is dropped.

## Validation

Run on hardware carrying the backlog described above, from a temporary binary, with a
full before/after inventory of every link and its target:

```
                    before    after
symlinks total       21,512   10,439
resolving OK         10,439   10,439      <- 0 lost
dangling             11,073        0
snapshot dirs           121      121
```

- Dry run reported 11,073; an independent `find -xtype l` agreed; the real run removed 11,073
  in 1.05s.
- Of the 10,439 healthy links present before, **0 were missing after**.
- The removal set equalled the dangling set exactly — nothing outside it was touched.
- Footage store untouched.

Notifications on the next cycle, with no counting change deployed:

```
Archive started:  Archiving 92 file(s)
Archive complete: Archived 92 files in 1m20s
```

The count became honest because the underlying data did. `1b6ae00` is a mitigation for
installs still carrying a backlog, not the fix.

## Tests

`cargo test -p sentryusb-gadget --lib` — 24 pass, including:

- `sweep_removes_only_links_into_missing_snapshots`
- `sweep_spares_a_link_that_became_valid_during_the_walk`
- `sweep_aborts_before_the_next_unlink_when_the_mount_drops_mid_directory`
- `release_prune_spares_links_into_a_reused_snapshot_slot`
- `sweep_bails_when_no_snapshots_visible`

`cargo check --workspace` and `bash -n run/archiveloop` clean.

## Notes for review

- The sweep runs 60s after boot, off the boot path, and is idempotent — a skipped run retries
  next boot.
- `snapshot sweep --dry-run` reports what would be removed without deleting.
- Remaining residual: the unlink is pathname-based, so a window exists between the final
  re-verify and `remove_file`. The shared lock closes it against the snapshot producers
  (shell and Rust). It does not cover a writer that manipulates the farm without taking that
  lock — `storage_repair` is one such in-tree path, which is why the mount is re-proved
  immediately before each unlink rather than relying on locking alone.
- `make_snapshot` holds the lock across long I/O, so a concurrent free-space run or sweep can
  hit the lock timeout and skip a cycle. That defers work; it does not affect correctness.
