### PR TITLE
fix(drives): keep trailing Park runs in gearRuns + port Summon detection

### DIFF
--- a/crates/api/src/drives_handler.rs
+++ b/crates/api/src/drives_handler.rs
@@ -281,6 +281,10 @@ fn single_drive_blocking(
                 drive.tacc_distance_km = s.tacc_distance_km;
                 drive.tacc_distance_mi = s.tacc_distance_mi;
                 drive.assisted_percent = s.assisted_percent;
+                // Summon is only decided on the summary path — it needs
+                // the park-split segment frame bounds that the full-BLOB
+                // rebuild above doesn't carry.
+                drive.summon = s.summon;
             }
             (
                 StatusCode::OK,

--- a/crates/drives/examples/probe_clip.rs
+++ b/crates/drives/examples/probe_clip.rs
@@ -1,0 +1,50 @@
+//! Probe a Tesla dashcam clip's SEI stream: raw frame count, gear/flag
+//! RLEs (raw frame space), and SEI speed extremes. Handy for verifying
+//! the extractor against real footage without a full server run.
+//!
+//! Usage:
+//!     cargo run -p sentryusb-drives --example probe_clip -- <clip.mp4> [more.mp4 ...]
+
+use sentryusb_drives::extract::extract_gps_from_file;
+
+fn gear_name(g: u8) -> &'static str {
+    match g {
+        0 => "Park",
+        1 => "Drive",
+        2 => "Reverse",
+        3 => "Neutral",
+        _ => "?",
+    }
+}
+
+fn main() -> anyhow::Result<()> {
+    let paths: Vec<String> = std::env::args().skip(1).collect();
+    if paths.is_empty() {
+        eprintln!("usage: probe_clip <clip.mp4> [more.mp4 ...]");
+        std::process::exit(2);
+    }
+    for path in paths {
+        let gps = extract_gps_from_file(&path)?;
+        println!("{path}");
+        println!("  raw_frame_count:  {}", gps.raw_frame_count);
+        println!("  raw_park_count:   {}", gps.raw_park_count);
+        println!("  points (deduped): {}", gps.points.len());
+        let gears: Vec<String> = gps
+            .gear_runs
+            .iter()
+            .map(|r| format!("{} x{}", gear_name(r.gear), r.frames))
+            .collect();
+        println!("  gearRuns:  [{}]", gears.join(", "));
+        // Flag bits: 1=blinker L, 2=blinker R, 4=brake, 8=accel — shown
+        // as ABRL binary so hazards read as 0011.
+        let flags: Vec<String> = gps
+            .flag_runs
+            .iter()
+            .map(|r| format!("{:04b} x{}", r.flags, r.frames))
+            .collect();
+        println!("  flagRuns (ABRL bits): [{}]", flags.join(", "));
+        let max_abs = gps.speeds.iter().fold(0.0f32, |m, s| m.max(s.abs()));
+        println!("  max |sei speed|:  {max_abs:.2} m/s");
+    }
+    Ok(())
+}

--- a/crates/drives/examples/probe_clip.rs
+++ b/crates/drives/examples/probe_clip.rs
@@ -32,11 +32,7 @@ fn main() -> anyhow::Result<()> {
         let gears: Vec<String> = gps
             .gear_runs
             .iter()
-            .enumerate()
-            .map(|(i, r)| {
-                let max = gps.gear_run_speed_max.get(i).copied().unwrap_or(0.0);
-                format!("{} x{} (|v|max {max:.2})", gear_name(r.gear), r.frames)
-            })
+            .map(|r| format!("{} x{}", gear_name(r.gear), r.frames))
             .collect();
         println!("  gearRuns:  [{}]", gears.join(", "));
         // Flag bits: 1=blinker L, 2=blinker R, 4=brake, 8=accel — shown
@@ -44,7 +40,10 @@ fn main() -> anyhow::Result<()> {
         let flags: Vec<String> = gps
             .flag_runs
             .iter()
-            .map(|r| format!("{:04b} x{}", r.flags, r.frames))
+            .map(|r| {
+                let max = r.max_mps.unwrap_or(f64::NAN);
+                format!("{:04b} x{} (|v|max {max:.1})", r.flags, r.frames)
+            })
             .collect();
         println!("  flagRuns (ABRL bits): [{}]", flags.join(", "));
         let max_abs = gps.speeds.iter().fold(0.0f32, |m, s| m.max(s.abs()));

--- a/crates/drives/examples/probe_clip.rs
+++ b/crates/drives/examples/probe_clip.rs
@@ -32,7 +32,11 @@ fn main() -> anyhow::Result<()> {
         let gears: Vec<String> = gps
             .gear_runs
             .iter()
-            .map(|r| format!("{} x{}", gear_name(r.gear), r.frames))
+            .enumerate()
+            .map(|(i, r)| {
+                let max = gps.gear_run_speed_max.get(i).copied().unwrap_or(0.0);
+                format!("{} x{} (|v|max {max:.2})", gear_name(r.gear), r.frames)
+            })
             .collect();
         println!("  gearRuns:  [{}]", gears.join(", "));
         // Flag bits: 1=blinker L, 2=blinker R, 4=brake, 8=accel — shown

--- a/crates/drives/src/aggregate.rs
+++ b/crates/drives/src/aggregate.rs
@@ -46,7 +46,13 @@ pub fn compute_route_aggregates(r: &Route) -> RouteAggregates {
     let has_ap = r.autopilot_states.len() == n;
     let has_gears = r.gear_states.len() == n;
     let has_accel = r.accel_positions.len() == n;
-    let has_sei_speeds = r.speeds.len() == n && r.speeds.iter().any(|&sp| sp > 0.0);
+    // Channel presence vs usefulness: `has_speeds_channel` = the clip
+    // carries an SEI speed array at all (feeds `sei_speed_abs_max`, which
+    // is NULL without the channel); `has_sei_speeds` additionally requires
+    // a positive sample — the locked stats fall back to GPS-derived speed
+    // when SEI reads all-zero/negative, and that behavior must not shift.
+    let has_speeds_channel = r.speeds.len() == n;
+    let has_sei_speeds = has_speeds_channel && r.speeds.iter().any(|&sp| sp > 0.0);
 
     // Start/End points: first and last non-null-island Points. Tracked
     // independently of the pair loop so single-point clips still report
@@ -147,6 +153,7 @@ pub fn compute_route_aggregates(r: &Route) -> RouteAggregates {
     }
 
     let mut speed_sum = 0.0f64;
+    let mut sei_abs_max = 0.0f64;
 
     for i in 1..n {
         let prev = r.points[i - 1];
@@ -163,6 +170,17 @@ pub fn compute_route_aggregates(r: &Route) -> RouteAggregates {
         }
 
         agg.distance_m += d;
+
+        // v16 summon evidence: max |SEI speed| regardless of sign. SEI
+        // speed is SIGNED (negative in Reverse); the locked stats below
+        // drop negative samples, but the summon detector must see a
+        // reverse-only crawl as movement. Same 100 m/s sanity cap.
+        if has_speeds_channel {
+            let abs_speed = (r.speeds[i] as f64).abs();
+            if abs_speed < 100.0 && abs_speed > sei_abs_max {
+                sei_abs_max = abs_speed;
+            }
+        }
 
         // Speed accounting.
         if has_sei_speeds {
@@ -288,6 +306,14 @@ pub fn compute_route_aggregates(r: &Route) -> RouteAggregates {
 
     if agg.speed_sample_count > 0 {
         agg.avg_speed_mps = speed_sum / agg.speed_sample_count as f64;
+    }
+
+    // Some(0.0) means "the clip HAS an SEI speed channel but never moved";
+    // None means "no channel at all" — the summon detector treats both as
+    // not-SEI-verified movement, but the distinction keeps the column
+    // honest for future consumers.
+    if has_speeds_channel {
+        agg.sei_speed_abs_max = Some(sei_abs_max);
     }
 
     agg
@@ -528,6 +554,41 @@ mod tests {
         assert_eq!(agg.ap_at_start, Some(AUTOPILOT_FSD as i32));
         let agg2 = compute_route_aggregates(&boundary_route(vec![], vec![4; 61], vec![]));
         assert_eq!(agg2.ap_at_start, None, "no AP data → no start mode");
+    }
+
+    #[test]
+    fn sei_speed_abs_max_sees_reverse_and_channel_absence() {
+        // Reverse-only crawl: SEI speeds all negative. The locked
+        // max_speed_mps drops them (stays 0), but the summon-evidence
+        // column must carry the magnitude.
+        let mut r = route_with(
+            (0..10)
+                .map(|i| [37.7749 + i as f64 * 0.00001, -122.4194])
+                .collect(),
+        );
+        r.speeds = vec![-1.5; 10];
+        let agg = compute_route_aggregates(&r);
+        // Locked stats drop the negative SEI samples and fall back to
+        // GPS-derived speed (~0.17 m/s for these points) — the 1.5 m/s
+        // SEI magnitude must never leak into max_speed_mps.
+        assert!(
+            agg.max_speed_mps < 1.0,
+            "locked column must stay GPS-derived, got {}",
+            agg.max_speed_mps
+        );
+        let abs_max = agg.sei_speed_abs_max.expect("channel present");
+        assert!((abs_max - 1.5).abs() < 1e-9, "got {abs_max}");
+
+        // No SEI speed channel at all → None, not Some(0.0).
+        let r2 = route_with(vec![[37.7749, -122.4194], [37.7750, -122.4194]]);
+        let agg2 = compute_route_aggregates(&r2);
+        assert!(agg2.sei_speed_abs_max.is_none());
+
+        // Channel present but the car never moved → Some(0.0).
+        let mut r3 = route_with(vec![[37.7749, -122.4194], [37.7750, -122.4194]]);
+        r3.speeds = vec![0.0; 2];
+        let agg3 = compute_route_aggregates(&r3);
+        assert_eq!(agg3.sei_speed_abs_max, Some(0.0));
     }
 
     #[test]

--- a/crates/drives/src/backfill.rs
+++ b/crates/drives/src/backfill.rs
@@ -278,8 +278,9 @@ fn backfill_one_batch(conn: &mut Connection) -> Result<i64> {
                 park_ms_start        = ?20,
                 fsd_at_end           = ?21,
                 fsd_accel_pushes_early = ?22,
-                ap_at_start          = ?23
-             WHERE file = ?24",
+                ap_at_start          = ?23,
+                sei_speed_abs_max    = ?24
+             WHERE file = ?25",
         )?;
         for (file, a) in &decoded {
             stmt.execute(params![
@@ -306,6 +307,7 @@ fn backfill_one_batch(conn: &mut Connection) -> Result<i64> {
                 a.fsd_at_end as i64,
                 a.fsd_accel_pushes_early,
                 a.ap_at_start,
+                a.sei_speed_abs_max,
                 file,
             ])
             .with_context(|| format!("update {}", file))?;

--- a/crates/drives/src/blob.rs
+++ b/crates/drives/src/blob.rs
@@ -146,11 +146,12 @@ pub fn decode_gear_runs(buf: Option<&[u8]>) -> Result<Option<Vec<GearRun>>> {
 }
 
 // -----------------------------------------------------------------------------
-// FlagRuns: 1-byte flags + 4-byte i32 frames per run (same wire shape as
-// GearRuns)
+// FlagRuns: 1-byte flags + 4-byte i32 frames + 4-byte f32 max_mps per run
+// (gear-run wire shape plus the per-run |SEI speed| max; NaN encodes an
+// absent max_mps so legacy no-speed runs survive the round-trip as None)
 // -----------------------------------------------------------------------------
 
-const FLAG_RUN_STRIDE: usize = 5; // u8 + i32
+const FLAG_RUN_STRIDE: usize = 9; // u8 + i32 + f32
 
 pub fn encode_flag_runs(runs: Option<&[FlagRun]>) -> Option<Vec<u8>> {
     let runs = runs?;
@@ -159,6 +160,8 @@ pub fn encode_flag_runs(runs: Option<&[FlagRun]>) -> Option<Vec<u8>> {
         buf.push(r.flags);
         let frames = r.frames as i32;
         buf.extend_from_slice(&frames.to_le_bytes());
+        let max = r.max_mps.map(|m| m as f32).unwrap_or(f32::NAN);
+        buf.extend_from_slice(&max.to_le_bytes());
     }
     Some(buf)
 }
@@ -178,7 +181,16 @@ pub fn decode_flag_runs(buf: Option<&[u8]>) -> Result<Option<Vec<FlagRun>>> {
         let off = i * FLAG_RUN_STRIDE;
         let flags = buf[off];
         let frames = i32::from_le_bytes(buf[off + 1..off + 5].try_into().unwrap()) as u32;
-        out.push(FlagRun { flags, frames });
+        let max_raw = f32::from_le_bytes(buf[off + 5..off + 9].try_into().unwrap());
+        // Values are 1-decimal by contract (computeFlagRuns rounds); re-round
+        // after the f32 round-trip so 2.7 comes back as exactly 2.7, not
+        // 2.700000047… — the JSON export must match Sentry-Drive's digits.
+        let max_mps = if max_raw.is_finite() {
+            Some(((max_raw as f64) * 10.0).round() / 10.0)
+        } else {
+            None
+        };
+        out.push(FlagRun { flags, frames, max_mps });
     }
     Ok(Some(out))
 }
@@ -264,11 +276,14 @@ mod tests {
 
     #[test]
     fn roundtrip_flag_runs() {
+        // Mixed per-run max_mps states: known 1-decimal values must come
+        // back exact (decode re-rounds after the f32 leg), zero stays a
+        // real Some(0.0), and None survives via the NaN sentinel.
         let runs = vec![
-            FlagRun { flags: 0, frames: 27 },
-            FlagRun { flags: 3, frames: 123 },
-            FlagRun { flags: 1, frames: 873 },
-            FlagRun { flags: 8, frames: 36 },
+            FlagRun { flags: 0, frames: 27, max_mps: Some(0.0) },
+            FlagRun { flags: 3, frames: 123, max_mps: Some(2.7) },
+            FlagRun { flags: 1, frames: 873, max_mps: None },
+            FlagRun { flags: 8, frames: 36, max_mps: Some(4.7) },
         ];
         let buf = encode_flag_runs(Some(&runs)).unwrap();
         assert_eq!(buf.len(), runs.len() * FLAG_RUN_STRIDE);

--- a/crates/drives/src/blob.rs
+++ b/crates/drives/src/blob.rs
@@ -14,7 +14,7 @@
 
 use anyhow::{bail, Result};
 
-use crate::types::{GearRun, GpsPoint};
+use crate::types::{FlagRun, GearRun, GpsPoint};
 
 // -----------------------------------------------------------------------------
 // Points: [f64; 2] per point (16 bytes)
@@ -145,6 +145,44 @@ pub fn decode_gear_runs(buf: Option<&[u8]>) -> Result<Option<Vec<GearRun>>> {
     Ok(Some(out))
 }
 
+// -----------------------------------------------------------------------------
+// FlagRuns: 1-byte flags + 4-byte i32 frames per run (same wire shape as
+// GearRuns)
+// -----------------------------------------------------------------------------
+
+const FLAG_RUN_STRIDE: usize = 5; // u8 + i32
+
+pub fn encode_flag_runs(runs: Option<&[FlagRun]>) -> Option<Vec<u8>> {
+    let runs = runs?;
+    let mut buf = Vec::with_capacity(runs.len() * FLAG_RUN_STRIDE);
+    for r in runs {
+        buf.push(r.flags);
+        let frames = r.frames as i32;
+        buf.extend_from_slice(&frames.to_le_bytes());
+    }
+    Some(buf)
+}
+
+pub fn decode_flag_runs(buf: Option<&[u8]>) -> Result<Option<Vec<FlagRun>>> {
+    let Some(buf) = buf else { return Ok(None) };
+    if buf.len() % FLAG_RUN_STRIDE != 0 {
+        bail!(
+            "decode_flag_runs: length {} not a multiple of {}",
+            buf.len(),
+            FLAG_RUN_STRIDE
+        );
+    }
+    let n = buf.len() / FLAG_RUN_STRIDE;
+    let mut out = Vec::with_capacity(n);
+    for i in 0..n {
+        let off = i * FLAG_RUN_STRIDE;
+        let flags = buf[off];
+        let frames = i32::from_le_bytes(buf[off + 1..off + 5].try_into().unwrap()) as u32;
+        out.push(FlagRun { flags, frames });
+    }
+    Ok(Some(out))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -175,6 +213,8 @@ mod tests {
         assert!(decode_f32s(None).unwrap().is_none());
         assert!(encode_gear_runs(None).is_none());
         assert!(decode_gear_runs(None).unwrap().is_none());
+        assert!(encode_flag_runs(None).is_none());
+        assert!(decode_flag_runs(None).unwrap().is_none());
     }
 
     #[test]
@@ -220,6 +260,26 @@ mod tests {
             assert_eq!(a.gear, b.gear);
             assert_eq!(a.frames, b.frames);
         }
+    }
+
+    #[test]
+    fn roundtrip_flag_runs() {
+        let runs = vec![
+            FlagRun { flags: 0, frames: 27 },
+            FlagRun { flags: 3, frames: 123 },
+            FlagRun { flags: 1, frames: 873 },
+            FlagRun { flags: 8, frames: 36 },
+        ];
+        let buf = encode_flag_runs(Some(&runs)).unwrap();
+        assert_eq!(buf.len(), runs.len() * FLAG_RUN_STRIDE);
+        let back = decode_flag_runs(Some(&buf)).unwrap().unwrap();
+        assert_eq!(back, runs);
+    }
+
+    #[test]
+    fn decode_flag_runs_rejects_misaligned_input() {
+        let buf = vec![0u8; 6];
+        assert!(decode_flag_runs(Some(&buf)).is_err());
     }
 
     #[test]

--- a/crates/drives/src/db.rs
+++ b/crates/drives/src/db.rs
@@ -1848,9 +1848,13 @@ fn compute_drive_caches(inputs: DriveCacheInputs) -> Result<DriveCacheArtifacts>
     // (tessie, teslascope, future importers) is imported data with fuzzy
     // or absent per-point autopilot telemetry — counted in totals, never
     // in FSD analytics. Matches Sentry-Drive's isImportedSource rule.
+    // Summon drives are likewise totals-only (mirrors Sentry-Drive's
+    // aggregate builder): autopilot_state stays unset while the car
+    // drives itself, so counting them would dilute the FSD score with
+    // fake "0% FSD" drives.
     let sei_drives: Vec<_> = drives
         .iter()
-        .filter(|d| !matches!(d.source.as_deref(), Some(s) if s != "sei"))
+        .filter(|d| !matches!(d.source.as_deref(), Some(s) if s != "sei") && !d.summon)
         .collect();
     let sei_total_km: f64 = sei_drives.iter().map(|d| d.distance_km).sum();
     let fsd_distance_km: f64 = sei_drives.iter().map(|d| d.fsd_distance_km).sum();

--- a/crates/drives/src/db.rs
+++ b/crates/drives/src/db.rs
@@ -509,6 +509,7 @@ impl DriveStore {
         raw_frame_count: u32,
         gear_runs: &[GearRun],
         flag_runs: &[FlagRun],
+        gear_run_speed_max: &[f32],
     ) -> Result<()> {
         let norm = normalize_path(relative_path);
         let now = now_unix();
@@ -535,6 +536,7 @@ impl DriveStore {
                 raw_frame_count,
                 gear_runs: gear_runs.to_vec(),
                 flag_runs: flag_runs.to_vec(),
+                gear_run_speed_max: gear_run_speed_max.to_vec(),
                 source: None,
                 external_signature: None,
                 tessie_autopilot_percent: None,
@@ -2018,6 +2020,12 @@ fn insert_or_update_route(
     } else {
         encode_flag_runs(Some(&r.flag_runs))
     };
+    // Same absence rule for the per-gear-run speed maxima.
+    let grsb = if r.gear_run_speed_max.is_empty() {
+        None
+    } else {
+        encode_f32s(Some(&r.gear_run_speed_max))
+    };
 
     let first_lat: Option<f64> = r.points.first().map(|p| p[0]);
     let first_lon: Option<f64> = r.points.first().map(|p| p[1]);
@@ -2054,7 +2062,7 @@ fn insert_or_update_route(
             location_name_start, location_name_end,
             fsd_pend_ms_end, park_ms_start, fsd_at_end, fsd_accel_pushes_early,
             ap_at_start,
-            flag_runs_blob, sei_speed_abs_max)
+            flag_runs_blob, sei_speed_abs_max, gear_run_speed_blob)
          VALUES(
             ?1, ?2, ?3, ?4, ?5,
             NULL, NULL, ?6, ?7, ?8,
@@ -2069,7 +2077,7 @@ fn insert_or_update_route(
             ?42, ?43, ?44, ?45,
             ?46, ?47, ?48, ?49,
             ?50, ?51, ?52, ?53, ?54,
-            ?55, ?56)
+            ?55, ?56, ?57)
          ON CONFLICT(file) DO UPDATE SET
             date_dir            = excluded.date_dir,
             point_count         = excluded.point_count,
@@ -2125,7 +2133,8 @@ fn insert_or_update_route(
             fsd_accel_pushes_early = excluded.fsd_accel_pushes_early,
             ap_at_start         = excluded.ap_at_start,
             flag_runs_blob      = excluded.flag_runs_blob,
-            sei_speed_abs_max   = excluded.sei_speed_abs_max",
+            sei_speed_abs_max   = excluded.sei_speed_abs_max,
+            gear_run_speed_blob = excluded.gear_run_speed_blob",
         params![
             norm_file,
             &r.date,
@@ -2183,6 +2192,7 @@ fn insert_or_update_route(
             a.ap_at_start,
             fb,
             a.sei_speed_abs_max,
+            grsb,
         ],
     )?;
     Ok(())
@@ -2201,7 +2211,7 @@ fn select_all_routes(conn: &Connection) -> Result<Vec<Route>> {
                 tire_fl_psi, tire_fr_psi, tire_rl_psi, tire_rr_psi,
                 odometer_mi_start, odometer_mi_end,
                 location_name_start, location_name_end,
-                flag_runs_blob
+                flag_runs_blob, gear_run_speed_blob
          FROM routes
          ORDER BY file",
     )?;
@@ -2234,7 +2244,7 @@ fn select_routes_by_files(conn: &Connection, files: &[&str]) -> Result<Vec<Route
                 tire_fl_psi, tire_fr_psi, tire_rl_psi, tire_rr_psi,
                 odometer_mi_start, odometer_mi_end,
                 location_name_start, location_name_end,
-                flag_runs_blob
+                flag_runs_blob, gear_run_speed_blob
          FROM routes
          WHERE file IN ({})
          ORDER BY file",
@@ -2274,7 +2284,9 @@ type RouteRow = (
     Option<f64>, Option<f64>, Option<f64>, Option<f64>,
     Option<f64>, Option<f64>,
     Option<String>, Option<String>,
-    // v16 flag_runs_blob — appended last to keep prior indices stable.
+    // v16 flag_runs_blob + gear_run_speed_blob — appended last to keep
+    // prior indices stable.
+    Option<Vec<u8>>,
     Option<Vec<u8>>,
 );
 
@@ -2310,6 +2322,7 @@ fn route_row_mapper(row: &rusqlite::Row<'_>) -> rusqlite::Result<RouteRow> {
         row.get::<_, Option<String>>(25)?,
         row.get::<_, Option<String>>(26)?,
         row.get::<_, Option<Vec<u8>>>(27)?,
+        row.get::<_, Option<Vec<u8>>>(28)?,
     ))
 }
 
@@ -2325,7 +2338,7 @@ fn build_route_from_row(r: RouteRow) -> Result<Route> {
         tire_fl_psi, tire_fr_psi, tire_rl_psi, tire_rr_psi,
         odometer_mi_start, odometer_mi_end,
         location_name_start, location_name_end,
-        fb,
+        fb, grsb,
     ) = r;
     let points = decode_points(pb.as_deref())
         .with_context(|| format!("decode points {}", file))?
@@ -2344,10 +2357,13 @@ fn build_route_from_row(r: RouteRow) -> Result<Route> {
     let flag_runs = decode_flag_runs(fb.as_deref())
         .with_context(|| format!("decode flag_runs {}", file))?
         .unwrap_or_default();
+    let gear_run_speed_max = decode_f32s(grsb.as_deref())
+        .with_context(|| format!("decode gear_run_speed_max {}", file))?
+        .unwrap_or_default();
     Ok(Route {
         file, date, points, gear_states, autopilot_states,
         speeds, accel_positions, raw_park_count, raw_frame_count, gear_runs,
-        flag_runs,
+        flag_runs, gear_run_speed_max,
         source, external_signature, tessie_autopilot_percent,
         battery_pct_start, battery_pct_end,
         interior_temp_min, interior_temp_max, exterior_temp_avg,
@@ -2381,7 +2397,7 @@ fn select_all_route_summaries(conn: &Connection) -> Result<Vec<RouteSummary>> {
                 location_name_start, location_name_end,
                 fsd_pend_ms_end, park_ms_start, fsd_at_end, fsd_accel_pushes_early,
                 ap_at_start,
-                flag_runs_blob, sei_speed_abs_max
+                flag_runs_blob, sei_speed_abs_max, gear_run_speed_blob
          FROM routes
          ORDER BY file",
     )?;
@@ -2451,6 +2467,7 @@ fn select_all_route_summaries(conn: &Connection) -> Result<Vec<RouteSummary>> {
             (
                 row.get::<_, Option<Vec<u8>>>(44)?,
                 row.get::<_, Option<f64>>(45)?,
+                row.get::<_, Option<Vec<u8>>>(46)?,
             ),
         ))
     })?;
@@ -2493,7 +2510,7 @@ fn select_all_route_summaries(conn: &Connection) -> Result<Vec<RouteSummary>> {
             (odometer_mi_start, odometer_mi_end),
             (location_name_start, location_name_end),
             (fsd_pend_ms_end, park_ms_start, fsd_at_end, fsd_accel_pushes_early, ap_at_start),
-            (fb, sei_speed_abs_max),
+            (fb, sei_speed_abs_max, grsb),
         ) = r?;
 
         let gear_runs = decode_gear_runs(rb.as_deref())
@@ -2501,6 +2518,9 @@ fn select_all_route_summaries(conn: &Connection) -> Result<Vec<RouteSummary>> {
             .unwrap_or_default();
         let flag_runs = decode_flag_runs(fb.as_deref())
             .with_context(|| format!("decode flag_runs {}", file))?
+            .unwrap_or_default();
+        let gear_run_speed_max = decode_f32s(grsb.as_deref())
+            .with_context(|| format!("decode gear_run_speed_max {}", file))?
             .unwrap_or_default();
 
         out.push(RouteSummary {
@@ -2510,6 +2530,7 @@ fn select_all_route_summaries(conn: &Connection) -> Result<Vec<RouteSummary>> {
             raw_frame_count,
             gear_runs,
             flag_runs,
+            gear_run_speed_max,
             aggregates: RouteAggregates {
                 distance_m: distance_m.unwrap_or(0.0),
                 max_speed_mps: max_speed_mps.unwrap_or(0.0),
@@ -2757,6 +2778,7 @@ mod tests {
                 2,
                 &[GearRun { gear: 4, frames: 2 }],
                 &[FlagRun { flags: 3, frames: 1 }, FlagRun { flags: 0, frames: 1 }],
+                &[26.0],
             )
             .unwrap();
         let routes = store.get_routes().unwrap();
@@ -2772,13 +2794,16 @@ mod tests {
             routes[0].flag_runs,
             vec![FlagRun { flags: 3, frames: 1 }, FlagRun { flags: 0, frames: 1 }],
         );
+        assert_eq!(routes[0].gear_run_speed_max, vec![26.0f32]);
         // The summary path carries the same flag evidence + the v16
-        // SEI abs-max column populated by compute_route_aggregates.
+        // SEI abs-max column populated by compute_route_aggregates and
+        // the per-gear-run maxima.
         store
             .with_route_summaries(|summaries| {
                 assert_eq!(summaries.len(), 1);
                 assert_eq!(summaries[0].flag_runs.len(), 2);
                 assert_eq!(summaries[0].aggregates.sei_speed_abs_max, Some(26.0));
+                assert_eq!(summaries[0].gear_run_speed_max, vec![26.0f32]);
             })
             .unwrap();
     }
@@ -2802,7 +2827,7 @@ mod tests {
         let store = DriveStore::open(&path_str).unwrap();
         let pts: Vec<GpsPoint> = vec![[37.7749, -122.4194], [37.7760, -122.4180]];
         store
-            .add_route("a/2025-02-02_09-00-00-front.mp4", "a", &pts, &[4, 4], &[0, 0], &[15.0, 16.0], &[0.0, 0.0], 0, 2, &[], &[])
+            .add_route("a/2025-02-02_09-00-00-front.mp4", "a", &pts, &[4, 4], &[0, 0], &[15.0, 16.0], &[0.0, 0.0], 0, 2, &[], &[], &[])
             .unwrap();
         let json = store.get_cached_drives_json().unwrap();
         assert!(json.contains("2025-02-02"), "file-backed rebuild should serve the drive: {json}");
@@ -2819,7 +2844,7 @@ mod tests {
         let store = DriveStore::open_memory().unwrap();
         let pts: Vec<GpsPoint> = vec![[37.7749, -122.4194], [37.7760, -122.4180]];
         store
-            .add_route("a/2025-01-01_10-00-00-front.mp4", "a", &pts, &[4, 4], &[0, 0], &[20.0, 21.0], &[0.0, 0.0], 0, 2, &[], &[])
+            .add_route("a/2025-01-01_10-00-00-front.mp4", "a", &pts, &[4, 4], &[0, 0], &[20.0, 21.0], &[0.0, 0.0], 0, 2, &[], &[], &[])
             .unwrap();
         // add_route marked the cache dirty; the getter must rebuild via the
         // off-lock path and serve a list containing the new drive.
@@ -2830,7 +2855,7 @@ mod tests {
         // A further mutation re-dirties; the next read rebuilds again and
         // reflects it (second route is 2.5h later — a separate drive).
         store
-            .add_route("a/2025-01-01_12-30-00-front.mp4", "a", &pts, &[4, 4], &[0, 0], &[20.0, 21.0], &[0.0, 0.0], 0, 2, &[], &[])
+            .add_route("a/2025-01-01_12-30-00-front.mp4", "a", &pts, &[4, 4], &[0, 0], &[20.0, 21.0], &[0.0, 0.0], 0, 2, &[], &[], &[])
             .unwrap();
         assert!(store.drive_cache_dirty.load(Ordering::Acquire));
         let json2 = store.get_cached_drives_json().unwrap();
@@ -2853,7 +2878,7 @@ mod tests {
         let store = DriveStore::open_memory().unwrap();
         let pts: Vec<GpsPoint> = vec![[37.7749, -122.4194], [37.7760, -122.4180]];
         store
-            .add_route("a.mp4", "2025-01-01", &pts, &[4, 4], &[1, 1], &[20.0, 21.0], &[0.0, 0.0], 0, 2, &[], &[])
+            .add_route("a.mp4", "2025-01-01", &pts, &[4, 4], &[1, 1], &[20.0, 21.0], &[0.0, 0.0], 0, 2, &[], &[], &[])
             .unwrap();
 
         {
@@ -2906,6 +2931,7 @@ mod tests {
                 2,
                 &[GearRun { gear: GEAR_DRIVE, frames: 2 }],
                 &[],
+                &[],
             )
             .unwrap();
 
@@ -2926,6 +2952,7 @@ mod tests {
                 60,
                 &[GearRun { gear: GEAR_PARK, frames: 60 }],
                 &[],
+                &[],
             )
             .unwrap();
 
@@ -2942,6 +2969,7 @@ mod tests {
                 0,
                 2,
                 &[GearRun { gear: GEAR_DRIVE, frames: 2 }],
+                &[],
                 &[],
             )
             .unwrap();
@@ -2965,7 +2993,7 @@ mod tests {
         let speeds = vec![10.0f32; n];
         let accel = vec![0.0f32; n];
         store
-            .add_route(file, "2025-01-01", &pts, &gears, &ap, &speeds, &accel, 0, 61, &[], &[])
+            .add_route(file, "2025-01-01", &pts, &gears, &ap, &speeds, &accel, 0, 61, &[], &[], &[])
             .unwrap();
     }
 
@@ -3070,7 +3098,7 @@ mod tests {
         let speeds = vec![10.0f32; n];
         let accel = vec![0.0f32; n];
         store
-            .add_route(file, "2025-01-01", &pts, &gears, &ap, &speeds, &accel, 0, 61, &[], &[])
+            .add_route(file, "2025-01-01", &pts, &gears, &ap, &speeds, &accel, 0, 61, &[], &[], &[])
             .unwrap();
     }
 
@@ -3152,7 +3180,7 @@ mod tests {
         let store = DriveStore::open_memory().unwrap();
         let pts: Vec<GpsPoint> = vec![[37.7749, -122.4194], [37.7760, -122.4180]];
         store
-            .add_route("2025-01-01/2025-01-01_10-00-00-front.mp4", "2025-01-01", &pts, &[4, 4], &[1, 1], &[20.0, 21.0], &[0.0, 0.0], 0, 2, &[], &[])
+            .add_route("2025-01-01/2025-01-01_10-00-00-front.mp4", "2025-01-01", &pts, &[4, 4], &[1, 1], &[20.0, 21.0], &[0.0, 0.0], 0, 2, &[], &[], &[])
             .unwrap();
         // Plant an absurd stored distance and bake it INTO the caches —
         // this is the old-formula world the gate exists to replace.
@@ -3224,14 +3252,14 @@ mod tests {
         store
             .add_route(
                 "RecentClips/2026-06-07/c-front.mp4", "2026-06-07", &pts,
-                &[4, 4], &[1, 1], &[20.0, 21.0], &[0.0, 0.0], 0, 2, &[], &[],
+                &[4, 4], &[1, 1], &[20.0, 21.0], &[0.0, 0.0], 0, 2, &[], &[], &[],
             )
             .unwrap();
         // Sentry-Drive-style import of the same clip (Windows separators).
         store
             .add_route(
                 "2026-06-07\\c-front.mp4", "2026-06-07", &pts,
-                &[4, 4], &[1, 1], &[20.0, 21.0], &[0.0, 0.0], 0, 2, &[], &[],
+                &[4, 4], &[1, 1], &[20.0, 21.0], &[0.0, 0.0], 0, 2, &[], &[], &[],
             )
             .unwrap();
 
@@ -3270,7 +3298,7 @@ mod tests {
         store
             .add_route(
                 "2026-06-07/dup-front.mp4", "2026-06-07", &pts2,
-                &[4, 4], &[1, 1], &[20.0, 21.0], &[0.0, 0.0], 0, 2, &[], &[],
+                &[4, 4], &[1, 1], &[20.0, 21.0], &[0.0, 0.0], 0, 2, &[], &[], &[],
             )
             .unwrap();
         // Native copy of the same clip (3 points), a lone native row, and a
@@ -3285,7 +3313,7 @@ mod tests {
             store
                 .add_route(
                     tmp, "2026-06-07", pts,
-                    &[4, 4], &[1, 1], &[20.0, 21.0], &[0.0, 0.0], 0, 2, &[], &[],
+                    &[4, 4], &[1, 1], &[20.0, 21.0], &[0.0, 0.0], 0, 2, &[], &[], &[],
                 )
                 .unwrap();
             let conn = store.conn.lock().unwrap();
@@ -3347,7 +3375,7 @@ mod tests {
         let pts: Vec<GpsPoint> = vec![[37.7749, -122.4194], [37.7750, -122.4194]];
         store
             .add_route(
-                "a.mp4", "2025-01-01", &pts, &[], &[], &[], &[], 0, 2, &[], &[],
+                "a.mp4", "2025-01-01", &pts, &[], &[], &[], &[], 0, 2, &[], &[], &[],
             )
             .unwrap();
         let out = store.with_route_summaries(|s| s.to_vec()).unwrap();
@@ -3484,6 +3512,7 @@ mod tests {
                 2,
                 &[GearRun { gear: 4, frames: 2 }],
                 &[],
+                &[],
             )
             .unwrap();
 
@@ -3599,7 +3628,7 @@ mod tests {
     fn add_test_route(store: &DriveStore, name: &str) {
         let pts: Vec<GpsPoint> = vec![[37.7749, -122.4194], [37.7750, -122.4195]];
         store
-            .add_route(name, "2025-01-15", &pts, &[4, 4], &[1, 1], &[25.0, 26.0], &[0.5, 0.6], 0, 2, &[], &[])
+            .add_route(name, "2025-01-15", &pts, &[4, 4], &[1, 1], &[25.0, 26.0], &[0.5, 0.6], 0, 2, &[], &[], &[])
             .unwrap();
     }
 

--- a/crates/drives/src/db.rs
+++ b/crates/drives/src/db.rs
@@ -509,7 +509,6 @@ impl DriveStore {
         raw_frame_count: u32,
         gear_runs: &[GearRun],
         flag_runs: &[FlagRun],
-        gear_run_speed_max: &[f32],
     ) -> Result<()> {
         let norm = normalize_path(relative_path);
         let now = now_unix();
@@ -536,7 +535,6 @@ impl DriveStore {
                 raw_frame_count,
                 gear_runs: gear_runs.to_vec(),
                 flag_runs: flag_runs.to_vec(),
-                gear_run_speed_max: gear_run_speed_max.to_vec(),
                 source: None,
                 external_signature: None,
                 tessie_autopilot_percent: None,
@@ -2024,12 +2022,6 @@ fn insert_or_update_route(
     } else {
         encode_flag_runs(Some(&r.flag_runs))
     };
-    // Same absence rule for the per-gear-run speed maxima.
-    let grsb = if r.gear_run_speed_max.is_empty() {
-        None
-    } else {
-        encode_f32s(Some(&r.gear_run_speed_max))
-    };
 
     let first_lat: Option<f64> = r.points.first().map(|p| p[0]);
     let first_lon: Option<f64> = r.points.first().map(|p| p[1]);
@@ -2066,7 +2058,7 @@ fn insert_or_update_route(
             location_name_start, location_name_end,
             fsd_pend_ms_end, park_ms_start, fsd_at_end, fsd_accel_pushes_early,
             ap_at_start,
-            flag_runs_blob, sei_speed_abs_max, gear_run_speed_blob)
+            flag_runs_blob, sei_speed_abs_max)
          VALUES(
             ?1, ?2, ?3, ?4, ?5,
             NULL, NULL, ?6, ?7, ?8,
@@ -2081,7 +2073,7 @@ fn insert_or_update_route(
             ?42, ?43, ?44, ?45,
             ?46, ?47, ?48, ?49,
             ?50, ?51, ?52, ?53, ?54,
-            ?55, ?56, ?57)
+            ?55, ?56)
          ON CONFLICT(file) DO UPDATE SET
             date_dir            = excluded.date_dir,
             point_count         = excluded.point_count,
@@ -2137,8 +2129,7 @@ fn insert_or_update_route(
             fsd_accel_pushes_early = excluded.fsd_accel_pushes_early,
             ap_at_start         = excluded.ap_at_start,
             flag_runs_blob      = excluded.flag_runs_blob,
-            sei_speed_abs_max   = excluded.sei_speed_abs_max,
-            gear_run_speed_blob = excluded.gear_run_speed_blob",
+            sei_speed_abs_max   = excluded.sei_speed_abs_max",
         params![
             norm_file,
             &r.date,
@@ -2196,7 +2187,6 @@ fn insert_or_update_route(
             a.ap_at_start,
             fb,
             a.sei_speed_abs_max,
-            grsb,
         ],
     )?;
     Ok(())
@@ -2215,7 +2205,7 @@ fn select_all_routes(conn: &Connection) -> Result<Vec<Route>> {
                 tire_fl_psi, tire_fr_psi, tire_rl_psi, tire_rr_psi,
                 odometer_mi_start, odometer_mi_end,
                 location_name_start, location_name_end,
-                flag_runs_blob, gear_run_speed_blob
+                flag_runs_blob
          FROM routes
          ORDER BY file",
     )?;
@@ -2248,7 +2238,7 @@ fn select_routes_by_files(conn: &Connection, files: &[&str]) -> Result<Vec<Route
                 tire_fl_psi, tire_fr_psi, tire_rl_psi, tire_rr_psi,
                 odometer_mi_start, odometer_mi_end,
                 location_name_start, location_name_end,
-                flag_runs_blob, gear_run_speed_blob
+                flag_runs_blob
          FROM routes
          WHERE file IN ({})
          ORDER BY file",
@@ -2288,9 +2278,7 @@ type RouteRow = (
     Option<f64>, Option<f64>, Option<f64>, Option<f64>,
     Option<f64>, Option<f64>,
     Option<String>, Option<String>,
-    // v16 flag_runs_blob + gear_run_speed_blob — appended last to keep
-    // prior indices stable.
-    Option<Vec<u8>>,
+    // v16 flag_runs_blob — appended last to keep prior indices stable.
     Option<Vec<u8>>,
 );
 
@@ -2326,7 +2314,6 @@ fn route_row_mapper(row: &rusqlite::Row<'_>) -> rusqlite::Result<RouteRow> {
         row.get::<_, Option<String>>(25)?,
         row.get::<_, Option<String>>(26)?,
         row.get::<_, Option<Vec<u8>>>(27)?,
-        row.get::<_, Option<Vec<u8>>>(28)?,
     ))
 }
 
@@ -2342,7 +2329,7 @@ fn build_route_from_row(r: RouteRow) -> Result<Route> {
         tire_fl_psi, tire_fr_psi, tire_rl_psi, tire_rr_psi,
         odometer_mi_start, odometer_mi_end,
         location_name_start, location_name_end,
-        fb, grsb,
+        fb,
     ) = r;
     let points = decode_points(pb.as_deref())
         .with_context(|| format!("decode points {}", file))?
@@ -2361,13 +2348,10 @@ fn build_route_from_row(r: RouteRow) -> Result<Route> {
     let flag_runs = decode_flag_runs(fb.as_deref())
         .with_context(|| format!("decode flag_runs {}", file))?
         .unwrap_or_default();
-    let gear_run_speed_max = decode_f32s(grsb.as_deref())
-        .with_context(|| format!("decode gear_run_speed_max {}", file))?
-        .unwrap_or_default();
     Ok(Route {
         file, date, points, gear_states, autopilot_states,
         speeds, accel_positions, raw_park_count, raw_frame_count, gear_runs,
-        flag_runs, gear_run_speed_max,
+        flag_runs,
         source, external_signature, tessie_autopilot_percent,
         battery_pct_start, battery_pct_end,
         interior_temp_min, interior_temp_max, exterior_temp_avg,
@@ -2401,7 +2385,7 @@ fn select_all_route_summaries(conn: &Connection) -> Result<Vec<RouteSummary>> {
                 location_name_start, location_name_end,
                 fsd_pend_ms_end, park_ms_start, fsd_at_end, fsd_accel_pushes_early,
                 ap_at_start,
-                flag_runs_blob, sei_speed_abs_max, gear_run_speed_blob
+                flag_runs_blob, sei_speed_abs_max
          FROM routes
          ORDER BY file",
     )?;
@@ -2471,7 +2455,6 @@ fn select_all_route_summaries(conn: &Connection) -> Result<Vec<RouteSummary>> {
             (
                 row.get::<_, Option<Vec<u8>>>(44)?,
                 row.get::<_, Option<f64>>(45)?,
-                row.get::<_, Option<Vec<u8>>>(46)?,
             ),
         ))
     })?;
@@ -2514,7 +2497,7 @@ fn select_all_route_summaries(conn: &Connection) -> Result<Vec<RouteSummary>> {
             (odometer_mi_start, odometer_mi_end),
             (location_name_start, location_name_end),
             (fsd_pend_ms_end, park_ms_start, fsd_at_end, fsd_accel_pushes_early, ap_at_start),
-            (fb, sei_speed_abs_max, grsb),
+            (fb, sei_speed_abs_max),
         ) = r?;
 
         let gear_runs = decode_gear_runs(rb.as_deref())
@@ -2522,9 +2505,6 @@ fn select_all_route_summaries(conn: &Connection) -> Result<Vec<RouteSummary>> {
             .unwrap_or_default();
         let flag_runs = decode_flag_runs(fb.as_deref())
             .with_context(|| format!("decode flag_runs {}", file))?
-            .unwrap_or_default();
-        let gear_run_speed_max = decode_f32s(grsb.as_deref())
-            .with_context(|| format!("decode gear_run_speed_max {}", file))?
             .unwrap_or_default();
 
         out.push(RouteSummary {
@@ -2534,7 +2514,6 @@ fn select_all_route_summaries(conn: &Connection) -> Result<Vec<RouteSummary>> {
             raw_frame_count,
             gear_runs,
             flag_runs,
-            gear_run_speed_max,
             aggregates: RouteAggregates {
                 distance_m: distance_m.unwrap_or(0.0),
                 max_speed_mps: max_speed_mps.unwrap_or(0.0),
@@ -2781,8 +2760,10 @@ mod tests {
                 0,
                 2,
                 &[GearRun { gear: 4, frames: 2 }],
-                &[FlagRun { flags: 3, frames: 1 }, FlagRun { flags: 0, frames: 1 }],
-                &[26.0],
+                &[
+                    FlagRun { flags: 3, frames: 1, max_mps: Some(25.0) },
+                    FlagRun { flags: 0, frames: 1, max_mps: None },
+                ],
             )
             .unwrap();
         let routes = store.get_routes().unwrap();
@@ -2794,20 +2775,22 @@ mod tests {
         assert_eq!(routes[0].accel_positions, vec![0.5, 0.6]);
         assert_eq!(routes[0].raw_frame_count, 2);
         assert_eq!(routes[0].gear_runs.len(), 1);
+        // Per-run max_mps round-trips through the blob, including the
+        // NaN-encoded None on legacy runs.
         assert_eq!(
             routes[0].flag_runs,
-            vec![FlagRun { flags: 3, frames: 1 }, FlagRun { flags: 0, frames: 1 }],
+            vec![
+                FlagRun { flags: 3, frames: 1, max_mps: Some(25.0) },
+                FlagRun { flags: 0, frames: 1, max_mps: None },
+            ],
         );
-        assert_eq!(routes[0].gear_run_speed_max, vec![26.0f32]);
         // The summary path carries the same flag evidence + the v16
-        // SEI abs-max column populated by compute_route_aggregates and
-        // the per-gear-run maxima.
+        // SEI abs-max column populated by compute_route_aggregates.
         store
             .with_route_summaries(|summaries| {
                 assert_eq!(summaries.len(), 1);
-                assert_eq!(summaries[0].flag_runs.len(), 2);
+                assert_eq!(summaries[0].flag_runs, routes[0].flag_runs);
                 assert_eq!(summaries[0].aggregates.sei_speed_abs_max, Some(26.0));
-                assert_eq!(summaries[0].gear_run_speed_max, vec![26.0f32]);
             })
             .unwrap();
     }
@@ -2831,7 +2814,7 @@ mod tests {
         let store = DriveStore::open(&path_str).unwrap();
         let pts: Vec<GpsPoint> = vec![[37.7749, -122.4194], [37.7760, -122.4180]];
         store
-            .add_route("a/2025-02-02_09-00-00-front.mp4", "a", &pts, &[4, 4], &[0, 0], &[15.0, 16.0], &[0.0, 0.0], 0, 2, &[], &[], &[])
+            .add_route("a/2025-02-02_09-00-00-front.mp4", "a", &pts, &[4, 4], &[0, 0], &[15.0, 16.0], &[0.0, 0.0], 0, 2, &[], &[])
             .unwrap();
         let json = store.get_cached_drives_json().unwrap();
         assert!(json.contains("2025-02-02"), "file-backed rebuild should serve the drive: {json}");
@@ -2848,7 +2831,7 @@ mod tests {
         let store = DriveStore::open_memory().unwrap();
         let pts: Vec<GpsPoint> = vec![[37.7749, -122.4194], [37.7760, -122.4180]];
         store
-            .add_route("a/2025-01-01_10-00-00-front.mp4", "a", &pts, &[4, 4], &[0, 0], &[20.0, 21.0], &[0.0, 0.0], 0, 2, &[], &[], &[])
+            .add_route("a/2025-01-01_10-00-00-front.mp4", "a", &pts, &[4, 4], &[0, 0], &[20.0, 21.0], &[0.0, 0.0], 0, 2, &[], &[])
             .unwrap();
         // add_route marked the cache dirty; the getter must rebuild via the
         // off-lock path and serve a list containing the new drive.
@@ -2859,7 +2842,7 @@ mod tests {
         // A further mutation re-dirties; the next read rebuilds again and
         // reflects it (second route is 2.5h later — a separate drive).
         store
-            .add_route("a/2025-01-01_12-30-00-front.mp4", "a", &pts, &[4, 4], &[0, 0], &[20.0, 21.0], &[0.0, 0.0], 0, 2, &[], &[], &[])
+            .add_route("a/2025-01-01_12-30-00-front.mp4", "a", &pts, &[4, 4], &[0, 0], &[20.0, 21.0], &[0.0, 0.0], 0, 2, &[], &[])
             .unwrap();
         assert!(store.drive_cache_dirty.load(Ordering::Acquire));
         let json2 = store.get_cached_drives_json().unwrap();
@@ -2882,7 +2865,7 @@ mod tests {
         let store = DriveStore::open_memory().unwrap();
         let pts: Vec<GpsPoint> = vec![[37.7749, -122.4194], [37.7760, -122.4180]];
         store
-            .add_route("a.mp4", "2025-01-01", &pts, &[4, 4], &[1, 1], &[20.0, 21.0], &[0.0, 0.0], 0, 2, &[], &[], &[])
+            .add_route("a.mp4", "2025-01-01", &pts, &[4, 4], &[1, 1], &[20.0, 21.0], &[0.0, 0.0], 0, 2, &[], &[])
             .unwrap();
 
         {
@@ -2935,7 +2918,6 @@ mod tests {
                 2,
                 &[GearRun { gear: GEAR_DRIVE, frames: 2 }],
                 &[],
-                &[],
             )
             .unwrap();
 
@@ -2956,7 +2938,6 @@ mod tests {
                 60,
                 &[GearRun { gear: GEAR_PARK, frames: 60 }],
                 &[],
-                &[],
             )
             .unwrap();
 
@@ -2973,7 +2954,6 @@ mod tests {
                 0,
                 2,
                 &[GearRun { gear: GEAR_DRIVE, frames: 2 }],
-                &[],
                 &[],
             )
             .unwrap();
@@ -2997,7 +2977,7 @@ mod tests {
         let speeds = vec![10.0f32; n];
         let accel = vec![0.0f32; n];
         store
-            .add_route(file, "2025-01-01", &pts, &gears, &ap, &speeds, &accel, 0, 61, &[], &[], &[])
+            .add_route(file, "2025-01-01", &pts, &gears, &ap, &speeds, &accel, 0, 61, &[], &[])
             .unwrap();
     }
 
@@ -3102,7 +3082,7 @@ mod tests {
         let speeds = vec![10.0f32; n];
         let accel = vec![0.0f32; n];
         store
-            .add_route(file, "2025-01-01", &pts, &gears, &ap, &speeds, &accel, 0, 61, &[], &[], &[])
+            .add_route(file, "2025-01-01", &pts, &gears, &ap, &speeds, &accel, 0, 61, &[], &[])
             .unwrap();
     }
 
@@ -3184,7 +3164,7 @@ mod tests {
         let store = DriveStore::open_memory().unwrap();
         let pts: Vec<GpsPoint> = vec![[37.7749, -122.4194], [37.7760, -122.4180]];
         store
-            .add_route("2025-01-01/2025-01-01_10-00-00-front.mp4", "2025-01-01", &pts, &[4, 4], &[1, 1], &[20.0, 21.0], &[0.0, 0.0], 0, 2, &[], &[], &[])
+            .add_route("2025-01-01/2025-01-01_10-00-00-front.mp4", "2025-01-01", &pts, &[4, 4], &[1, 1], &[20.0, 21.0], &[0.0, 0.0], 0, 2, &[], &[])
             .unwrap();
         // Plant an absurd stored distance and bake it INTO the caches —
         // this is the old-formula world the gate exists to replace.
@@ -3256,14 +3236,14 @@ mod tests {
         store
             .add_route(
                 "RecentClips/2026-06-07/c-front.mp4", "2026-06-07", &pts,
-                &[4, 4], &[1, 1], &[20.0, 21.0], &[0.0, 0.0], 0, 2, &[], &[], &[],
+                &[4, 4], &[1, 1], &[20.0, 21.0], &[0.0, 0.0], 0, 2, &[], &[],
             )
             .unwrap();
         // Sentry-Drive-style import of the same clip (Windows separators).
         store
             .add_route(
                 "2026-06-07\\c-front.mp4", "2026-06-07", &pts,
-                &[4, 4], &[1, 1], &[20.0, 21.0], &[0.0, 0.0], 0, 2, &[], &[], &[],
+                &[4, 4], &[1, 1], &[20.0, 21.0], &[0.0, 0.0], 0, 2, &[], &[],
             )
             .unwrap();
 
@@ -3302,7 +3282,7 @@ mod tests {
         store
             .add_route(
                 "2026-06-07/dup-front.mp4", "2026-06-07", &pts2,
-                &[4, 4], &[1, 1], &[20.0, 21.0], &[0.0, 0.0], 0, 2, &[], &[], &[],
+                &[4, 4], &[1, 1], &[20.0, 21.0], &[0.0, 0.0], 0, 2, &[], &[],
             )
             .unwrap();
         // Native copy of the same clip (3 points), a lone native row, and a
@@ -3317,7 +3297,7 @@ mod tests {
             store
                 .add_route(
                     tmp, "2026-06-07", pts,
-                    &[4, 4], &[1, 1], &[20.0, 21.0], &[0.0, 0.0], 0, 2, &[], &[], &[],
+                    &[4, 4], &[1, 1], &[20.0, 21.0], &[0.0, 0.0], 0, 2, &[], &[],
                 )
                 .unwrap();
             let conn = store.conn.lock().unwrap();
@@ -3379,7 +3359,7 @@ mod tests {
         let pts: Vec<GpsPoint> = vec![[37.7749, -122.4194], [37.7750, -122.4194]];
         store
             .add_route(
-                "a.mp4", "2025-01-01", &pts, &[], &[], &[], &[], 0, 2, &[], &[], &[],
+                "a.mp4", "2025-01-01", &pts, &[], &[], &[], &[], 0, 2, &[], &[],
             )
             .unwrap();
         let out = store.with_route_summaries(|s| s.to_vec()).unwrap();
@@ -3516,7 +3496,6 @@ mod tests {
                 2,
                 &[GearRun { gear: 4, frames: 2 }],
                 &[],
-                &[],
             )
             .unwrap();
 
@@ -3632,7 +3611,7 @@ mod tests {
     fn add_test_route(store: &DriveStore, name: &str) {
         let pts: Vec<GpsPoint> = vec![[37.7749, -122.4194], [37.7750, -122.4195]];
         store
-            .add_route(name, "2025-01-15", &pts, &[4, 4], &[1, 1], &[25.0, 26.0], &[0.5, 0.6], 0, 2, &[], &[], &[])
+            .add_route(name, "2025-01-15", &pts, &[4, 4], &[1, 1], &[25.0, 26.0], &[0.5, 0.6], 0, 2, &[], &[])
             .unwrap();
     }
 

--- a/crates/drives/src/db.rs
+++ b/crates/drives/src/db.rs
@@ -31,12 +31,12 @@ use tracing::{info, warn};
 use crate::aggregate::compute_route_aggregates;
 use crate::backfill::backfill_route_aggregates;
 use crate::blob::{
-    decode_f32s, decode_gear_runs, decode_points, decode_u8s, encode_f32s, encode_gear_runs,
-    encode_points, encode_u8s,
+    decode_f32s, decode_flag_runs, decode_gear_runs, decode_points, decode_u8s, encode_f32s,
+    encode_flag_runs, encode_gear_runs, encode_points, encode_u8s,
 };
 use crate::schema::{self, meta_get, meta_set};
 use crate::syncguard::{self, check_sync_size_guard, read_sync_cache, write_sync_cache};
-use crate::types::{GearRun, GpsPoint, Route, RouteAggregates, RouteSummary, StoreData};
+use crate::types::{FlagRun, GearRun, GpsPoint, Route, RouteAggregates, RouteSummary, StoreData};
 
 /// Default SQLite DB path on the Pi.
 pub const DEFAULT_DATA_PATH: &str = "/backingfiles/drive-data.db";
@@ -508,6 +508,7 @@ impl DriveStore {
         raw_park_count: u32,
         raw_frame_count: u32,
         gear_runs: &[GearRun],
+        flag_runs: &[FlagRun],
     ) -> Result<()> {
         let norm = normalize_path(relative_path);
         let now = now_unix();
@@ -533,6 +534,7 @@ impl DriveStore {
                 raw_park_count,
                 raw_frame_count,
                 gear_runs: gear_runs.to_vec(),
+                flag_runs: flag_runs.to_vec(),
                 source: None,
                 external_signature: None,
                 tessie_autopilot_percent: None,
@@ -2009,6 +2011,13 @@ fn insert_or_update_route(
     let sb = encode_f32s(Some(&r.speeds));
     let acb = encode_f32s(Some(&r.accel_positions));
     let rb = encode_gear_runs(Some(&r.gear_runs));
+    // Empty flag_runs stores NULL, not a zero-length blob — "no flag
+    // evidence" must survive the round-trip as absence.
+    let fb = if r.flag_runs.is_empty() {
+        None
+    } else {
+        encode_flag_runs(Some(&r.flag_runs))
+    };
 
     let first_lat: Option<f64> = r.points.first().map(|p| p[0]);
     let first_lon: Option<f64> = r.points.first().map(|p| p[1]);
@@ -2044,7 +2053,8 @@ fn insert_or_update_route(
             odometer_mi_start, odometer_mi_end,
             location_name_start, location_name_end,
             fsd_pend_ms_end, park_ms_start, fsd_at_end, fsd_accel_pushes_early,
-            ap_at_start)
+            ap_at_start,
+            flag_runs_blob, sei_speed_abs_max)
          VALUES(
             ?1, ?2, ?3, ?4, ?5,
             NULL, NULL, ?6, ?7, ?8,
@@ -2058,7 +2068,8 @@ fn insert_or_update_route(
             ?36, ?37, ?38, ?39, ?40, ?41,
             ?42, ?43, ?44, ?45,
             ?46, ?47, ?48, ?49,
-            ?50, ?51, ?52, ?53, ?54)
+            ?50, ?51, ?52, ?53, ?54,
+            ?55, ?56)
          ON CONFLICT(file) DO UPDATE SET
             date_dir            = excluded.date_dir,
             point_count         = excluded.point_count,
@@ -2112,7 +2123,9 @@ fn insert_or_update_route(
             park_ms_start       = excluded.park_ms_start,
             fsd_at_end          = excluded.fsd_at_end,
             fsd_accel_pushes_early = excluded.fsd_accel_pushes_early,
-            ap_at_start         = excluded.ap_at_start",
+            ap_at_start         = excluded.ap_at_start,
+            flag_runs_blob      = excluded.flag_runs_blob,
+            sei_speed_abs_max   = excluded.sei_speed_abs_max",
         params![
             norm_file,
             &r.date,
@@ -2168,6 +2181,8 @@ fn insert_or_update_route(
             a.fsd_at_end as i64,
             a.fsd_accel_pushes_early,
             a.ap_at_start,
+            fb,
+            a.sei_speed_abs_max,
         ],
     )?;
     Ok(())
@@ -2185,7 +2200,8 @@ fn select_all_routes(conn: &Connection) -> Result<Vec<Route>> {
                 hvac_runtime_s,
                 tire_fl_psi, tire_fr_psi, tire_rl_psi, tire_rr_psi,
                 odometer_mi_start, odometer_mi_end,
-                location_name_start, location_name_end
+                location_name_start, location_name_end,
+                flag_runs_blob
          FROM routes
          ORDER BY file",
     )?;
@@ -2217,7 +2233,8 @@ fn select_routes_by_files(conn: &Connection, files: &[&str]) -> Result<Vec<Route
                 hvac_runtime_s,
                 tire_fl_psi, tire_fr_psi, tire_rl_psi, tire_rr_psi,
                 odometer_mi_start, odometer_mi_end,
-                location_name_start, location_name_end
+                location_name_start, location_name_end,
+                flag_runs_blob
          FROM routes
          WHERE file IN ({})
          ORDER BY file",
@@ -2257,6 +2274,8 @@ type RouteRow = (
     Option<f64>, Option<f64>, Option<f64>, Option<f64>,
     Option<f64>, Option<f64>,
     Option<String>, Option<String>,
+    // v16 flag_runs_blob — appended last to keep prior indices stable.
+    Option<Vec<u8>>,
 );
 
 /// Shared row mapper for the two route SELECTs above. The column order
@@ -2290,6 +2309,7 @@ fn route_row_mapper(row: &rusqlite::Row<'_>) -> rusqlite::Result<RouteRow> {
         row.get::<_, Option<f64>>(24)?,
         row.get::<_, Option<String>>(25)?,
         row.get::<_, Option<String>>(26)?,
+        row.get::<_, Option<Vec<u8>>>(27)?,
     ))
 }
 
@@ -2305,6 +2325,7 @@ fn build_route_from_row(r: RouteRow) -> Result<Route> {
         tire_fl_psi, tire_fr_psi, tire_rl_psi, tire_rr_psi,
         odometer_mi_start, odometer_mi_end,
         location_name_start, location_name_end,
+        fb,
     ) = r;
     let points = decode_points(pb.as_deref())
         .with_context(|| format!("decode points {}", file))?
@@ -2320,9 +2341,13 @@ fn build_route_from_row(r: RouteRow) -> Result<Route> {
     let gear_runs = decode_gear_runs(rb.as_deref())
         .with_context(|| format!("decode gear_runs {}", file))?
         .unwrap_or_default();
+    let flag_runs = decode_flag_runs(fb.as_deref())
+        .with_context(|| format!("decode flag_runs {}", file))?
+        .unwrap_or_default();
     Ok(Route {
         file, date, points, gear_states, autopilot_states,
         speeds, accel_positions, raw_park_count, raw_frame_count, gear_runs,
+        flag_runs,
         source, external_signature, tessie_autopilot_percent,
         battery_pct_start, battery_pct_end,
         interior_temp_min, interior_temp_max, exterior_temp_avg,
@@ -2355,7 +2380,8 @@ fn select_all_route_summaries(conn: &Connection) -> Result<Vec<RouteSummary>> {
                 odometer_mi_start, odometer_mi_end,
                 location_name_start, location_name_end,
                 fsd_pend_ms_end, park_ms_start, fsd_at_end, fsd_accel_pushes_early,
-                ap_at_start
+                ap_at_start,
+                flag_runs_blob, sei_speed_abs_max
          FROM routes
          ORDER BY file",
     )?;
@@ -2421,6 +2447,11 @@ fn select_all_route_summaries(conn: &Connection) -> Result<Vec<RouteSummary>> {
                 row.get::<_, Option<i64>>(42)?,
                 row.get::<_, Option<i64>>(43)?,
             ),
+            // v16 summon evidence
+            (
+                row.get::<_, Option<Vec<u8>>>(44)?,
+                row.get::<_, Option<f64>>(45)?,
+            ),
         ))
     })?;
 
@@ -2462,10 +2493,14 @@ fn select_all_route_summaries(conn: &Connection) -> Result<Vec<RouteSummary>> {
             (odometer_mi_start, odometer_mi_end),
             (location_name_start, location_name_end),
             (fsd_pend_ms_end, park_ms_start, fsd_at_end, fsd_accel_pushes_early, ap_at_start),
+            (fb, sei_speed_abs_max),
         ) = r?;
 
         let gear_runs = decode_gear_runs(rb.as_deref())
             .with_context(|| format!("decode gear_runs {}", file))?
+            .unwrap_or_default();
+        let flag_runs = decode_flag_runs(fb.as_deref())
+            .with_context(|| format!("decode flag_runs {}", file))?
             .unwrap_or_default();
 
         out.push(RouteSummary {
@@ -2474,6 +2509,7 @@ fn select_all_route_summaries(conn: &Connection) -> Result<Vec<RouteSummary>> {
             raw_park_count,
             raw_frame_count,
             gear_runs,
+            flag_runs,
             aggregates: RouteAggregates {
                 distance_m: distance_m.unwrap_or(0.0),
                 max_speed_mps: max_speed_mps.unwrap_or(0.0),
@@ -2498,6 +2534,7 @@ fn select_all_route_summaries(conn: &Connection) -> Result<Vec<RouteSummary>> {
                 start_lng: start_lon,
                 end_lat,
                 end_lng: end_lon,
+                sei_speed_abs_max,
             },
             source,
             external_signature,
@@ -2719,6 +2756,7 @@ mod tests {
                 0,
                 2,
                 &[GearRun { gear: 4, frames: 2 }],
+                &[FlagRun { flags: 3, frames: 1 }, FlagRun { flags: 0, frames: 1 }],
             )
             .unwrap();
         let routes = store.get_routes().unwrap();
@@ -2730,6 +2768,19 @@ mod tests {
         assert_eq!(routes[0].accel_positions, vec![0.5, 0.6]);
         assert_eq!(routes[0].raw_frame_count, 2);
         assert_eq!(routes[0].gear_runs.len(), 1);
+        assert_eq!(
+            routes[0].flag_runs,
+            vec![FlagRun { flags: 3, frames: 1 }, FlagRun { flags: 0, frames: 1 }],
+        );
+        // The summary path carries the same flag evidence + the v16
+        // SEI abs-max column populated by compute_route_aggregates.
+        store
+            .with_route_summaries(|summaries| {
+                assert_eq!(summaries.len(), 1);
+                assert_eq!(summaries[0].flag_runs.len(), 2);
+                assert_eq!(summaries[0].aggregates.sei_speed_abs_max, Some(26.0));
+            })
+            .unwrap();
     }
 
     #[test]
@@ -2751,7 +2802,7 @@ mod tests {
         let store = DriveStore::open(&path_str).unwrap();
         let pts: Vec<GpsPoint> = vec![[37.7749, -122.4194], [37.7760, -122.4180]];
         store
-            .add_route("a/2025-02-02_09-00-00-front.mp4", "a", &pts, &[4, 4], &[0, 0], &[15.0, 16.0], &[0.0, 0.0], 0, 2, &[])
+            .add_route("a/2025-02-02_09-00-00-front.mp4", "a", &pts, &[4, 4], &[0, 0], &[15.0, 16.0], &[0.0, 0.0], 0, 2, &[], &[])
             .unwrap();
         let json = store.get_cached_drives_json().unwrap();
         assert!(json.contains("2025-02-02"), "file-backed rebuild should serve the drive: {json}");
@@ -2768,7 +2819,7 @@ mod tests {
         let store = DriveStore::open_memory().unwrap();
         let pts: Vec<GpsPoint> = vec![[37.7749, -122.4194], [37.7760, -122.4180]];
         store
-            .add_route("a/2025-01-01_10-00-00-front.mp4", "a", &pts, &[4, 4], &[0, 0], &[20.0, 21.0], &[0.0, 0.0], 0, 2, &[])
+            .add_route("a/2025-01-01_10-00-00-front.mp4", "a", &pts, &[4, 4], &[0, 0], &[20.0, 21.0], &[0.0, 0.0], 0, 2, &[], &[])
             .unwrap();
         // add_route marked the cache dirty; the getter must rebuild via the
         // off-lock path and serve a list containing the new drive.
@@ -2779,7 +2830,7 @@ mod tests {
         // A further mutation re-dirties; the next read rebuilds again and
         // reflects it (second route is 2.5h later — a separate drive).
         store
-            .add_route("a/2025-01-01_12-30-00-front.mp4", "a", &pts, &[4, 4], &[0, 0], &[20.0, 21.0], &[0.0, 0.0], 0, 2, &[])
+            .add_route("a/2025-01-01_12-30-00-front.mp4", "a", &pts, &[4, 4], &[0, 0], &[20.0, 21.0], &[0.0, 0.0], 0, 2, &[], &[])
             .unwrap();
         assert!(store.drive_cache_dirty.load(Ordering::Acquire));
         let json2 = store.get_cached_drives_json().unwrap();
@@ -2802,7 +2853,7 @@ mod tests {
         let store = DriveStore::open_memory().unwrap();
         let pts: Vec<GpsPoint> = vec![[37.7749, -122.4194], [37.7760, -122.4180]];
         store
-            .add_route("a.mp4", "2025-01-01", &pts, &[4, 4], &[1, 1], &[20.0, 21.0], &[0.0, 0.0], 0, 2, &[])
+            .add_route("a.mp4", "2025-01-01", &pts, &[4, 4], &[1, 1], &[20.0, 21.0], &[0.0, 0.0], 0, 2, &[], &[])
             .unwrap();
 
         {
@@ -2854,6 +2905,7 @@ mod tests {
                 0,
                 2,
                 &[GearRun { gear: GEAR_DRIVE, frames: 2 }],
+                &[],
             )
             .unwrap();
 
@@ -2873,6 +2925,7 @@ mod tests {
                 60,
                 60,
                 &[GearRun { gear: GEAR_PARK, frames: 60 }],
+                &[],
             )
             .unwrap();
 
@@ -2889,6 +2942,7 @@ mod tests {
                 0,
                 2,
                 &[GearRun { gear: GEAR_DRIVE, frames: 2 }],
+                &[],
             )
             .unwrap();
 
@@ -2911,7 +2965,7 @@ mod tests {
         let speeds = vec![10.0f32; n];
         let accel = vec![0.0f32; n];
         store
-            .add_route(file, "2025-01-01", &pts, &gears, &ap, &speeds, &accel, 0, 61, &[])
+            .add_route(file, "2025-01-01", &pts, &gears, &ap, &speeds, &accel, 0, 61, &[], &[])
             .unwrap();
     }
 
@@ -3016,7 +3070,7 @@ mod tests {
         let speeds = vec![10.0f32; n];
         let accel = vec![0.0f32; n];
         store
-            .add_route(file, "2025-01-01", &pts, &gears, &ap, &speeds, &accel, 0, 61, &[])
+            .add_route(file, "2025-01-01", &pts, &gears, &ap, &speeds, &accel, 0, 61, &[], &[])
             .unwrap();
     }
 
@@ -3098,7 +3152,7 @@ mod tests {
         let store = DriveStore::open_memory().unwrap();
         let pts: Vec<GpsPoint> = vec![[37.7749, -122.4194], [37.7760, -122.4180]];
         store
-            .add_route("2025-01-01/2025-01-01_10-00-00-front.mp4", "2025-01-01", &pts, &[4, 4], &[1, 1], &[20.0, 21.0], &[0.0, 0.0], 0, 2, &[])
+            .add_route("2025-01-01/2025-01-01_10-00-00-front.mp4", "2025-01-01", &pts, &[4, 4], &[1, 1], &[20.0, 21.0], &[0.0, 0.0], 0, 2, &[], &[])
             .unwrap();
         // Plant an absurd stored distance and bake it INTO the caches —
         // this is the old-formula world the gate exists to replace.
@@ -3170,14 +3224,14 @@ mod tests {
         store
             .add_route(
                 "RecentClips/2026-06-07/c-front.mp4", "2026-06-07", &pts,
-                &[4, 4], &[1, 1], &[20.0, 21.0], &[0.0, 0.0], 0, 2, &[],
+                &[4, 4], &[1, 1], &[20.0, 21.0], &[0.0, 0.0], 0, 2, &[], &[],
             )
             .unwrap();
         // Sentry-Drive-style import of the same clip (Windows separators).
         store
             .add_route(
                 "2026-06-07\\c-front.mp4", "2026-06-07", &pts,
-                &[4, 4], &[1, 1], &[20.0, 21.0], &[0.0, 0.0], 0, 2, &[],
+                &[4, 4], &[1, 1], &[20.0, 21.0], &[0.0, 0.0], 0, 2, &[], &[],
             )
             .unwrap();
 
@@ -3216,7 +3270,7 @@ mod tests {
         store
             .add_route(
                 "2026-06-07/dup-front.mp4", "2026-06-07", &pts2,
-                &[4, 4], &[1, 1], &[20.0, 21.0], &[0.0, 0.0], 0, 2, &[],
+                &[4, 4], &[1, 1], &[20.0, 21.0], &[0.0, 0.0], 0, 2, &[], &[],
             )
             .unwrap();
         // Native copy of the same clip (3 points), a lone native row, and a
@@ -3231,7 +3285,7 @@ mod tests {
             store
                 .add_route(
                     tmp, "2026-06-07", pts,
-                    &[4, 4], &[1, 1], &[20.0, 21.0], &[0.0, 0.0], 0, 2, &[],
+                    &[4, 4], &[1, 1], &[20.0, 21.0], &[0.0, 0.0], 0, 2, &[], &[],
                 )
                 .unwrap();
             let conn = store.conn.lock().unwrap();
@@ -3293,7 +3347,7 @@ mod tests {
         let pts: Vec<GpsPoint> = vec![[37.7749, -122.4194], [37.7750, -122.4194]];
         store
             .add_route(
-                "a.mp4", "2025-01-01", &pts, &[], &[], &[], &[], 0, 2, &[],
+                "a.mp4", "2025-01-01", &pts, &[], &[], &[], &[], 0, 2, &[], &[],
             )
             .unwrap();
         let out = store.with_route_summaries(|s| s.to_vec()).unwrap();
@@ -3429,6 +3483,7 @@ mod tests {
                 0,
                 2,
                 &[GearRun { gear: 4, frames: 2 }],
+                &[],
             )
             .unwrap();
 
@@ -3544,7 +3599,7 @@ mod tests {
     fn add_test_route(store: &DriveStore, name: &str) {
         let pts: Vec<GpsPoint> = vec![[37.7749, -122.4194], [37.7750, -122.4195]];
         store
-            .add_route(name, "2025-01-15", &pts, &[4, 4], &[1, 1], &[25.0, 26.0], &[0.5, 0.6], 0, 2, &[])
+            .add_route(name, "2025-01-15", &pts, &[4, 4], &[1, 1], &[25.0, 26.0], &[0.5, 0.6], 0, 2, &[], &[])
             .unwrap();
     }
 

--- a/crates/drives/src/extract.rs
+++ b/crates/drives/src/extract.rs
@@ -11,7 +11,10 @@ use std::io::{Read, Seek, SeekFrom};
 
 use anyhow::{Context, Result};
 
-use crate::types::{ExtractedGps, GearRun, GpsPoint};
+use crate::types::{
+    ExtractedGps, FlagRun, GearRun, GpsPoint, FLAG_ACCEL, FLAG_BLINKER_LEFT,
+    FLAG_BLINKER_RIGHT, FLAG_BRAKE,
+};
 
 /// Gear constants matching Tesla's SeiMetadata.Gear enum.
 pub const GEAR_PARK: u8 = 0;
@@ -39,21 +42,42 @@ pub fn extract_gps_from_file(path: &str) -> Result<ExtractedGps> {
         return Ok(ExtractedGps::empty());
     }
 
-    let (mut points, mut gears, mut ap_states, mut speeds, mut accel_positions) =
+    let (points, gears, ap_states, speeds, accel_positions, flags) =
         extract_from_mdat(&mut f, mdat_offset, mdat_size)?;
+    Ok(assemble_extracted(points, gears, ap_states, speeds, accel_positions, flags))
+}
 
-    // Capture counts BEFORE dedup — raw_frame_count is the true number of
-    // SEI frames in the video, needed for correct t = index/FPS computation.
+/// Assemble the final [`ExtractedGps`] from raw per-frame arrays: raw
+/// counts and BOTH RLEs first, GPS dedup last.
+///
+/// Order matters: gear/flag runs must RLE every raw SEI frame. Computing
+/// gear runs after dedup silently dropped any run whose frames shared a
+/// GPS fix with the frame before it — a car parking is stationary, so the
+/// short trailing Park run collapsed into the last Drive-gear point and
+/// vanished, and the park-gap splitter then fused the summon segment with
+/// the drive that followed it. The final clip of a session can also carry
+/// far fewer real frames than its 60s container claims (recording stops
+/// early); trailing frames are real data, never junk to trim.
+fn assemble_extracted(
+    mut points: Vec<GpsPoint>,
+    mut gears: Vec<u8>,
+    mut ap_states: Vec<u8>,
+    mut speeds: Vec<f32>,
+    mut accel_positions: Vec<f32>,
+    flags: Vec<u8>,
+) -> ExtractedGps {
+    // Raw-frame-space values BEFORE dedup — raw_frame_count is the true
+    // number of SEI frames in the video, needed for correct t = index/FPS
+    // computation, and the runs must cover every raw frame (see above).
     let raw_frame_count = gears.len() as u32;
     let raw_park_count = gears.iter().filter(|&&g| g == GEAR_PARK).count() as u32;
+    let gear_runs = compute_gear_runs(&gears);
+    let flag_runs = compute_flag_runs(&flags);
 
     // Deduplicate consecutive identical GPS points
     dedup_consecutive(&mut points, &mut gears, &mut ap_states, &mut speeds, &mut accel_positions);
 
-    // Compute gear runs
-    let gear_runs = compute_gear_runs(&gears);
-
-    Ok(ExtractedGps {
+    ExtractedGps {
         points,
         gear_states: gears,
         autopilot_states: ap_states,
@@ -62,7 +86,8 @@ pub fn extract_gps_from_file(path: &str) -> Result<ExtractedGps> {
         raw_park_count,
         raw_frame_count,
         gear_runs,
-    })
+        flag_runs,
+    }
 }
 
 /// Extract raw (non-deduplicated) GPS data from a Tesla dashcam MP4 file.
@@ -76,7 +101,9 @@ pub fn extract_gps_from_file_raw(path: &str) -> Result<(Vec<GpsPoint>, Vec<u8>, 
     if mdat_size == 0 {
         return Ok((Vec::new(), Vec::new(), Vec::new(), Vec::new(), Vec::new()));
     }
-    extract_from_mdat(&mut f, mdat_offset, mdat_size)
+    let (points, gears, ap_states, speeds, accel_positions, _flags) =
+        extract_from_mdat(&mut f, mdat_offset, mdat_size)?;
+    Ok((points, gears, ap_states, speeds, accel_positions))
 }
 
 /// Scan MP4 top-level boxes to find the mdat box.
@@ -142,7 +169,7 @@ fn extract_from_mdat(
     f: &mut File,
     offset: u64,
     size: u64,
-) -> Result<(Vec<GpsPoint>, Vec<u8>, Vec<u8>, Vec<f32>, Vec<f32>)> {
+) -> Result<(Vec<GpsPoint>, Vec<u8>, Vec<u8>, Vec<f32>, Vec<f32>, Vec<u8>)> {
     use std::io::BufReader;
     const BUF_SIZE: u64 = 64 * 1024;
 
@@ -151,6 +178,7 @@ fn extract_from_mdat(
     let mut ap_states = Vec::new();
     let mut speeds = Vec::new();
     let mut accel_positions = Vec::new();
+    let mut flags = Vec::new();
 
     let end = offset + size;
     let mut cursor = offset;
@@ -185,15 +213,21 @@ fn extract_from_mdat(
             let mut nal = vec![0u8; nal_size as usize];
             nal[0] = type_buf[0];
             if reader.read_exact(&mut nal[1..]).is_ok() {
-                if let Some((lat, lon, gear, ap_state, speed, accel_pos)) = parse_tesla_sei(&nal) {
+                if let Some(frame) = parse_tesla_sei(&nal) {
                     points.push([
-                        (lat * 1e6).round() / 1e6,
-                        (lon * 1e6).round() / 1e6,
+                        (frame.lat * 1e6).round() / 1e6,
+                        (frame.lon * 1e6).round() / 1e6,
                     ]);
-                    gears.push(gear);
-                    ap_states.push(ap_state);
-                    speeds.push(speed);
-                    accel_positions.push(accel_pos);
+                    gears.push(frame.gear);
+                    ap_states.push(frame.ap_state);
+                    speeds.push(frame.speed);
+                    accel_positions.push(frame.accel_pos);
+                    flags.push(
+                        (if frame.blinker_left { FLAG_BLINKER_LEFT } else { 0 })
+                            | (if frame.blinker_right { FLAG_BLINKER_RIGHT } else { 0 })
+                            | (if frame.brake { FLAG_BRAKE } else { 0 })
+                            | (if frame.accel_pos > 0.0 { FLAG_ACCEL } else { 0 }),
+                    );
                 }
             } else {
                 break;
@@ -208,11 +242,24 @@ fn extract_from_mdat(
         cursor += nal_size;
     }
 
-    Ok((points, gears, ap_states, speeds, accel_positions))
+    Ok((points, gears, ap_states, speeds, accel_positions, flags))
+}
+
+/// One decoded SEI frame's worth of Tesla metadata.
+struct SeiFrame {
+    lat: f64,
+    lon: f64,
+    gear: u8,
+    ap_state: u8,
+    speed: f32,
+    accel_pos: f32,
+    blinker_left: bool,
+    blinker_right: bool,
+    brake: bool,
 }
 
 /// Finds the Tesla magic bytes (0x42...0x69) in a SEI NAL and decodes GPS + metadata.
-fn parse_tesla_sei(nal: &[u8]) -> Option<(f64, f64, u8, u8, f32, f32)> {
+fn parse_tesla_sei(nal: &[u8]) -> Option<SeiFrame> {
     // Skip NAL header, look for 0x42 sequence followed by 0x69
     let mut i = 3;
     while i < nal.len() && nal[i] == 0x42 {
@@ -258,15 +305,23 @@ fn strip_emulation_bytes(data: &[u8]) -> Vec<u8> {
 /// - autopilot_state (field 10, varint)
 /// - vehicle_speed_mps (field 4, float/fixed32)
 /// - accelerator_pedal_position (field 5, float/fixed32)
+/// - blinker_on_left / blinker_on_right (fields 7/8, varint) — steady
+///   switch state, not lamp flash
+/// - brake_applied (field 9, varint) — pedal-only
 ///
-/// Hand-parses protobuf wire format to avoid external dependencies.
-fn decode_sei_gps(data: &[u8]) -> Option<(f64, f64, u8, u8, f32, f32)> {
+/// proto3 omits false/zero fields from the wire, so absent simply
+/// decodes as off. Hand-parses protobuf wire format to avoid external
+/// dependencies.
+fn decode_sei_gps(data: &[u8]) -> Option<SeiFrame> {
     let mut lat: f64 = 0.0;
     let mut lon: f64 = 0.0;
     let mut gear: u8 = 0;
     let mut ap_state: u8 = 0;
     let mut speed: f32 = 0.0;
     let mut accel_pos: f32 = 0.0;
+    let mut blinker_left = false;
+    let mut blinker_right = false;
+    let mut brake = false;
 
     let mut i = 0;
     while i < data.len() {
@@ -289,6 +344,12 @@ fn decode_sei_gps(data: &[u8]) -> Option<(f64, f64, u8, u8, f32, f32)> {
                 i += vn;
                 if field_num == 2 {
                     gear = val as u8;
+                } else if field_num == 7 {
+                    blinker_left = val != 0;
+                } else if field_num == 8 {
+                    blinker_right = val != 0;
+                } else if field_num == 9 {
+                    brake = val != 0;
                 } else if field_num == 10 {
                     ap_state = val as u8;
                 }
@@ -346,7 +407,17 @@ fn decode_sei_gps(data: &[u8]) -> Option<(f64, f64, u8, u8, f32, f32)> {
         && lon.abs() <= 180.0;
 
     if ok {
-        Some((lat, lon, gear, ap_state, speed, accel_pos))
+        Some(SeiFrame {
+            lat,
+            lon,
+            gear,
+            ap_state,
+            speed,
+            accel_pos,
+            blinker_left,
+            blinker_right,
+            brake,
+        })
     } else {
         None
     }
@@ -430,6 +501,38 @@ fn compute_gear_runs(gears: &[u8]) -> Vec<GearRun> {
     runs
 }
 
+/// RLE the per-frame SEI flag bytes (blinkers/brake/accel bits) over RAW
+/// frame indices — the same frame space as gear runs. Mirrors
+/// Sentry-Drive's `computeFlagRuns` (drive-calc.cjs).
+fn compute_flag_runs(flags: &[u8]) -> Vec<FlagRun> {
+    if flags.is_empty() {
+        return Vec::new();
+    }
+
+    let mut runs = Vec::new();
+    let mut current_flags = flags[0];
+    let mut count: u32 = 1;
+
+    for &f in &flags[1..] {
+        if f == current_flags {
+            count += 1;
+        } else {
+            runs.push(FlagRun {
+                flags: current_flags,
+                frames: count,
+            });
+            current_flags = f;
+            count = 1;
+        }
+    }
+    runs.push(FlagRun {
+        flags: current_flags,
+        frames: count,
+    });
+
+    runs
+}
+
 impl ExtractedGps {
     /// Create an empty ExtractedGps result.
     pub fn empty() -> Self {
@@ -442,6 +545,7 @@ impl ExtractedGps {
             raw_park_count: 0,
             raw_frame_count: 0,
             gear_runs: Vec::new(),
+            flag_runs: Vec::new(),
         }
     }
 }
@@ -510,6 +614,90 @@ mod tests {
     }
 
     #[test]
+    fn test_compute_flag_runs() {
+        // Mirrors Sentry-Drive drive-calc.test.js "computeFlagRuns RLEs
+        // raw frames and round-trips totals".
+        assert!(compute_flag_runs(&[]).is_empty());
+        let runs = compute_flag_runs(&[0, 0, 3, 3, 3, 1, 0]);
+        assert_eq!(
+            runs,
+            vec![
+                FlagRun { flags: 0, frames: 2 },
+                FlagRun { flags: 3, frames: 3 },
+                FlagRun { flags: 1, frames: 1 },
+                FlagRun { flags: 0, frames: 1 },
+            ]
+        );
+        // Run totals must reconstruct the frame count — the summon
+        // detector's segment bounds depend on flagRuns living in raw
+        // frame space.
+        let flags = [0u8, 8, 8, 4, 0, 0, 3, 3, 2, 1];
+        let total: u32 = compute_flag_runs(&flags).iter().map(|r| r.frames).sum();
+        assert_eq!(total as usize, flags.len());
+    }
+
+    #[test]
+    fn test_gear_runs_keep_trailing_park_despite_frozen_gps() {
+        // Regression for the 2026-07-15_20-50-43 clip: the car stops
+        // (GPS freezes) while still in Drive, then shifts to Park for the
+        // final frames. Computing gear runs AFTER GPS dedup collapsed all
+        // the same-fix frames into the last Drive point, so gearRuns
+        // reported [Drive] only and the park splitter never separated the
+        // summon from the following drive. Runs must RLE every RAW frame.
+        let moving = 447; // distinct GPS fixes while driving
+        let stopped_drive = 53; // still in Drive, GPS frozen
+        let parked = 53; // trailing Park, GPS frozen
+        let mut points = Vec::new();
+        let mut gears = Vec::new();
+        let mut flags = Vec::new();
+        for i in 0..moving {
+            points.push([37.0 + i as f64 * 1e-5, -122.0]);
+            gears.push(GEAR_DRIVE);
+            flags.push(0);
+        }
+        for _ in 0..(stopped_drive + parked) {
+            points.push([37.0 + (moving - 1) as f64 * 1e-5, -122.0]);
+            flags.push(3); // hazards held through the stop and D→P shift
+        }
+        gears.resize(moving + stopped_drive, GEAR_DRIVE);
+        gears.resize(moving + stopped_drive + parked, GEAR_PARK);
+        let n = points.len();
+        let out = assemble_extracted(
+            points,
+            gears,
+            vec![0; n],
+            vec![0.0; n],
+            vec![0.0; n],
+            flags,
+        );
+
+        assert_eq!(out.raw_frame_count, 553);
+        assert_eq!(out.raw_park_count, 53);
+        // Full raw-frame RLE: [Drive x500, Park x53] — the trailing Park
+        // run survives even though its GPS fix never changed.
+        assert_eq!(out.gear_runs.len(), 2);
+        assert_eq!(out.gear_runs[0].gear, GEAR_DRIVE);
+        assert_eq!(out.gear_runs[0].frames, 500);
+        assert_eq!(out.gear_runs[1].gear, GEAR_PARK);
+        assert_eq!(out.gear_runs[1].frames, 53);
+        let gear_total: u32 = out.gear_runs.iter().map(|r| r.frames).sum();
+        assert_eq!(gear_total, out.raw_frame_count);
+        // Flag runs live in the same raw frame space.
+        let flag_total: u32 = out.flag_runs.iter().map(|r| r.frames).sum();
+        assert_eq!(flag_total, out.raw_frame_count);
+        assert_eq!(
+            out.flag_runs,
+            vec![
+                FlagRun { flags: 0, frames: 447 },
+                FlagRun { flags: 3, frames: 106 },
+            ]
+        );
+        // Dedup still applies to the point-domain arrays.
+        assert_eq!(out.points.len(), moving);
+        assert_eq!(out.gear_states.len(), moving);
+    }
+
+    #[test]
     fn test_decode_sei_gps_valid() {
         // Build a minimal protobuf message with:
         // field 2 (gear) = 1 (Drive), varint
@@ -531,10 +719,32 @@ mod tests {
 
         let result = decode_sei_gps(&data);
         assert!(result.is_some());
-        let (lat, lon, gear, _, _, _) = result.unwrap();
-        assert!((lat - 37.7749).abs() < 1e-10);
-        assert!((lon - (-122.4194)).abs() < 1e-10);
-        assert_eq!(gear, 1);
+        let frame = result.unwrap();
+        assert!((frame.lat - 37.7749).abs() < 1e-10);
+        assert!((frame.lon - (-122.4194)).abs() < 1e-10);
+        assert_eq!(frame.gear, 1);
+        // proto3 omits false fields — absent decodes as off.
+        assert!(!frame.blinker_left);
+        assert!(!frame.blinker_right);
+        assert!(!frame.brake);
+    }
+
+    #[test]
+    fn test_decode_sei_gps_flag_fields() {
+        // Fields 7 (blinker_on_left), 8 (blinker_on_right), 9
+        // (brake_applied) are varints; nonzero = on. Tags: (7<<3)|0 = 56,
+        // (8<<3)|0 = 64, (9<<3)|0 = 72.
+        let mut data = vec![0x38, 0x01, 0x40, 0x01, 0x48, 0x01];
+        // Field 11 (lat), field 12 (lon) — required for a valid frame.
+        data.push(0x59);
+        data.extend_from_slice(&37.7749f64.to_le_bytes());
+        data.push(0x61);
+        data.extend_from_slice(&(-122.4194f64).to_le_bytes());
+
+        let frame = decode_sei_gps(&data).expect("valid frame");
+        assert!(frame.blinker_left);
+        assert!(frame.blinker_right);
+        assert!(frame.brake);
     }
 
     #[test]

--- a/crates/drives/src/extract.rs
+++ b/crates/drives/src/extract.rs
@@ -72,8 +72,7 @@ fn assemble_extracted(
     let raw_frame_count = gears.len() as u32;
     let raw_park_count = gears.iter().filter(|&&g| g == GEAR_PARK).count() as u32;
     let gear_runs = compute_gear_runs(&gears);
-    let flag_runs = compute_flag_runs(&flags);
-    let gear_run_speed_max = compute_gear_run_speed_max(&gear_runs, &speeds);
+    let flag_runs = compute_flag_runs(&flags, Some(&speeds));
 
     // Deduplicate consecutive identical GPS points
     dedup_consecutive(&mut points, &mut gears, &mut ap_states, &mut speeds, &mut accel_positions);
@@ -88,33 +87,7 @@ fn assemble_extracted(
         raw_frame_count,
         gear_runs,
         flag_runs,
-        gear_run_speed_max,
     }
-}
-
-/// Max |SEI speed| inside each gear run, in the same raw kept-frame
-/// space as the runs themselves (SEI speed is signed — negative in
-/// Reverse). Park splits always land on gear-run boundaries, so this
-/// gives the summary-path summon detector exact per-segment speed
-/// evidence: a summon crawl that shares a clip with the human driving
-/// off seconds later keeps its own max instead of inheriting the whole
-/// clip's. Same 100 m/s sanity cap as the clip-level abs max.
-fn compute_gear_run_speed_max(gear_runs: &[GearRun], speeds: &[f32]) -> Vec<f32> {
-    let mut out = Vec::with_capacity(gear_runs.len());
-    let mut frame = 0usize;
-    for run in gear_runs {
-        let end = (frame + run.frames as usize).min(speeds.len());
-        let mut max_abs = 0.0f32;
-        for &s in &speeds[frame.min(end)..end] {
-            let a = s.abs();
-            if a < 100.0 && a > max_abs {
-                max_abs = a;
-            }
-        }
-        out.push(max_abs);
-        frame = end;
-    }
-    out
 }
 
 /// Extract raw (non-deduplicated) GPS data from a Tesla dashcam MP4 file.
@@ -530,31 +503,55 @@ fn compute_gear_runs(gears: &[u8]) -> Vec<GearRun> {
 
 /// RLE the per-frame SEI flag bytes (blinkers/brake/accel bits) over RAW
 /// frame indices — the same frame space as gear runs. Mirrors
-/// Sentry-Drive's `computeFlagRuns` (drive-calc.cjs).
-fn compute_flag_runs(flags: &[u8]) -> Vec<FlagRun> {
+/// Sentry-Drive's `computeFlagRuns(flags, speeds)` (drive-calc.cjs).
+///
+/// When `speeds` is given, each run carries `max_mps` — the max |SEI
+/// speed| within its frames, rounded to 0.1 (SEI speed is signed;
+/// Reverse counts via magnitude). This is the summon detector's
+/// frame-space speed evidence: the park splitter's fraction→point slice
+/// overshoots on deduped points, so a summon segment's stats can
+/// inherit the following drive's speed samples — per-run maxima confine
+/// the gate to the segment's own frames.
+fn compute_flag_runs(flags: &[u8], speeds: Option<&[f32]>) -> Vec<FlagRun> {
     if flags.is_empty() {
         return Vec::new();
     }
 
+    let r1 = |v: f64| (v * 10.0).round() / 10.0;
+    let speed_at = |i: usize| -> f64 {
+        speeds
+            .and_then(|s| s.get(i))
+            .map(|&v| (v as f64).abs())
+            .unwrap_or(0.0)
+    };
+
     let mut runs = Vec::new();
     let mut current_flags = flags[0];
     let mut count: u32 = 1;
+    let mut max_abs = speed_at(0);
 
-    for &f in &flags[1..] {
+    for (i, &f) in flags.iter().enumerate().skip(1) {
         if f == current_flags {
             count += 1;
+            let a = speed_at(i);
+            if a > max_abs {
+                max_abs = a;
+            }
         } else {
             runs.push(FlagRun {
                 flags: current_flags,
                 frames: count,
+                max_mps: speeds.map(|_| r1(max_abs)),
             });
             current_flags = f;
             count = 1;
+            max_abs = speed_at(i);
         }
     }
     runs.push(FlagRun {
         flags: current_flags,
         frames: count,
+        max_mps: speeds.map(|_| r1(max_abs)),
     });
 
     runs
@@ -573,7 +570,6 @@ impl ExtractedGps {
             raw_frame_count: 0,
             gear_runs: Vec::new(),
             flag_runs: Vec::new(),
-            gear_run_speed_max: Vec::new(),
         }
     }
 }
@@ -645,23 +641,41 @@ mod tests {
     fn test_compute_flag_runs() {
         // Mirrors Sentry-Drive drive-calc.test.js "computeFlagRuns RLEs
         // raw frames and round-trips totals".
-        assert!(compute_flag_runs(&[]).is_empty());
-        let runs = compute_flag_runs(&[0, 0, 3, 3, 3, 1, 0]);
+        assert!(compute_flag_runs(&[], None).is_empty());
+        let runs = compute_flag_runs(&[0, 0, 3, 3, 3, 1, 0], None);
         assert_eq!(
             runs,
             vec![
-                FlagRun { flags: 0, frames: 2 },
-                FlagRun { flags: 3, frames: 3 },
-                FlagRun { flags: 1, frames: 1 },
-                FlagRun { flags: 0, frames: 1 },
+                FlagRun { flags: 0, frames: 2, max_mps: None },
+                FlagRun { flags: 3, frames: 3, max_mps: None },
+                FlagRun { flags: 1, frames: 1, max_mps: None },
+                FlagRun { flags: 0, frames: 1, max_mps: None },
             ]
         );
         // Run totals must reconstruct the frame count — the summon
         // detector's segment bounds depend on flagRuns living in raw
         // frame space.
         let flags = [0u8, 8, 8, 4, 0, 0, 3, 3, 2, 1];
-        let total: u32 = compute_flag_runs(&flags).iter().map(|r| r.frames).sum();
+        let total: u32 = compute_flag_runs(&flags, None).iter().map(|r| r.frames).sum();
         assert_eq!(total as usize, flags.len());
+    }
+
+    #[test]
+    fn test_compute_flag_runs_carries_per_run_max_speed() {
+        // Mirrors drive-calc.test.js "computeFlagRuns carries per-run
+        // max |SEI speed| when speeds are given".
+        let flags = [0u8, 0, 3, 3, 8, 8, 8];
+        let speeds = [0.0f32, -1.5, 0.4, 0.26, 2.0, 4.73, 3.1];
+        assert_eq!(
+            compute_flag_runs(&flags, Some(&speeds)),
+            vec![
+                // reverse counts via magnitude
+                FlagRun { flags: 0, frames: 2, max_mps: Some(1.5) },
+                FlagRun { flags: 3, frames: 2, max_mps: Some(0.4) },
+                // rounded to 0.1
+                FlagRun { flags: 8, frames: 3, max_mps: Some(4.7) },
+            ]
+        );
     }
 
     #[test]
@@ -691,8 +705,8 @@ mod tests {
         gears.resize(moving + stopped_drive + parked, GEAR_PARK);
         let n = points.len();
         // Crawl speed while in Drive (negative — this clip shape also
-        // covers Reverse semantics), zero once parked: the per-gear-run
-        // maxima must be |v| per run, not whole-clip.
+        // covers Reverse semantics), zero once parked: per-run maxima
+        // must be |v| within the run's own frames, not whole-clip.
         let mut speeds = vec![-2.13f32; moving + stopped_drive];
         speeds.resize(n, 0.0);
         let out = assemble_extracted(
@@ -715,22 +729,18 @@ mod tests {
         assert_eq!(out.gear_runs[1].frames, 53);
         let gear_total: u32 = out.gear_runs.iter().map(|r| r.frames).sum();
         assert_eq!(gear_total, out.raw_frame_count);
-        // Flag runs live in the same raw frame space.
+        // Flag runs live in the same raw frame space, each carrying its
+        // own max |SEI speed| (the -2.13 m/s crawl reads 2.1 absolute,
+        // rounded to 0.1 — Sentry-Drive's r1).
         let flag_total: u32 = out.flag_runs.iter().map(|r| r.frames).sum();
         assert_eq!(flag_total, out.raw_frame_count);
         assert_eq!(
             out.flag_runs,
             vec![
-                FlagRun { flags: 0, frames: 447 },
-                FlagRun { flags: 3, frames: 106 },
+                FlagRun { flags: 0, frames: 447, max_mps: Some(2.1) },
+                FlagRun { flags: 3, frames: 106, max_mps: Some(2.1) },
             ]
         );
-        // Per-gear-run |SEI| maxima, parallel to gear_runs: the Drive
-        // run keeps its 2.13 m/s crawl (absolute — the samples are
-        // negative), the Park run reads 0.
-        assert_eq!(out.gear_run_speed_max.len(), out.gear_runs.len());
-        assert!((out.gear_run_speed_max[0] - 2.13).abs() < 1e-6);
-        assert_eq!(out.gear_run_speed_max[1], 0.0);
         // Dedup still applies to the point-domain arrays.
         assert_eq!(out.points.len(), moving);
         assert_eq!(out.gear_states.len(), moving);

--- a/crates/drives/src/extract.rs
+++ b/crates/drives/src/extract.rs
@@ -165,11 +165,11 @@ fn find_mdat_box(f: &mut File) -> Result<(u64, u64)> {
 /// bytes — encoded video) are skipped with `seek_relative`, which discards
 /// the buffer only when the skip lands outside it, so large video frames
 /// don't get pulled into memory.
-fn extract_from_mdat(
-    f: &mut File,
-    offset: u64,
-    size: u64,
-) -> Result<(Vec<GpsPoint>, Vec<u8>, Vec<u8>, Vec<f32>, Vec<f32>, Vec<u8>)> {
+/// Raw per-frame arrays out of the SEI scan, 1:1 with SEI frames:
+/// (points, gears, autopilot states, speeds, accel positions, flag bytes).
+type RawFrameArrays = (Vec<GpsPoint>, Vec<u8>, Vec<u8>, Vec<f32>, Vec<f32>, Vec<u8>);
+
+fn extract_from_mdat(f: &mut File, offset: u64, size: u64) -> Result<RawFrameArrays> {
     use std::io::BufReader;
     const BUF_SIZE: u64 = 64 * 1024;
 

--- a/crates/drives/src/extract.rs
+++ b/crates/drives/src/extract.rs
@@ -73,6 +73,7 @@ fn assemble_extracted(
     let raw_park_count = gears.iter().filter(|&&g| g == GEAR_PARK).count() as u32;
     let gear_runs = compute_gear_runs(&gears);
     let flag_runs = compute_flag_runs(&flags);
+    let gear_run_speed_max = compute_gear_run_speed_max(&gear_runs, &speeds);
 
     // Deduplicate consecutive identical GPS points
     dedup_consecutive(&mut points, &mut gears, &mut ap_states, &mut speeds, &mut accel_positions);
@@ -87,7 +88,33 @@ fn assemble_extracted(
         raw_frame_count,
         gear_runs,
         flag_runs,
+        gear_run_speed_max,
     }
+}
+
+/// Max |SEI speed| inside each gear run, in the same raw kept-frame
+/// space as the runs themselves (SEI speed is signed — negative in
+/// Reverse). Park splits always land on gear-run boundaries, so this
+/// gives the summary-path summon detector exact per-segment speed
+/// evidence: a summon crawl that shares a clip with the human driving
+/// off seconds later keeps its own max instead of inheriting the whole
+/// clip's. Same 100 m/s sanity cap as the clip-level abs max.
+fn compute_gear_run_speed_max(gear_runs: &[GearRun], speeds: &[f32]) -> Vec<f32> {
+    let mut out = Vec::with_capacity(gear_runs.len());
+    let mut frame = 0usize;
+    for run in gear_runs {
+        let end = (frame + run.frames as usize).min(speeds.len());
+        let mut max_abs = 0.0f32;
+        for &s in &speeds[frame.min(end)..end] {
+            let a = s.abs();
+            if a < 100.0 && a > max_abs {
+                max_abs = a;
+            }
+        }
+        out.push(max_abs);
+        frame = end;
+    }
+    out
 }
 
 /// Extract raw (non-deduplicated) GPS data from a Tesla dashcam MP4 file.
@@ -546,6 +573,7 @@ impl ExtractedGps {
             raw_frame_count: 0,
             gear_runs: Vec::new(),
             flag_runs: Vec::new(),
+            gear_run_speed_max: Vec::new(),
         }
     }
 }
@@ -662,11 +690,16 @@ mod tests {
         gears.resize(moving + stopped_drive, GEAR_DRIVE);
         gears.resize(moving + stopped_drive + parked, GEAR_PARK);
         let n = points.len();
+        // Crawl speed while in Drive (negative — this clip shape also
+        // covers Reverse semantics), zero once parked: the per-gear-run
+        // maxima must be |v| per run, not whole-clip.
+        let mut speeds = vec![-2.13f32; moving + stopped_drive];
+        speeds.resize(n, 0.0);
         let out = assemble_extracted(
             points,
             gears,
             vec![0; n],
-            vec![0.0; n],
+            speeds,
             vec![0.0; n],
             flags,
         );
@@ -692,6 +725,12 @@ mod tests {
                 FlagRun { flags: 3, frames: 106 },
             ]
         );
+        // Per-gear-run |SEI| maxima, parallel to gear_runs: the Drive
+        // run keeps its 2.13 m/s crawl (absolute — the samples are
+        // negative), the Park run reads 0.
+        assert_eq!(out.gear_run_speed_max.len(), out.gear_runs.len());
+        assert!((out.gear_run_speed_max[0] - 2.13).abs() < 1e-6);
+        assert_eq!(out.gear_run_speed_max[1], 0.0);
         // Dedup still applies to the point-domain arrays.
         assert_eq!(out.points.len(), moving);
         assert_eq!(out.gear_states.len(), moving);

--- a/crates/drives/src/grouper.rs
+++ b/crates/drives/src/grouper.rs
@@ -1262,6 +1262,10 @@ pub(crate) fn detect_summon(
         }
         speed_mps = max_speed_mps;
     }
+    // `!(x > 0.0)` rather than `x <= 0.0`: NaN fails both comparisons, so
+    // the negated form rejects a NaN speed while `<=` would admit it —
+    // same semantics as Sentry-Drive's `!(speedMps > 0)`.
+    #[allow(clippy::neg_cmp_op_on_partial_ord)]
     if !(speed_mps > 0.0) || speed_mps > SUMMON_MAX_SPEED_MPS {
         return false;
     }

--- a/crates/drives/src/grouper.rs
+++ b/crates/drives/src/grouper.rs
@@ -69,12 +69,15 @@ const CLIP_DURATION_MS: i64 = 60_000;
 // exactly (locked there by drive-calc.test.js), verified against real
 // Actually Smart Summon footage (2026-07-15 20:49/20:50): hazards = both
 // blinker bits in the SAME run, held 1-4 s spanning BOTH gear
-// transitions; accel/brake stay 0 the whole drive; speed peaked at
-// 2.7 m/s (Tesla caps summon near 6 mph); autopilot_state stays 0 during
-// summon, so it plays no part here.
+// transitions; accel/brake stay 0 the whole drive; autopilot_state stays
+// 0 during summon, so it plays no part here. Speed cap: Tesla limits
+// summon to ~6 mph on older firmware and 8 mph (3.58 m/s) on newer cars
+// — 4.5 m/s (10.1 mph) gives the 8 mph ceiling the same headroom the
+// previous 3.5 gate gave the 6 mph one (observed ASS peak on the 6 mph
+// firmware: 2.7 m/s).
 
 /// SEI max speed (m/s) above which a drive cannot be a summon.
-const SUMMON_MAX_SPEED_MPS: f64 = 3.5;
+const SUMMON_MAX_SPEED_MPS: f64 = 4.5;
 
 /// Hazards must appear within this many seconds of the drive's start and
 /// end (in frames-of-clip terms — see `detect_summon`).
@@ -1026,9 +1029,8 @@ fn split_clip_at_park_gaps(clip: &TimedRoute) -> Vec<ClipSegment> {
                     // Sentry-Drive's `{...clip}` sub-segment spread) —
                     // flag runs live in RAW frame space, so slicing
                     // them to the segment would corrupt the frame
-                    // indexing. Same for the per-gear-run maxima.
+                    // indexing.
                     flag_runs: clip.route.flag_runs.clone(),
-                    gear_run_speed_max: clip.route.gear_run_speed_max.clone(),
                     source: clip.route.source.clone(),
                     external_signature: clip.route.external_signature.clone(),
                     tessie_autopilot_percent: clip.route.tessie_autopilot_percent,
@@ -1175,6 +1177,31 @@ pub(crate) fn flag_runs_overlap(
     false
 }
 
+/// Frame-space max |SEI speed| over the flag runs overlapping a
+/// segment's `[start_frame, end_frame)` — `None` when any overlapping
+/// run predates per-run speed evidence (pre-`max_mps` extraction), so
+/// callers can fall back. Mirrors Sentry-Drive's `segmentMaxSpeed`.
+fn segment_max_speed(c: &SummonClipEvidence) -> Option<f64> {
+    let mut frame: u32 = 0;
+    let mut max = 0.0f64;
+    for run in c.flag_runs {
+        let start = frame;
+        let end = frame + run.frames;
+        frame = end;
+        if end <= c.start_frame {
+            continue;
+        }
+        if start >= c.end_frame {
+            break;
+        }
+        let m = run.max_mps.filter(|m| m.is_finite())?;
+        if m > max {
+            max = m;
+        }
+    }
+    Some(max)
+}
+
 /// Detect a Summon / Smart Summon drive from per-clip SEI flag evidence.
 ///
 /// The verified signature: hazards within the opening seconds of the
@@ -1184,11 +1211,13 @@ pub(crate) fn flag_runs_overlap(
 /// human repositioning with hazards on still touches a pedal or exceeds
 /// the summon speed cap.
 ///
-/// `max_speed_mps` must be the max **absolute** SEI speed (Reverse
-/// reports negative); `has_sei_speeds` gates out GPS-derived speeds,
-/// which jitter well past walking pace on a car that barely moved. Flag
-/// data always ships alongside SEI speed, so that gate only rejects
-/// degenerate inputs.
+/// Speed gate, frame-accurate when possible: per-run `max_mps` evidence
+/// is immune to the dedup point-slice overshoot that can leak the
+/// following drive's speed into a summon segment's stats. Legacy
+/// evidence (no `max_mps`) falls back to `max_speed_mps` — the max
+/// **absolute** SEI speed (Reverse reports negative) — and there
+/// GPS-derived speeds are still untrustworthy at summon magnitudes, so
+/// `has_sei_speeds` is required.
 pub(crate) fn detect_summon(
     clips: &[SummonClipEvidence],
     max_speed_mps: f64,
@@ -1196,12 +1225,6 @@ pub(crate) fn detect_summon(
     has_sei_speeds: bool,
 ) -> bool {
     if clips.is_empty() {
-        return false;
-    }
-    if !has_sei_speeds {
-        return false;
-    }
-    if !(max_speed_mps > 0.0) || max_speed_mps > SUMMON_MAX_SPEED_MPS {
         return false;
     }
     if !(duration_ms > 0) || duration_ms > SUMMON_MAX_DURATION_MS {
@@ -1216,6 +1239,31 @@ pub(crate) fn detect_summon(
         if c.flag_runs.is_empty() || c.total_frames == 0 || c.end_frame <= c.start_frame {
             return false;
         }
+    }
+
+    let mut speed_mps = 0.0f64;
+    let mut frame_accurate = true;
+    for c in clips {
+        match segment_max_speed(c) {
+            None => {
+                frame_accurate = false;
+                break;
+            }
+            Some(m) => {
+                if m > speed_mps {
+                    speed_mps = m;
+                }
+            }
+        }
+    }
+    if !frame_accurate {
+        if !has_sei_speeds {
+            return false;
+        }
+        speed_mps = max_speed_mps;
+    }
+    if !(speed_mps > 0.0) || speed_mps > SUMMON_MAX_SPEED_MPS {
+        return false;
     }
 
     const HAZARD: u8 = FLAG_BLINKER_LEFT | FLAG_BLINKER_RIGHT;
@@ -2800,25 +2848,20 @@ fn build_summary_from_aggregates(
     // flag_runs plus its park-split segment bounds — raw SEI frame
     // space, immune to GPS dedup. Clips without flag_runs (pre-flags
     // extractions, imports) make the drive unverifiable and
-    // detect_summon returns false. Speed comes from the v16
-    // sei_speed_abs_max column: the locked max_speed_mps drops negative
-    // (Reverse) SEI samples — a reverse-only summon would read 0 — and
-    // can't distinguish GPS-derived speed, which jitters past walking
-    // pace on a car that barely moved.
+    // detect_summon returns false. The speed gate is frame-accurate
+    // inside detect_summon via per-run `max_mps`; these clip-level
+    // values only feed its legacy fallback (rows extracted before
+    // per-run maxima existed). There the v16 sei_speed_abs_max column is
+    // used because the locked max_speed_mps drops negative (Reverse)
+    // SEI samples — a reverse-only summon would read 0 — and can't
+    // distinguish GPS-derived speed, which jitters past walking pace on
+    // a car that barely moved. A whole-clip abs max over-reports a
+    // shared clip's summon segment — conservative: the drive stays
+    // unflagged until reprocessed.
     let mut has_sei_speeds = false;
     let mut summon_max_speed: f64 = 0.0;
     for clip in clips {
-        // Segment-scoped max |SEI| when the v16 per-gear-run maxima are
-        // present — park splits land on gear-run boundaries, so the runs
-        // overlapping this sub-clip's frame range cover it exactly. This
-        // is what keeps a summon crawl's speed evidence clean when the
-        // human drives off seconds later IN THE SAME CLIP (real case:
-        // 2026-07-27 20:04). Rows without the column (pre-v16, imports)
-        // fall back to the whole-clip abs max — conservative: a shared
-        // clip then over-reports the summon segment's speed and the
-        // drive simply stays unflagged until reprocessed.
-        let seg_max = segment_abs_speed_max(clip).or(clip.summary.aggregates.sei_speed_abs_max);
-        if let Some(m) = seg_max {
+        if let Some(m) = clip.summary.aggregates.sei_speed_abs_max {
             if m > 0.0 {
                 has_sei_speeds = true;
             }
@@ -2826,42 +2869,6 @@ fn build_summary_from_aggregates(
                 summon_max_speed = m;
             }
         }
-    }
-    /// Max |SEI speed| over the gear runs overlapping this sub-clip's
-    /// `[start_frame, end_frame)` range, from the v16 per-gear-run
-    /// maxima. `None` when the column is absent or doesn't match the
-    /// gear runs (pre-v16 rows, imports, corrupt pairing) — callers
-    /// fall back to the clip-level abs max.
-    fn segment_abs_speed_max(c: &SubClipSummary) -> Option<f64> {
-        let runs = &c.summary.gear_runs;
-        let maxes = &c.summary.gear_run_speed_max;
-        if runs.is_empty() || maxes.len() != runs.len() {
-            return None;
-        }
-        // Whole-clip wraps of gear-less rows carry the total_frames=1
-        // sentinel; runs being non-empty means real bounds here, but
-        // keep the sentinel path meaning "whole clip" regardless.
-        let (s, e) = if c.total_frames > 1 {
-            (c.start_frame, c.end_frame)
-        } else {
-            (0, u32::MAX)
-        };
-        let mut frame = 0u32;
-        let mut best = 0.0f64;
-        for (run, &m) in runs.iter().zip(maxes.iter()) {
-            let (rs, re) = (frame, frame + run.frames);
-            frame = re;
-            if re <= s {
-                continue;
-            }
-            if rs >= e {
-                break;
-            }
-            if (m as f64) > best {
-                best = m as f64;
-            }
-        }
-        Some(best)
     }
 
     let summon_evidence: Vec<SummonClipEvidence> = clips
@@ -3283,7 +3290,6 @@ mod tests {
             raw_frame_count: 0,
             gear_runs: Vec::new(),
             flag_runs: Vec::new(),
-            gear_run_speed_max: Vec::new(),
             aggregates: a1,
             source: None,
             external_signature: None,
@@ -3296,7 +3302,6 @@ mod tests {
             raw_frame_count: 0,
             gear_runs: Vec::new(),
             flag_runs: Vec::new(),
-            gear_run_speed_max: Vec::new(),
             aggregates: a2,
             source: None,
             external_signature: None,
@@ -3329,7 +3334,6 @@ mod tests {
             raw_frame_count: 60,
             gear_runs: vec![GearRun { gear: 1, frames: 60 }],
             flag_runs: Vec::new(),
-            gear_run_speed_max: Vec::new(),
             aggregates: RouteAggregates::default(),
             source: None,
             external_signature: None,
@@ -3351,7 +3355,6 @@ mod tests {
             raw_frame_count: runs.iter().map(|(_, f)| *f).sum(),
             gear_runs: runs.iter().map(|(g, f)| GearRun { gear: *g, frames: *f }).collect(),
             flag_runs: Vec::new(),
-            gear_run_speed_max: Vec::new(),
             aggregates: a,
             source: None,
             external_signature: None,
@@ -3775,7 +3778,6 @@ mod tests {
             raw_frame_count: 60,
             gear_runs: vec![GearRun { gear: 1, frames: 60 }],
             flag_runs: Vec::new(),
-            gear_run_speed_max: Vec::new(),
             aggregates: RouteAggregates::default(),
             source: None,
             external_signature: None,
@@ -4023,7 +4025,6 @@ mod tests {
             raw_frame_count: 60,
             gear_runs: vec![GearRun { gear: 1, frames: 60 }],
             flag_runs: Vec::new(),
-            gear_run_speed_max: Vec::new(),
             aggregates: RouteAggregates::default(),
             source: None,
             external_signature: None,
@@ -4036,7 +4037,6 @@ mod tests {
             raw_frame_count: 60,
             gear_runs: vec![GearRun { gear: GEAR_PARK, frames: 60 }],
             flag_runs: Vec::new(),
-            gear_run_speed_max: Vec::new(),
             aggregates: RouteAggregates::default(),
             source: None,
             external_signature: None,
@@ -4083,7 +4083,6 @@ mod tests {
             raw_frame_count: 60,
             gear_runs: vec![GearRun { gear: 1, frames: 60 }],
             flag_runs: Vec::new(),
-            gear_run_speed_max: Vec::new(),
             aggregates: RouteAggregates::default(),
             source: None,
             external_signature: None,
@@ -4247,8 +4246,21 @@ mod tests {
     // human parking-lot reposition that superficially matches summon on
     // gear/speed but fails every no-human tell.
 
+    // Legacy-shape runs (no per-run max_mps) — these exercise the
+    // detector's stats-fallback speed path, mirroring Drive's fixtures.
     fn fr(pairs: &[(u8, u32)]) -> Vec<FlagRun> {
-        pairs.iter().map(|&(flags, frames)| FlagRun { flags, frames }).collect()
+        pairs
+            .iter()
+            .map(|&(flags, frames)| FlagRun { flags, frames, max_mps: None })
+            .collect()
+    }
+
+    // Modern-shape runs carrying max_mps — the frame-accurate speed path.
+    fn frm(triples: &[(u8, u32, f64)]) -> Vec<FlagRun> {
+        triples
+            .iter()
+            .map(|&(flags, frames, m)| FlagRun { flags, frames, max_mps: Some(m) })
+            .collect()
     }
 
     fn ev(runs: &[FlagRun], start: u32, end: u32, total: u32) -> SummonClipEvidence<'_> {
@@ -4282,7 +4294,8 @@ mod tests {
         assert_eq!(FLAG_BLINKER_RIGHT, 2);
         assert_eq!(FLAG_BRAKE, 4);
         assert_eq!(FLAG_ACCEL, 8);
-        assert_eq!(SUMMON_MAX_SPEED_MPS, 3.5);
+        // 8 mph newer-car summon cap + margin.
+        assert_eq!(SUMMON_MAX_SPEED_MPS, 4.5);
         assert_eq!(SUMMON_BOOKEND_SECONDS, 10.0);
         assert_eq!(SUMMON_MAX_DURATION_MS, 600_000);
         assert_eq!(CLIP_DURATION_MS, 60_000);
@@ -4397,15 +4410,76 @@ mod tests {
         assert!(!detect_summon(&second, 1.5, 22_000, true));
     }
 
+    #[test]
+    fn segment_max_speed_frame_space_max_over_segment_null_on_legacy_runs() {
+        // Ported from drive-calc.test.js "segmentMaxSpeed: frame-space
+        // max over the segment, null on legacy runs".
+        let runs = frm(&[(3, 100, 0.5), (0, 400, 2.7), (8, 500, 4.7)]);
+        // Segment covering only the first two runs never sees the fast
+        // run.
+        assert_eq!(segment_max_speed(&ev(&runs, 0, 500, 1000)), Some(2.7));
+        // Full clip includes it.
+        assert_eq!(segment_max_speed(&ev(&runs, 0, 1000, 1000)), Some(4.7));
+        // A run merely straddling the segment boundary still
+        // contributes.
+        assert_eq!(segment_max_speed(&ev(&runs, 450, 550, 1000)), Some(4.7));
+        // Any overlapping run without max_mps makes the answer
+        // unknowable.
+        let legacy = vec![
+            FlagRun { flags: 3, frames: 100, max_mps: None },
+            FlagRun { flags: 0, frames: 100, max_mps: Some(1.0) },
+        ];
+        assert_eq!(segment_max_speed(&ev(&legacy, 0, 200, 200)), None);
+        // …but only if it actually overlaps.
+        assert_eq!(segment_max_speed(&ev(&legacy, 100, 200, 200)), Some(1.0));
+    }
+
+    #[test]
+    fn detect_summon_frame_space_speed_evidence_overrides_polluted_drive_stats() {
+        // Ported from drive-calc.test.js. Real 2026-07-27 00:34 failure:
+        // the park splitter's fraction→point slice overshoots on deduped
+        // points, so the summon drive's stats inherited the following
+        // drive's 4.05 m/s samples. Per-run max_mps confines the gate to
+        // the summon's own frames.
+        let clip_a_runs = frm(&[(0, 7, 0.0), (3, 144, 0.1), (0, 766, 2.7)]);
+        let clip_b_runs = frm(&[
+            (0, 143, 2.7),
+            (3, 219, 2.6),
+            (0, 105, 2.0),
+            (3, 191, 1.8),
+            (4, 50, 0.0),
+            (0, 10, 0.0),
+            (8, 521, 4.7),
+            (0, 16, 4.0),
+            (8, 545, 4.7),
+            (0, 55, 1.0),
+        ]);
+        let clips = vec![
+            ev(&clip_a_runs, 0, 917, 917),
+            ev(&clip_b_runs, 0, 579, 1855),
+        ];
+        // Polluted stats say 4.05 m/s — over the cap — yet the drive is
+        // summon.
+        assert!(detect_summon(&clips, 4.05, 42_000, true));
+        // The inverse guard: fast frames INSIDE the segment still reject
+        // on speed alone (hazard bookends present, zero pedal bits),
+        // even when the sliced stats happen to look slow.
+        let fast_no_pedals = frm(&[(3, 100, 0.5), (0, 700, 4.7), (3, 100, 0.3)]);
+        let fast_clips = vec![ev(&fast_no_pedals, 0, 900, 900)];
+        assert!(!detect_summon(&fast_clips, 2.0, 42_000, true));
+    }
+
     // ── End-to-end through the summary grouper (grouper.test.js port) ──
 
     /// RouteSummary with the raw-frame RLEs + SEI abs-max speed the way
     /// the v16 extractor writes them: flag totals match gear totals
-    /// exactly (same raw SEI frame sequence).
-    fn summon_summary(
+    /// exactly (same raw SEI frame sequence). Takes prebuilt flag runs
+    /// so fixtures can be legacy-shape (`fr`, stats-fallback speed path)
+    /// or modern (`frm`, frame-accurate per-run maxima).
+    fn summon_summary_runs(
         file: &str,
         gear_runs: &[(u8, u32)],
-        flag_runs: &[(u8, u32)],
+        flag_runs: Vec<FlagRun>,
         sei_speed_abs_max: Option<f64>,
     ) -> RouteSummary {
         let aggregates = RouteAggregates {
@@ -4422,13 +4496,21 @@ mod tests {
                 .sum(),
             raw_frame_count: gear_runs.iter().map(|(_, f)| *f).sum(),
             gear_runs: gear_runs.iter().map(|&(gear, frames)| GearRun { gear, frames }).collect(),
-            flag_runs: fr(flag_runs),
-            gear_run_speed_max: Vec::new(),
+            flag_runs,
             aggregates,
             source: None,
             external_signature: None,
             telemetry: Default::default(),
         }
+    }
+
+    fn summon_summary(
+        file: &str,
+        gear_runs: &[(u8, u32)],
+        flag_runs: &[(u8, u32)],
+        sei_speed_abs_max: Option<f64>,
+    ) -> RouteSummary {
+        summon_summary_runs(file, gear_runs, fr(flag_runs), sei_speed_abs_max)
     }
 
     #[test]
@@ -4547,21 +4629,6 @@ mod tests {
         assert!(!drives[1].summon, "the human drive must not inherit it");
     }
 
-    /// `summon_summary` variant carrying the v16 per-gear-run |SEI|
-    /// maxima — the segment-scoped speed evidence path.
-    fn summon_summary_with_run_speeds(
-        file: &str,
-        gear_runs: &[(u8, u32)],
-        flag_runs: &[(u8, u32)],
-        run_speed_max: &[f32],
-        sei_speed_abs_max: Option<f64>,
-    ) -> RouteSummary {
-        assert_eq!(run_speed_max.len(), gear_runs.len(), "fixture: one max per gear run");
-        let mut s = summon_summary(file, gear_runs, flag_runs, sei_speed_abs_max);
-        s.gear_run_speed_max = run_speed_max.to_vec();
-        s
-    }
-
     #[test]
     fn summon_reverse_summon_ending_seconds_before_human_drives_off_splits_and_flags() {
         // Real 2026-07-27 20:04 shape (ported from Sentry-Drive
@@ -4572,21 +4639,33 @@ mod tests {
         // accel) and drives off. The mid-clip park must split the summon
         // into its own drive; pedal input stays outside the summon
         // segment's frame range — and so does the human's SPEED: clip
-        // B's whole-clip abs max is 5.4 m/s (over the 3.5 cap), but the
-        // v16 per-gear-run maxima scope the summon segment to its own
-        // 0.3 m/s crawl.
-        let clip_a = summon_summary_with_run_speeds(
+        // B's whole-clip abs max is 5.4 m/s (over the cap), but the
+        // per-run maxima scope the summon segment to its own crawl.
+        let clip_a = summon_summary_runs(
             "2026-07-27/2026-07-27_20-04-00-front.mp4",
             &[(GEAR_PARK, 46), (2 /* GEAR_REVERSE */, 727), (1, 917)],
-            &[(0, 11), (3, 113), (0, 394), (2, 256), (0, 301), (2, 615)],
-            &[0.0, 2.0, 2.0],
+            frm(&[
+                (0, 11, 0.0),
+                (3, 113, 0.1),  // hazards spanning P→R
+                (0, 394, 2.0),
+                (2, 256, 2.0),  // right signal while maneuvering
+                (0, 301, 1.5),
+                (2, 615, 2.0),
+            ]),
             Some(2.0),
         );
-        let clip_b = summon_summary_with_run_speeds(
+        let clip_b = summon_summary_runs(
             "2026-07-27/2026-07-27_20-04-46-front.mp4",
             &[(1, 120), (GEAR_PARK, 84), (1, 1469)],
-            &[(2, 81), (3, 89), (4, 70), (0, 200), (8, 690), (0, 112), (1, 431)],
-            &[0.3, 0.0, 5.4],
+            frm(&[
+                (2, 81, 0.3),
+                (3, 89, 0.3),   // hazards through the stop and D→P
+                (4, 70, 0.0),   // human brake to shift (after the park)
+                (0, 200, 0.0),
+                (8, 690, 5.4),  // human accelerator
+                (0, 112, 4.0),
+                (1, 431, 5.4),
+            ]),
             Some(5.4),
         );
         let drives = group_summaries_fast(&[clip_a, clip_b], &HashMap::new());
@@ -4599,10 +4678,58 @@ mod tests {
     }
 
     #[test]
+    fn summon_point_slice_speed_pollution_does_not_reject_frame_slow_summon() {
+        // Real 2026-07-27 00:34 failure shape (ported from Sentry-Drive
+        // grouper.test.js). In Drive, the park splitter's fraction→point
+        // slice overshoots on deduped points and the summon's STATS
+        // inherit the following drive's fast samples (a 6 mph summon
+        // read 9 mph). Rusty's summary path has no point slices, but the
+        // equivalent pollution exists: clip B's whole-clip abs max
+        // (4.7 m/s, over the 4.5 gate) is the only clip-level speed —
+        // per-run maxMps must confine the gate to the summon's own
+        // frames ([0, 579) of clip B: 2.7 max) and flag the drive.
+        let clip_a = summon_summary_runs(
+            "2026-07-27/2026-07-27_00-34-31-front.mp4",
+            &[(GEAR_PARK, 68), (2 /* GEAR_REVERSE */, 538), (1, 311)],
+            frm(&[
+                (0, 7, 0.0),
+                (3, 144, 0.1),  // hazards spanning P→R
+                (0, 766, 2.7),
+            ]),
+            Some(2.7),
+        );
+        let clip_b = summon_summary_runs(
+            "2026-07-27/2026-07-27_00-34-59-front.mp4",
+            &[(1, 579), (GEAR_PARK, 114), (1, 1162)],
+            frm(&[
+                (0, 143, 2.7),
+                (3, 219, 2.6),  // hazard stop
+                (0, 105, 2.0),
+                (3, 191, 1.8),  // hazards through D→P
+                (4, 50, 0.0),   // human brake (after the park)
+                (0, 10, 0.0),
+                (8, 521, 4.7),  // human accelerator
+                (0, 16, 4.0),
+                (8, 545, 4.7),
+                (0, 55, 1.0),
+            ]),
+            Some(4.7),
+        );
+        let drives = group_summaries_fast(&[clip_a, clip_b], &HashMap::new());
+        assert_eq!(drives.len(), 2);
+        assert!(
+            drives[0].summon,
+            "frame-space speed evidence must override the polluted clip-level max"
+        );
+        assert!(!drives[1].summon, "the human drive after the park is not summon");
+    }
+
+    #[test]
     fn summon_whole_clip_abs_max_fallback_stays_conservative_on_shared_clip() {
-        // The same 07-27 drive WITHOUT per-run maxima (pre-v16 row,
-        // import): the fallback sees clip B's whole-clip 5.4 m/s and
-        // must reject rather than guess — no flag beats a wrong flag.
+        // The same 07-27 20:04 drive WITHOUT per-run maxima (pre-maxMps
+        // row, import): the fallback sees clip B's whole-clip 5.4 m/s
+        // and must reject rather than guess — no flag beats a wrong
+        // flag.
         let clip_a = summon_summary(
             "2026-07-27/2026-07-27_20-04-00-front.mp4",
             &[(GEAR_PARK, 46), (2, 727), (1, 917)],

--- a/crates/drives/src/grouper.rs
+++ b/crates/drives/src/grouper.rs
@@ -59,6 +59,30 @@ pub(crate) const GAP_FILL_MIN_SPEED_MPS: f32 = 0.5;
 /// Minimum Park duration (seconds) that ends the current drive within a clip.
 const PARK_GAP_SECONDS: f64 = 2.0;
 
+/// Nominal clip container length (ms) — the recorder splits all clips at
+/// one-minute boundaries. Frame→time math against a clip's raw frame
+/// count uses this span (the last clip of a session can carry far fewer
+/// real frames than the container claims; those frames are real data).
+const CLIP_DURATION_MS: i64 = 60_000;
+
+// Summon detection thresholds — mirror Sentry-Drive's drive-calc.cjs
+// exactly (locked there by drive-calc.test.js), verified against real
+// Actually Smart Summon footage (2026-07-15 20:49/20:50): hazards = both
+// blinker bits in the SAME run, held 1-4 s spanning BOTH gear
+// transitions; accel/brake stay 0 the whole drive; speed peaked at
+// 2.7 m/s (Tesla caps summon near 6 mph); autopilot_state stays 0 during
+// summon, so it plays no part here.
+
+/// SEI max speed (m/s) above which a drive cannot be a summon.
+const SUMMON_MAX_SPEED_MPS: f64 = 3.5;
+
+/// Hazards must appear within this many seconds of the drive's start and
+/// end (in frames-of-clip terms — see `detect_summon`).
+const SUMMON_BOOKEND_SECONDS: f64 = 10.0;
+
+/// Max summon drive duration (10 minutes).
+const SUMMON_MAX_DURATION_MS: i64 = 10 * 60 * 1000;
+
 // ---------------------------------------------------------------------------
 // Public API
 //
@@ -998,6 +1022,12 @@ fn split_clip_at_park_gaps(clip: &TimedRoute) -> Vec<ClipSegment> {
                     raw_park_count: 0,
                     raw_frame_count: 0,
                     gear_runs: Vec::new(),
+                    // Parent's full-clip flag RLE rides along (mirrors
+                    // Sentry-Drive's `{...clip}` sub-segment spread) —
+                    // flag runs live in RAW frame space, so slicing
+                    // them to the segment would corrupt the frame
+                    // indexing.
+                    flag_runs: clip.route.flag_runs.clone(),
                     source: clip.route.source.clone(),
                     external_signature: clip.route.external_signature.clone(),
                     tessie_autopilot_percent: clip.route.tessie_autopilot_percent,
@@ -1088,6 +1118,139 @@ fn clip_is_mostly_parked_legacy(clip: &TimedRoute) -> bool {
         .filter(|&&g| g == GEAR_PARK)
         .count();
     park_count > clip.route.gear_states.len() / 2
+}
+
+// ---------------------------------------------------------------------------
+// Summon detection
+//
+// Port of Sentry-Drive's flagRunsOverlap / detectSummon (drive-calc.cjs).
+// Evidence lives in RAW SEI frame space (flag_runs + park-split segment
+// bounds), so it is immune to GPS dedup and to the fraction-based
+// frame→point index mapping the splitter uses.
+// ---------------------------------------------------------------------------
+
+/// Per-clip summon evidence, one entry per clip of the drive in drive
+/// order. `[start_frame, end_frame)` bounds the drive's segment of that
+/// clip in raw SEI frame space (the full clip when the park splitter
+/// left it whole).
+pub(crate) struct SummonClipEvidence<'a> {
+    pub flag_runs: &'a [FlagRun],
+    pub start_frame: u32,
+    pub end_frame: u32,
+    pub total_frames: u32,
+}
+
+/// True when any flag run overlapping `[from_frame, to_frame)` carries
+/// `mask` bits: all of them when `require_all` (hazards = left AND right
+/// in the SAME run), any of them otherwise (pedal input = brake OR
+/// accel).
+pub(crate) fn flag_runs_overlap(
+    runs: &[FlagRun],
+    from_frame: u32,
+    to_frame: u32,
+    mask: u8,
+    require_all: bool,
+) -> bool {
+    let mut frame: u32 = 0;
+    for run in runs {
+        let start = frame;
+        let end = frame + run.frames;
+        frame = end;
+        if end <= from_frame {
+            continue;
+        }
+        if start >= to_frame {
+            break;
+        }
+        let bits = run.flags & mask;
+        if require_all {
+            if bits == mask {
+                return true;
+            }
+        } else if bits != 0 {
+            return true;
+        }
+    }
+    false
+}
+
+/// Detect a Summon / Smart Summon drive from per-clip SEI flag evidence.
+///
+/// The verified signature: hazards within the opening seconds of the
+/// first segment AND the closing seconds of the last, no pedal input
+/// anywhere in between, and the whole drive at parking-lot speed. A
+/// driverless car is the only thing that satisfies all three at once — a
+/// human repositioning with hazards on still touches a pedal or exceeds
+/// the summon speed cap.
+///
+/// `max_speed_mps` must be the max **absolute** SEI speed (Reverse
+/// reports negative); `has_sei_speeds` gates out GPS-derived speeds,
+/// which jitter well past walking pace on a car that barely moved. Flag
+/// data always ships alongside SEI speed, so that gate only rejects
+/// degenerate inputs.
+pub(crate) fn detect_summon(
+    clips: &[SummonClipEvidence],
+    max_speed_mps: f64,
+    duration_ms: i64,
+    has_sei_speeds: bool,
+) -> bool {
+    if clips.is_empty() {
+        return false;
+    }
+    if !has_sei_speeds {
+        return false;
+    }
+    if !(max_speed_mps > 0.0) || max_speed_mps > SUMMON_MAX_SPEED_MPS {
+        return false;
+    }
+    if !(duration_ms > 0) || duration_ms > SUMMON_MAX_DURATION_MS {
+        return false;
+    }
+
+    // Every clip needs flag evidence — a single pre-flags clip (older
+    // extraction, or routes written by a tool that hasn't ported
+    // flagRuns yet) makes the drive unverifiable, and unverifiable must
+    // mean "not summon".
+    for c in clips {
+        if c.flag_runs.is_empty() || c.total_frames == 0 || c.end_frame <= c.start_frame {
+            return false;
+        }
+    }
+
+    const HAZARD: u8 = FLAG_BLINKER_LEFT | FLAG_BLINKER_RIGHT;
+    const PEDAL: u8 = FLAG_BRAKE | FLAG_ACCEL;
+
+    for c in clips {
+        if flag_runs_overlap(c.flag_runs, c.start_frame, c.end_frame, PEDAL, false) {
+            return false;
+        }
+    }
+
+    // Seconds→frames via the clip's own frame density, so variable SEI
+    // rates (and short final clips) keep the window at real seconds.
+    let bookend_frames = |c: &SummonClipEvidence| -> u32 {
+        (((c.total_frames as f64 * SUMMON_BOOKEND_SECONDS * 1000.0)
+            / CLIP_DURATION_MS as f64)
+            .ceil() as u32)
+            .max(1)
+    };
+    let first = &clips[0];
+    let last = &clips[clips.len() - 1];
+    let hazard_at_start = flag_runs_overlap(
+        first.flag_runs,
+        first.start_frame,
+        first.end_frame.min(first.start_frame + bookend_frames(first)),
+        HAZARD,
+        true,
+    );
+    let hazard_at_end = flag_runs_overlap(
+        last.flag_runs,
+        last.start_frame.max(last.end_frame.saturating_sub(bookend_frames(last))),
+        last.end_frame,
+        HAZARD,
+        true,
+    );
+    hazard_at_start && hazard_at_end
 }
 
 // ---------------------------------------------------------------------------
@@ -1500,6 +1663,12 @@ fn build_drive_stats(
         tacc_distance_km: round2(tacc_distance_m / 1000.0),
         tacc_distance_mi: round2(tacc_distance_m / calc::M_PER_MILE),
         assisted_percent,
+        // Summon is decided on the summary path, which carries the
+        // park-split segment frame bounds this full-Route path lacks
+        // (build_single_drive_from_clips receives whole clips). The
+        // single-drive API handler overlays the canonical summary value,
+        // exactly like the headline percentages above it.
+        summon: false,
         source: first_clip.route.source.clone(),
         external_signature: first_clip.route.external_signature.clone(),
         tessie_autopilot_percent: first_clip.route.tessie_autopilot_percent,
@@ -2621,6 +2790,63 @@ fn build_summary_from_aggregates(
     // ── v6 BLE telemetry rollup across this drive's unique clips ──
     let telemetry = roll_up_telemetry(clips);
 
+    // ── Summon detection ──
+    // Mirrors Sentry-Drive buildDriveStats: evidence is each clip's
+    // flag_runs plus its park-split segment bounds — raw SEI frame
+    // space, immune to GPS dedup. Clips without flag_runs (pre-flags
+    // extractions, imports) make the drive unverifiable and
+    // detect_summon returns false. Speed comes from the v16
+    // sei_speed_abs_max column: the locked max_speed_mps drops negative
+    // (Reverse) SEI samples — a reverse-only summon would read 0 — and
+    // can't distinguish GPS-derived speed, which jitters past walking
+    // pace on a car that barely moved.
+    let mut has_sei_speeds = false;
+    let mut summon_max_speed: f64 = 0.0;
+    for clip in clips {
+        if let Some(m) = clip.summary.aggregates.sei_speed_abs_max {
+            if m > 0.0 {
+                has_sei_speeds = true;
+            }
+            if m > summon_max_speed {
+                summon_max_speed = m;
+            }
+        }
+    }
+    let summon_evidence: Vec<SummonClipEvidence> = clips
+        .iter()
+        .map(|c| {
+            if c.total_frames > 1 {
+                SummonClipEvidence {
+                    flag_runs: &c.summary.flag_runs,
+                    start_frame: c.start_frame,
+                    end_frame: c.end_frame,
+                    total_frames: c.total_frames,
+                }
+            } else {
+                // Whole-clip wrap of a row without gear data carries the
+                // total_frames=1 sentinel; fall back to raw_frame_count,
+                // then to the flag-run sum (Sentry-Drive's evidence
+                // fallback order).
+                let mut total = c.summary.raw_frame_count;
+                if total == 0 {
+                    total = c.summary.flag_runs.iter().map(|r| r.frames).sum();
+                }
+                SummonClipEvidence {
+                    flag_runs: &c.summary.flag_runs,
+                    start_frame: 0,
+                    end_frame: total,
+                    total_frames: total,
+                }
+            }
+        })
+        .collect();
+    let summon = detect_summon(
+        &summon_evidence,
+        if has_sei_speeds { summon_max_speed } else { 0.0 },
+        duration_ms,
+        has_sei_speeds,
+    );
+
     let start_time_str = start_time.format("%Y-%m-%dT%H:%M:%S").to_string();
     let drive_tags = tags.get(&start_time_str).cloned().unwrap_or_default();
 
@@ -2658,6 +2884,7 @@ fn build_summary_from_aggregates(
         tacc_distance_km: round2(tacc_dist_m / 1000.0),
         tacc_distance_mi: round2(tacc_dist_m / calc::M_PER_MILE),
         assisted_percent,
+        summon,
         battery_pct_start: telemetry.battery_pct_start,
         battery_pct_end: telemetry.battery_pct_end,
         battery_pct_used: telemetry.battery_pct_used,
@@ -3003,6 +3230,7 @@ mod tests {
             raw_park_count: 0,
             raw_frame_count: 0,
             gear_runs: Vec::new(),
+            flag_runs: Vec::new(),
             aggregates: a1,
             source: None,
             external_signature: None,
@@ -3014,6 +3242,7 @@ mod tests {
             raw_park_count: 0,
             raw_frame_count: 0,
             gear_runs: Vec::new(),
+            flag_runs: Vec::new(),
             aggregates: a2,
             source: None,
             external_signature: None,
@@ -3045,6 +3274,7 @@ mod tests {
             raw_park_count: 0,
             raw_frame_count: 60,
             gear_runs: vec![GearRun { gear: 1, frames: 60 }],
+            flag_runs: Vec::new(),
             aggregates: RouteAggregates::default(),
             source: None,
             external_signature: None,
@@ -3065,6 +3295,7 @@ mod tests {
             raw_park_count: runs.iter().filter(|(g, _)| *g == GEAR_PARK).map(|(_, f)| f).sum(),
             raw_frame_count: runs.iter().map(|(_, f)| *f).sum(),
             gear_runs: runs.iter().map(|(g, f)| GearRun { gear: *g, frames: *f }).collect(),
+            flag_runs: Vec::new(),
             aggregates: a,
             source: None,
             external_signature: None,
@@ -3487,6 +3718,7 @@ mod tests {
             raw_park_count: 0,
             raw_frame_count: 60,
             gear_runs: vec![GearRun { gear: 1, frames: 60 }],
+            flag_runs: Vec::new(),
             aggregates: RouteAggregates::default(),
             source: None,
             external_signature: None,
@@ -3733,6 +3965,7 @@ mod tests {
             raw_park_count: 0,
             raw_frame_count: 60,
             gear_runs: vec![GearRun { gear: 1, frames: 60 }],
+            flag_runs: Vec::new(),
             aggregates: RouteAggregates::default(),
             source: None,
             external_signature: None,
@@ -3744,6 +3977,7 @@ mod tests {
             raw_park_count: 60,
             raw_frame_count: 60,
             gear_runs: vec![GearRun { gear: GEAR_PARK, frames: 60 }],
+            flag_runs: Vec::new(),
             aggregates: RouteAggregates::default(),
             source: None,
             external_signature: None,
@@ -3789,6 +4023,7 @@ mod tests {
             raw_park_count: 0,
             raw_frame_count: 60,
             gear_runs: vec![GearRun { gear: 1, frames: 60 }],
+            flag_runs: Vec::new(),
             aggregates: RouteAggregates::default(),
             source: None,
             external_signature: None,
@@ -3942,5 +4177,312 @@ mod tests {
         assert_eq!(r.hvac_runtime_s, Some(30), "dedupe: hvac counted once, not twice");
         assert_eq!(r.battery_pct_start, Some(70.0));
         assert_eq!(r.battery_pct_end, Some(69.0));
+    }
+
+    // ── Summon detection ─────────────────────────────────────────────
+    // Test vectors ported from Sentry-Drive's drive-calc.test.js
+    // ("Summon detection" section) and grouper.test.js ("summon:"
+    // tests). Fixtures mirror real probed footage: the 2026-07-15
+    // Actually Smart Summon (two clips, ~29.9 fps) and the 2026-07-28
+    // human parking-lot reposition that superficially matches summon on
+    // gear/speed but fails every no-human tell.
+
+    fn fr(pairs: &[(u8, u32)]) -> Vec<FlagRun> {
+        pairs.iter().map(|&(flags, frames)| FlagRun { flags, frames }).collect()
+    }
+
+    fn ev(runs: &[FlagRun], start: u32, end: u32, total: u32) -> SummonClipEvidence<'_> {
+        SummonClipEvidence {
+            flag_runs: runs,
+            start_frame: start,
+            end_frame: end,
+            total_frames: total,
+        }
+    }
+
+    // Probe shape of 2026-07-15_20-49-54 (start clip): hazards through
+    // the P→D shift, a 29 s left-signal run while maneuvering, no pedal
+    // bits anywhere.
+    fn ass_start_runs() -> Vec<FlagRun> {
+        fr(&[(0, 27), (3, 123), (0, 17), (1, 873), (0, 746)])
+    }
+
+    // Probe shape of 2026-07-15_20-50-43 (end clip): hazards through the
+    // stop and D→P shift at the tail.
+    fn ass_end_runs() -> Vec<FlagRun> {
+        fr(&[(0, 471), (3, 82)])
+    }
+
+    const ASS_MAX_SPEED: f64 = 2.7;
+    const ASS_DURATION_MS: i64 = 78_000;
+
+    #[test]
+    fn summon_flag_constants_and_thresholds_are_locked() {
+        assert_eq!(FLAG_BLINKER_LEFT, 1);
+        assert_eq!(FLAG_BLINKER_RIGHT, 2);
+        assert_eq!(FLAG_BRAKE, 4);
+        assert_eq!(FLAG_ACCEL, 8);
+        assert_eq!(SUMMON_MAX_SPEED_MPS, 3.5);
+        assert_eq!(SUMMON_BOOKEND_SECONDS, 10.0);
+        assert_eq!(SUMMON_MAX_DURATION_MS, 600_000);
+        assert_eq!(CLIP_DURATION_MS, 60_000);
+    }
+
+    #[test]
+    fn flag_runs_overlap_require_all_needs_both_bits_in_same_run() {
+        const HAZARD: u8 = FLAG_BLINKER_LEFT | FLAG_BLINKER_RIGHT;
+        // Hazards: one run carrying both bits.
+        assert!(flag_runs_overlap(&fr(&[(3, 10)]), 0, 10, HAZARD, true));
+        // A left-only run followed by a right-only run must NOT read as
+        // hazards…
+        let alternating = fr(&[(1, 10), (2, 10)]);
+        assert!(!flag_runs_overlap(&alternating, 0, 20, HAZARD, true));
+        // …but require_all=false (any-bit) sees them.
+        assert!(flag_runs_overlap(&alternating, 0, 20, HAZARD, false));
+    }
+
+    #[test]
+    fn flag_runs_overlap_honors_from_to_frame_bounds() {
+        let runs = fr(&[
+            (3, 60),   // frames 0-59
+            (0, 540),  // frames 60-599
+            (3, 60),   // frames 600-659
+            (0, 1140), // frames 660-1799
+        ]);
+        assert!(flag_runs_overlap(&runs, 0, 60, 3, true));
+        assert!(!flag_runs_overlap(&runs, 60, 600, 3, true));
+        // Run ending exactly at `from` is outside the window…
+        assert!(!flag_runs_overlap(&runs, 660, 1800, 3, true));
+        // …and a window ending exactly at a run start excludes it too.
+        assert!(!flag_runs_overlap(&runs, 360, 600, 3, true));
+        assert!(flag_runs_overlap(&runs, 360, 601, 3, true));
+    }
+
+    #[test]
+    fn detect_summon_real_ass_two_clip_shape_is_summon() {
+        let (start, end) = (ass_start_runs(), ass_end_runs());
+        let clips = vec![ev(&start, 0, 1786, 1786), ev(&end, 0, 553, 553)];
+        assert!(detect_summon(&clips, ASS_MAX_SPEED, ASS_DURATION_MS, true));
+    }
+
+    #[test]
+    fn detect_summon_single_clip_dumb_summon_shape_is_summon() {
+        let runs = fr(&[(3, 90), (0, 300), (3, 60)]);
+        let clips = vec![ev(&runs, 0, 450, 450)];
+        assert!(detect_summon(&clips, 1.0, 15_000, true));
+    }
+
+    #[test]
+    fn detect_summon_pedal_input_anywhere_disqualifies() {
+        // 2026-07-28_21-05-46 shape: brake to shift, accel to creep, no
+        // hazards.
+        let human = fr(&[(0, 1200), (4, 12), (8, 230), (4, 40), (0, 674)]);
+        let clips = vec![ev(&human, 0, 2156, 2156)];
+        assert!(!detect_summon(&clips, 1.3, 10_000, true));
+        // Even WITH hazard bookends, a single accel frame anywhere kills
+        // it.
+        let hazards_but_pedal = fr(&[(3, 90), (0, 100), (8, 1), (0, 199), (3, 60)]);
+        let clips = vec![ev(&hazards_but_pedal, 0, 450, 450)];
+        assert!(!detect_summon(&clips, 1.0, 15_000, true));
+    }
+
+    #[test]
+    fn detect_summon_hazards_must_bookend_both_ends() {
+        let start = ass_start_runs();
+        let no_hazard_end = fr(&[(0, 553)]);
+        let clips = vec![ev(&start, 0, 1786, 1786), ev(&no_hazard_end, 0, 553, 553)];
+        assert!(!detect_summon(&clips, ASS_MAX_SPEED, ASS_DURATION_MS, true));
+    }
+
+    #[test]
+    fn detect_summon_individual_turn_signals_never_read_as_hazards() {
+        let runs = fr(&[
+            (1, 90),  // left only at start
+            (0, 300),
+            (2, 60),  // right only at end
+        ]);
+        let clips = vec![ev(&runs, 0, 450, 450)];
+        assert!(!detect_summon(&clips, 1.0, 15_000, true));
+    }
+
+    #[test]
+    fn detect_summon_speed_duration_and_sei_speed_gates() {
+        let (start, end) = (ass_start_runs(), ass_end_runs());
+        let clips = vec![ev(&start, 0, 1786, 1786), ev(&end, 0, 553, 553)];
+        assert!(!detect_summon(&clips, 5.0, ASS_DURATION_MS, true));
+        assert!(!detect_summon(&clips, 0.0, ASS_DURATION_MS, true));
+        assert!(!detect_summon(&clips, ASS_MAX_SPEED, 601_000, true));
+        assert!(!detect_summon(&clips, ASS_MAX_SPEED, ASS_DURATION_MS, false));
+    }
+
+    #[test]
+    fn detect_summon_any_clip_without_flag_runs_makes_drive_unverifiable() {
+        let start = ass_start_runs();
+        let legacy: Vec<FlagRun> = Vec::new();
+        let clips = vec![ev(&start, 0, 1786, 1786), ev(&legacy, 0, 553, 553)];
+        assert!(!detect_summon(&clips, ASS_MAX_SPEED, ASS_DURATION_MS, true));
+        assert!(!detect_summon(&[], ASS_MAX_SPEED, ASS_DURATION_MS, true));
+    }
+
+    #[test]
+    fn detect_summon_park_split_segment_bounds_gate_the_bookend_windows() {
+        // Full clip has hazards at frames 0-59 and 600-659; a 2 s park
+        // gap split the clip at frame 660. The FIRST segment sees both
+        // hazard windows; the SECOND segment (frames 660+) contains none
+        // and must not inherit them.
+        let runs = fr(&[(3, 60), (0, 540), (3, 60), (0, 1140)]);
+        let first = vec![ev(&runs, 0, 660, 1800)];
+        let second = vec![ev(&runs, 660, 1800, 1800)];
+        assert!(detect_summon(&first, 1.5, 22_000, true));
+        assert!(!detect_summon(&second, 1.5, 22_000, true));
+    }
+
+    // ── End-to-end through the summary grouper (grouper.test.js port) ──
+
+    /// RouteSummary with the raw-frame RLEs + SEI abs-max speed the way
+    /// the v16 extractor writes them: flag totals match gear totals
+    /// exactly (same raw SEI frame sequence).
+    fn summon_summary(
+        file: &str,
+        gear_runs: &[(u8, u32)],
+        flag_runs: &[(u8, u32)],
+        sei_speed_abs_max: Option<f64>,
+    ) -> RouteSummary {
+        let aggregates = RouteAggregates {
+            sei_speed_abs_max,
+            ..Default::default()
+        };
+        RouteSummary {
+            file: file.to_string(),
+            date: "2026-07-15".to_string(),
+            raw_park_count: gear_runs
+                .iter()
+                .filter(|(g, _)| *g == GEAR_PARK)
+                .map(|(_, f)| f)
+                .sum(),
+            raw_frame_count: gear_runs.iter().map(|(_, f)| *f).sum(),
+            gear_runs: gear_runs.iter().map(|&(gear, frames)| GearRun { gear, frames }).collect(),
+            flag_runs: fr(flag_runs),
+            aggregates,
+            source: None,
+            external_signature: None,
+            telemetry: Default::default(),
+        }
+    }
+
+    #[test]
+    fn summon_hazard_bookended_pedal_free_crawl_across_two_clips_is_flagged() {
+        // The real 2026-07-15 ASS shape: leading Park trimmed by the
+        // splitter on clip A, trailing Park on clip B (the run the
+        // pre-fix extractor dropped — without it these clips fuse with
+        // the following drive and the flag is lost).
+        let clip_a = summon_summary(
+            "2026-07-15/2026-07-15_20-49-54-front.mp4",
+            &[(GEAR_PARK, 60), (1, 1726)],
+            &[(0, 27), (3, 123), (0, 17), (1, 873), (0, 746)],
+            Some(2.7),
+        );
+        let clip_b = summon_summary(
+            "2026-07-15/2026-07-15_20-50-43-front.mp4",
+            &[(1, 500), (GEAR_PARK, 53)],
+            &[(0, 471), (3, 82)],
+            Some(2.7),
+        );
+        let drives = group_summaries_fast(&[clip_a, clip_b], &HashMap::new());
+        assert_eq!(drives.len(), 1);
+        assert!(drives[0].summon);
+        // Serialized shape matches Sentry-Drive: key present iff true.
+        let json = serde_json::to_string(&drives[0]).unwrap();
+        assert!(json.contains(r#""summon":true"#), "json: {json}");
+    }
+
+    #[test]
+    fn summon_missing_flag_runs_or_pedal_input_never_flags() {
+        // Same drive shape without flag evidence (pre-flags extraction)
+        // — the summary must omit the flag entirely rather than guess.
+        let bare_a = summon_summary(
+            "2026-07-15/2026-07-15_20-49-54-front.mp4",
+            &[(GEAR_PARK, 60), (1, 1726)],
+            &[],
+            Some(2.7),
+        );
+        let bare_b = summon_summary(
+            "2026-07-15/2026-07-15_20-50-43-front.mp4",
+            &[(1, 500), (GEAR_PARK, 53)],
+            &[],
+            Some(2.7),
+        );
+        let bare_drives = group_summaries_fast(&[bare_a, bare_b], &HashMap::new());
+        assert_eq!(bare_drives.len(), 1);
+        assert!(!bare_drives[0].summon);
+        let json = serde_json::to_string(&bare_drives[0]).unwrap();
+        assert!(!json.contains("summon"), "false must serialize as absent: {json}");
+
+        // Hazard bookends but a human touched the accelerator mid-drive.
+        let pedal_clip = summon_summary(
+            "2026-07-16/2026-07-16_09-00-00-front.mp4",
+            &[(GEAR_PARK, 60), (1, 1726)],
+            &[(3, 150), (0, 800), (8, 36), (0, 718), (3, 82)],
+            Some(2.0),
+        );
+        let pedal_drives = group_summaries_fast(&[pedal_clip], &HashMap::new());
+        assert_eq!(pedal_drives.len(), 1);
+        assert!(!pedal_drives[0].summon);
+    }
+
+    #[test]
+    fn summon_reverse_only_negative_sei_speeds_is_flagged() {
+        // Backing out of a garage: P → R → P with hazard bookends.
+        // Reverse gear reports NEGATIVE SEI speeds, which the locked
+        // display stats drop (stored max_speed_mps stays 0) — the
+        // detector must still see the movement via the v16 abs-max
+        // column.
+        let clip = summon_summary(
+            "2026-07-20/2026-07-20_09-00-00-front.mp4",
+            &[(GEAR_PARK, 90), (2 /* GEAR_REVERSE */, 300), (GEAR_PARK, 60)],
+            &[(3, 120), (0, 240), (3, 90)],
+            Some(1.5),
+        );
+        assert_eq!(
+            clip.aggregates.max_speed_mps, 0.0,
+            "precondition: locked stats dropped the negative samples"
+        );
+        let drives = group_summaries_fast(&[clip], &HashMap::new());
+        assert_eq!(drives.len(), 1);
+        assert!(drives[0].summon);
+    }
+
+    #[test]
+    fn summon_trailing_park_run_isolates_summon_from_following_drive() {
+        // The bug this whole change fixes, end-to-end: with the trailing
+        // Park run present on 20-50-43, the splitter ends the summon
+        // there and a drive starting two minutes later stays separate;
+        // both classify correctly. (Pre-fix, gearRuns=[Drive] fused all
+        // three clips into one 4-minute drive → no summon flag.)
+        let clip_a = summon_summary(
+            "2026-07-15/2026-07-15_20-49-54-front.mp4",
+            &[(GEAR_PARK, 60), (1, 1726)],
+            &[(0, 27), (3, 123), (0, 17), (1, 873), (0, 746)],
+            Some(2.7),
+        );
+        let clip_b = summon_summary(
+            "2026-07-15/2026-07-15_20-50-43-front.mp4",
+            &[(1, 500), (GEAR_PARK, 53)],
+            &[(0, 471), (3, 82)],
+            Some(2.7),
+        );
+        // Human drive 2 minutes later: no hazards, pedal input, normal
+        // speed.
+        let clip_c = summon_summary(
+            "2026-07-15/2026-07-15_20-52-45-front.mp4",
+            &[(1, 1790)],
+            &[(8, 900), (4, 90), (8, 800)],
+            Some(12.0),
+        );
+        let drives =
+            group_summaries_fast(&[clip_a, clip_b, clip_c], &HashMap::new());
+        assert_eq!(drives.len(), 2, "park gap must split summon from the next drive");
+        assert!(drives[0].summon, "the summon drive keeps its flag");
+        assert!(!drives[1].summon, "the human drive must not inherit it");
     }
 }

--- a/crates/drives/src/grouper.rs
+++ b/crates/drives/src/grouper.rs
@@ -1026,8 +1026,9 @@ fn split_clip_at_park_gaps(clip: &TimedRoute) -> Vec<ClipSegment> {
                     // Sentry-Drive's `{...clip}` sub-segment spread) —
                     // flag runs live in RAW frame space, so slicing
                     // them to the segment would corrupt the frame
-                    // indexing.
+                    // indexing. Same for the per-gear-run maxima.
                     flag_runs: clip.route.flag_runs.clone(),
+                    gear_run_speed_max: clip.route.gear_run_speed_max.clone(),
                     source: clip.route.source.clone(),
                     external_signature: clip.route.external_signature.clone(),
                     tessie_autopilot_percent: clip.route.tessie_autopilot_percent,
@@ -2803,7 +2804,17 @@ fn build_summary_from_aggregates(
     let mut has_sei_speeds = false;
     let mut summon_max_speed: f64 = 0.0;
     for clip in clips {
-        if let Some(m) = clip.summary.aggregates.sei_speed_abs_max {
+        // Segment-scoped max |SEI| when the v16 per-gear-run maxima are
+        // present — park splits land on gear-run boundaries, so the runs
+        // overlapping this sub-clip's frame range cover it exactly. This
+        // is what keeps a summon crawl's speed evidence clean when the
+        // human drives off seconds later IN THE SAME CLIP (real case:
+        // 2026-07-27 20:04). Rows without the column (pre-v16, imports)
+        // fall back to the whole-clip abs max — conservative: a shared
+        // clip then over-reports the summon segment's speed and the
+        // drive simply stays unflagged until reprocessed.
+        let seg_max = segment_abs_speed_max(clip).or(clip.summary.aggregates.sei_speed_abs_max);
+        if let Some(m) = seg_max {
             if m > 0.0 {
                 has_sei_speeds = true;
             }
@@ -2812,6 +2823,43 @@ fn build_summary_from_aggregates(
             }
         }
     }
+    /// Max |SEI speed| over the gear runs overlapping this sub-clip's
+    /// `[start_frame, end_frame)` range, from the v16 per-gear-run
+    /// maxima. `None` when the column is absent or doesn't match the
+    /// gear runs (pre-v16 rows, imports, corrupt pairing) — callers
+    /// fall back to the clip-level abs max.
+    fn segment_abs_speed_max(c: &SubClipSummary) -> Option<f64> {
+        let runs = &c.summary.gear_runs;
+        let maxes = &c.summary.gear_run_speed_max;
+        if runs.is_empty() || maxes.len() != runs.len() {
+            return None;
+        }
+        // Whole-clip wraps of gear-less rows carry the total_frames=1
+        // sentinel; runs being non-empty means real bounds here, but
+        // keep the sentinel path meaning "whole clip" regardless.
+        let (s, e) = if c.total_frames > 1 {
+            (c.start_frame, c.end_frame)
+        } else {
+            (0, u32::MAX)
+        };
+        let mut frame = 0u32;
+        let mut best = 0.0f64;
+        for (run, &m) in runs.iter().zip(maxes.iter()) {
+            let (rs, re) = (frame, frame + run.frames);
+            frame = re;
+            if re <= s {
+                continue;
+            }
+            if rs >= e {
+                break;
+            }
+            if (m as f64) > best {
+                best = m as f64;
+            }
+        }
+        Some(best)
+    }
+
     let summon_evidence: Vec<SummonClipEvidence> = clips
         .iter()
         .map(|c| {
@@ -3231,6 +3279,7 @@ mod tests {
             raw_frame_count: 0,
             gear_runs: Vec::new(),
             flag_runs: Vec::new(),
+            gear_run_speed_max: Vec::new(),
             aggregates: a1,
             source: None,
             external_signature: None,
@@ -3243,6 +3292,7 @@ mod tests {
             raw_frame_count: 0,
             gear_runs: Vec::new(),
             flag_runs: Vec::new(),
+            gear_run_speed_max: Vec::new(),
             aggregates: a2,
             source: None,
             external_signature: None,
@@ -3275,6 +3325,7 @@ mod tests {
             raw_frame_count: 60,
             gear_runs: vec![GearRun { gear: 1, frames: 60 }],
             flag_runs: Vec::new(),
+            gear_run_speed_max: Vec::new(),
             aggregates: RouteAggregates::default(),
             source: None,
             external_signature: None,
@@ -3296,6 +3347,7 @@ mod tests {
             raw_frame_count: runs.iter().map(|(_, f)| *f).sum(),
             gear_runs: runs.iter().map(|(g, f)| GearRun { gear: *g, frames: *f }).collect(),
             flag_runs: Vec::new(),
+            gear_run_speed_max: Vec::new(),
             aggregates: a,
             source: None,
             external_signature: None,
@@ -3719,6 +3771,7 @@ mod tests {
             raw_frame_count: 60,
             gear_runs: vec![GearRun { gear: 1, frames: 60 }],
             flag_runs: Vec::new(),
+            gear_run_speed_max: Vec::new(),
             aggregates: RouteAggregates::default(),
             source: None,
             external_signature: None,
@@ -3966,6 +4019,7 @@ mod tests {
             raw_frame_count: 60,
             gear_runs: vec![GearRun { gear: 1, frames: 60 }],
             flag_runs: Vec::new(),
+            gear_run_speed_max: Vec::new(),
             aggregates: RouteAggregates::default(),
             source: None,
             external_signature: None,
@@ -3978,6 +4032,7 @@ mod tests {
             raw_frame_count: 60,
             gear_runs: vec![GearRun { gear: GEAR_PARK, frames: 60 }],
             flag_runs: Vec::new(),
+            gear_run_speed_max: Vec::new(),
             aggregates: RouteAggregates::default(),
             source: None,
             external_signature: None,
@@ -4024,6 +4079,7 @@ mod tests {
             raw_frame_count: 60,
             gear_runs: vec![GearRun { gear: 1, frames: 60 }],
             flag_runs: Vec::new(),
+            gear_run_speed_max: Vec::new(),
             aggregates: RouteAggregates::default(),
             source: None,
             external_signature: None,
@@ -4363,6 +4419,7 @@ mod tests {
             raw_frame_count: gear_runs.iter().map(|(_, f)| *f).sum(),
             gear_runs: gear_runs.iter().map(|&(gear, frames)| GearRun { gear, frames }).collect(),
             flag_runs: fr(flag_runs),
+            gear_run_speed_max: Vec::new(),
             aggregates,
             source: None,
             external_signature: None,
@@ -4484,5 +4541,82 @@ mod tests {
         assert_eq!(drives.len(), 2, "park gap must split summon from the next drive");
         assert!(drives[0].summon, "the summon drive keeps its flag");
         assert!(!drives[1].summon, "the human drive must not inherit it");
+    }
+
+    /// `summon_summary` variant carrying the v16 per-gear-run |SEI|
+    /// maxima — the segment-scoped speed evidence path.
+    fn summon_summary_with_run_speeds(
+        file: &str,
+        gear_runs: &[(u8, u32)],
+        flag_runs: &[(u8, u32)],
+        run_speed_max: &[f32],
+        sei_speed_abs_max: Option<f64>,
+    ) -> RouteSummary {
+        assert_eq!(run_speed_max.len(), gear_runs.len(), "fixture: one max per gear run");
+        let mut s = summon_summary(file, gear_runs, flag_runs, sei_speed_abs_max);
+        s.gear_run_speed_max = run_speed_max.to_vec();
+        s
+    }
+
+    #[test]
+    fn summon_reverse_summon_ending_seconds_before_human_drives_off_splits_and_flags() {
+        // Real 2026-07-27 20:04 shape (ported from Sentry-Drive
+        // grouper.test.js). Clip A: hazards in P, P→R under hazards
+        // (leading P too short to split), backs out, shifts D, creeps
+        // toward the user. Clip B: creep finishes, hazards through the
+        // stop and D→P, ~3 s of Park, then the human gets in (brake,
+        // accel) and drives off. The mid-clip park must split the summon
+        // into its own drive; pedal input stays outside the summon
+        // segment's frame range — and so does the human's SPEED: clip
+        // B's whole-clip abs max is 5.4 m/s (over the 3.5 cap), but the
+        // v16 per-gear-run maxima scope the summon segment to its own
+        // 0.3 m/s crawl.
+        let clip_a = summon_summary_with_run_speeds(
+            "2026-07-27/2026-07-27_20-04-00-front.mp4",
+            &[(GEAR_PARK, 46), (2 /* GEAR_REVERSE */, 727), (1, 917)],
+            &[(0, 11), (3, 113), (0, 394), (2, 256), (0, 301), (2, 615)],
+            &[0.0, 2.0, 2.0],
+            Some(2.0),
+        );
+        let clip_b = summon_summary_with_run_speeds(
+            "2026-07-27/2026-07-27_20-04-46-front.mp4",
+            &[(1, 120), (GEAR_PARK, 84), (1, 1469)],
+            &[(2, 81), (3, 89), (4, 70), (0, 200), (8, 690), (0, 112), (1, 431)],
+            &[0.3, 0.0, 5.4],
+            Some(5.4),
+        );
+        let drives = group_summaries_fast(&[clip_a, clip_b], &HashMap::new());
+        assert_eq!(drives.len(), 2, "mid-clip park must split the summon from the departure");
+        assert!(
+            drives[0].summon,
+            "summon keeps its flag despite sharing clip B with 5.4 m/s driving"
+        );
+        assert!(!drives[1].summon, "the human drive after the park is not summon");
+    }
+
+    #[test]
+    fn summon_whole_clip_abs_max_fallback_stays_conservative_on_shared_clip() {
+        // The same 07-27 drive WITHOUT per-run maxima (pre-v16 row,
+        // import): the fallback sees clip B's whole-clip 5.4 m/s and
+        // must reject rather than guess — no flag beats a wrong flag.
+        let clip_a = summon_summary(
+            "2026-07-27/2026-07-27_20-04-00-front.mp4",
+            &[(GEAR_PARK, 46), (2, 727), (1, 917)],
+            &[(0, 11), (3, 113), (0, 394), (2, 256), (0, 301), (2, 615)],
+            Some(2.0),
+        );
+        let clip_b = summon_summary(
+            "2026-07-27/2026-07-27_20-04-46-front.mp4",
+            &[(1, 120), (GEAR_PARK, 84), (1, 1469)],
+            &[(2, 81), (3, 89), (4, 70), (0, 200), (8, 690), (0, 112), (1, 431)],
+            Some(5.4),
+        );
+        let drives = group_summaries_fast(&[clip_a, clip_b], &HashMap::new());
+        assert_eq!(drives.len(), 2);
+        assert!(
+            !drives[0].summon,
+            "without per-run maxima the whole-clip 5.4 m/s must reject the summon"
+        );
+        assert!(!drives[1].summon);
     }
 }

--- a/crates/drives/src/grouper.rs
+++ b/crates/drives/src/grouper.rs
@@ -1788,11 +1788,15 @@ fn build_fsd_analytics(summaries: &[DriveSummary], period: &str) -> FsdAnalytics
     // Filter drives in period. Imported drives (tessie, teslascope, …)
     // are excluded from FSD analytics entirely — their autopilot data is
     // inferred or absent, not dashcam SEI telemetry, so mixing them
-    // would dilute the score.
+    // would dilute the score. Summon drives are excluded too (mirrors
+    // Sentry-Drive's aggregate builder): driverless with autopilot_state
+    // unset, they'd otherwise read as fake "0% FSD" drives — dragging
+    // down the score and padding the per-drive disengagement averages
+    // with trips no human (or FSD) ever drove.
     let period_drives: Vec<&DriveSummary> = summaries
         .iter()
         .filter(|d| {
-            if is_imported(&d.source) {
+            if is_imported(&d.source) || d.summon {
                 return false;
             }
             if let Some(ps) = period_start {
@@ -4618,5 +4622,59 @@ mod tests {
             "without per-run maxima the whole-clip 5.4 m/s must reject the summon"
         );
         assert!(!drives[1].summon);
+    }
+
+    #[test]
+    fn summon_drives_do_not_count_toward_fsd_analytics() {
+        // A 100%-FSD commute in the morning, a detected summon in the
+        // evening. The summon is driverless with autopilot_state unset,
+        // so counting it would read as a fake "0% FSD" drive — the
+        // score must stay 100%, the per-drive averages must not gain a
+        // phantom denominator, and the summon's distance must stay out
+        // of the analytics totals (mirrors Sentry-Drive's aggregate
+        // builder; top-line drive totals elsewhere still include it).
+        let mut fsd_commute = summon_summary(
+            "2026-07-15/2026-07-15_08-00-00-front.mp4",
+            &[(1, 1800)],
+            &[],
+            Some(20.0),
+        );
+        fsd_commute.aggregates.distance_m = 9850.0;
+        fsd_commute.aggregates.fsd_distance_m = 9850.0;
+        fsd_commute.aggregates.fsd_engaged_ms = 300_000;
+        fsd_commute.aggregates.fsd_disengagements = 1;
+
+        let mut summon_a = summon_summary(
+            "2026-07-15/2026-07-15_20-49-54-front.mp4",
+            &[(GEAR_PARK, 60), (1, 1726)],
+            &[(0, 27), (3, 123), (0, 17), (1, 873), (0, 746)],
+            Some(2.7),
+        );
+        summon_a.aggregates.distance_m = 100.0;
+        let mut summon_b = summon_summary(
+            "2026-07-15/2026-07-15_20-50-43-front.mp4",
+            &[(1, 500), (GEAR_PARK, 53)],
+            &[(0, 471), (3, 82)],
+            Some(2.7),
+        );
+        summon_b.aggregates.distance_m = 50.0;
+
+        let drives =
+            group_summaries_fast(&[fsd_commute, summon_a, summon_b], &HashMap::new());
+        assert_eq!(drives.len(), 2);
+        assert!(!drives[0].summon);
+        assert_eq!(drives[0].fsd_percent, 100.0);
+        assert!(drives[1].summon, "precondition: the evening drive is a summon");
+        assert!(drives[1].distance_km > 0.0, "precondition: it carries distance");
+
+        let fsd = build_fsd_analytics(&drives, "all");
+        assert_eq!(fsd.total_drives, 1, "summon drive must not count");
+        assert_eq!(fsd.fsd_percent, 100.0, "score undiluted by the summon's distance");
+        assert_eq!(fsd.total_distance_km, 9.85, "summon distance stays out of analytics");
+        assert_eq!(
+            fsd.avg_disengagements_per_drive, 1.0,
+            "per-drive averages must not gain a phantom summon denominator"
+        );
+        assert_eq!(fsd.best_day_percent, 100.0);
     }
 }

--- a/crates/drives/src/json_compat.rs
+++ b/crates/drives/src/json_compat.rs
@@ -26,9 +26,9 @@ use rusqlite::{params, Connection};
 use tracing::{debug, info, warn};
 
 use crate::aggregate::compute_route_aggregates;
-use crate::blob::{decode_f32s, decode_gear_runs, decode_points, decode_u8s};
+use crate::blob::{decode_f32s, decode_flag_runs, decode_gear_runs, decode_points, decode_u8s};
 use crate::db::normalize_path;
-use crate::types::{GearRun, GpsPoint, Route};
+use crate::types::{FlagRun, GearRun, GpsPoint, Route};
 
 /// Minimum existing-route count before the shrink guard applies. Below
 /// this, allow any import — tiny DBs don't need corruption protection
@@ -481,6 +481,14 @@ fn insert_imported_route(
     let sb = crate::blob::encode_f32s(Some(&r.speeds));
     let acb = crate::blob::encode_f32s(Some(&r.accel_positions));
     let rb = crate::blob::encode_gear_runs(Some(&r.gear_runs));
+    // Absent flagRuns (pre-flags Sentry-Drive exports, Tessie imports)
+    // stores NULL — the summon detector must see "no evidence", not an
+    // empty-but-present run list.
+    let fb = if r.flag_runs.is_empty() {
+        None
+    } else {
+        crate::blob::encode_flag_runs(Some(&r.flag_runs))
+    };
 
     let first_lat: Option<f64> = r.points.first().map(|p| p[0]);
     let first_lon: Option<f64> = r.points.first().map(|p| p[1]);
@@ -516,7 +524,8 @@ fn insert_imported_route(
             odometer_mi_start, odometer_mi_end,
             location_name_start, location_name_end,
             fsd_pend_ms_end, park_ms_start, fsd_at_end, fsd_accel_pushes_early,
-            ap_at_start)
+            ap_at_start,
+            flag_runs_blob, sei_speed_abs_max)
          VALUES(
             ?1, ?2, ?3, ?4, ?5,
             NULL, NULL, ?6, ?7, ?8,
@@ -530,7 +539,8 @@ fn insert_imported_route(
             ?36, ?37, ?38, ?39, ?40, ?41,
             ?42, ?43, ?44, ?45,
             ?46, ?47, ?48, ?49,
-            ?50, ?51, ?52, ?53, ?54)
+            ?50, ?51, ?52, ?53, ?54,
+            ?55, ?56)
          ON CONFLICT(file) DO UPDATE SET
             date_dir            = excluded.date_dir,
             point_count         = excluded.point_count,
@@ -584,7 +594,9 @@ fn insert_imported_route(
             park_ms_start       = excluded.park_ms_start,
             fsd_at_end          = excluded.fsd_at_end,
             fsd_accel_pushes_early = excluded.fsd_accel_pushes_early,
-            ap_at_start         = excluded.ap_at_start",
+            ap_at_start         = excluded.ap_at_start,
+            flag_runs_blob      = excluded.flag_runs_blob,
+            sei_speed_abs_max   = excluded.sei_speed_abs_max",
         params![
             norm, r.date, r.points.len() as i64, r.raw_park_count as i64, r.raw_frame_count as i64,
             a.distance_m, first_lat, first_lon,
@@ -603,6 +615,7 @@ fn insert_imported_route(
             r.location_name_start, r.location_name_end,
             a.fsd_pend_ms_end, a.park_ms_start, a.fsd_at_end as i64, a.fsd_accel_pushes_early,
             a.ap_at_start,
+            fb, a.sei_speed_abs_max,
         ],
     )?;
     Ok(())
@@ -841,7 +854,8 @@ impl<'a> serde::Serialize for RouteStream<'a> {
                         hvac_runtime_s,
                         tire_fl_psi, tire_fr_psi, tire_rl_psi, tire_rr_psi,
                         odometer_mi_start, odometer_mi_end,
-                        location_name_start, location_name_end
+                        location_name_start, location_name_end,
+                        flag_runs_blob
                  FROM routes
                  ORDER BY file",
             )
@@ -983,6 +997,10 @@ impl<'a> serde::Serialize for RouteStream<'a> {
                 *self.error.borrow_mut() = Some(e);
                 S::Error::custom("col location_name_end")
             })?;
+            let fb: Option<Vec<u8>> = row.get(27).map_err(|e| {
+                *self.error.borrow_mut() = Some(e);
+                S::Error::custom("col flag_runs_blob")
+            })?;
 
             let points: Vec<GpsPoint> = decode_points(pb.as_deref())
                 .map_err(|e| S::Error::custom(format!("decode points {}: {}", file, e)))?
@@ -998,6 +1016,9 @@ impl<'a> serde::Serialize for RouteStream<'a> {
             let gear_runs: Vec<GearRun> = decode_gear_runs(rb.as_deref())
                 .map_err(|e| S::Error::custom(format!("decode gear_runs {}: {}", file, e)))?
                 .unwrap_or_default();
+            let flag_runs: Vec<FlagRun> = decode_flag_runs(fb.as_deref())
+                .map_err(|e| S::Error::custom(format!("decode flag_runs {}: {}", file, e)))?
+                .unwrap_or_default();
 
             let route = Route {
                 file,
@@ -1010,6 +1031,7 @@ impl<'a> serde::Serialize for RouteStream<'a> {
                 raw_park_count,
                 raw_frame_count,
                 gear_runs,
+                flag_runs,
                 source,
                 external_signature,
                 tessie_autopilot_percent,
@@ -1116,8 +1138,9 @@ impl<'a> serde::Serialize for TelemetrySampleStream<'a> {
 
 #[cfg(test)]
 mod streaming_export_tests {
+    use super::{export_json, import_json};
     use crate::db::DriveStore;
-    use crate::types::{GearRun, GpsPoint, StoreData};
+    use crate::types::{FlagRun, GearRun, GpsPoint, StoreData};
 
     /// The streaming exporter must produce byte-for-byte parseable JSON
     /// that deserializes back into the same `StoreData` the importer
@@ -1140,6 +1163,7 @@ mod streaming_export_tests {
                 0,
                 2,
                 &[GearRun { gear: 4, frames: 2 }],
+                &[FlagRun { flags: 3, frames: 1 }, FlagRun { flags: 0, frames: 1 }],
             )
             .unwrap();
 
@@ -1156,9 +1180,62 @@ mod streaming_export_tests {
         assert_eq!(data.routes[0].gear_states, vec![4, 4]);
         assert_eq!(data.routes[0].autopilot_states, vec![1, 1]);
         assert_eq!(data.routes[0].speeds, vec![25.0, 26.0]);
+        assert_eq!(
+            data.routes[0].flag_runs,
+            vec![FlagRun { flags: 3, frames: 1 }, FlagRun { flags: 0, frames: 1 }],
+        );
+        // Wire shape matches Sentry-Drive's flagRuns exactly.
+        let raw_str = String::from_utf8(raw.clone()).unwrap();
+        assert!(
+            raw_str.contains(r#""flagRuns":[{"flags":3,"frames":1},{"flags":0,"frames":1}]"#),
+            "export json: {raw_str}"
+        );
         assert_eq!(data.processed_files, vec!["2025-01-15/clip.mp4"]);
 
         let _ = std::fs::remove_file(&tmp);
+    }
+
+    #[test]
+    fn flag_runs_round_trip_import_then_export() {
+        // A Sentry-Drive-authored drive-data.json with flagRuns must
+        // import into SQLite and re-export byte-equal on that field —
+        // and a route WITHOUT flagRuns must stay absent (unverifiable),
+        // not become an empty array.
+        let json = r#"{"processedFiles":["2026-07-15/2026-07-15_20-50-43-front.mp4","2026-07-15/2026-07-15_20-51-44-front.mp4"],"routes":[
+            {"file":"2026-07-15/2026-07-15_20-50-43-front.mp4","date":"2026-07-15","points":[[37.0,-122.0],[37.0001,-122.0]],"gearStates":"AQE=","autopilotStates":"AAA=","speeds":[1.5,2.7],"accelPositions":[0.0,0.0],"rawParkCount":53,"rawFrameCount":553,"gearRuns":[{"gear":1,"frames":500},{"gear":0,"frames":53}],"flagRuns":[{"flags":0,"frames":471},{"flags":3,"frames":82}]},
+            {"file":"2026-07-15/2026-07-15_20-51-44-front.mp4","date":"2026-07-15","points":[[37.0,-122.0],[37.0001,-122.0]],"gearStates":"AQE=","autopilotStates":"AAA=","speeds":[1.5,2.7],"accelPositions":[0.0,0.0],"rawParkCount":0,"rawFrameCount":600,"gearRuns":[{"gear":1,"frames":600}]}
+        ],"driveTags":{}}"#;
+        let path = std::env::temp_dir().join(format!(
+            "sentryusb-flagruns-roundtrip-{}.json",
+            std::process::id()
+        ));
+        std::fs::write(&path, json).unwrap();
+
+        let mut conn = rusqlite::Connection::open_in_memory().unwrap();
+        crate::schema::migrate(&conn).unwrap();
+        import_json(&mut conn, path.to_str().unwrap(), |_| {}).unwrap();
+
+        let mut out: Vec<u8> = Vec::new();
+        export_json(&conn, &mut out).unwrap();
+        let data: crate::types::StoreData = serde_json::from_slice(&out).unwrap();
+        assert_eq!(data.routes.len(), 2);
+        assert_eq!(
+            data.routes[0].flag_runs,
+            vec![FlagRun { flags: 0, frames: 471 }, FlagRun { flags: 3, frames: 82 }],
+        );
+        assert!(
+            data.routes[1].flag_runs.is_empty(),
+            "route without flagRuns must stay unverifiable"
+        );
+        let out_str = String::from_utf8(out).unwrap();
+        assert!(
+            out_str.contains(r#""flagRuns":[{"flags":0,"frames":471},{"flags":3,"frames":82}]"#),
+            "export: {out_str}"
+        );
+        // Absent stays absent for the second route — count the key.
+        assert_eq!(out_str.matches(r#""flagRuns""#).count(), 1);
+
+        let _ = std::fs::remove_file(&path);
     }
 
     #[test]
@@ -1210,6 +1287,7 @@ mod streaming_export_tests {
                 0,
                 2,
                 &[GearRun { gear: 4, frames: 2 }],
+                &[FlagRun { flags: 3, frames: 1 }, FlagRun { flags: 0, frames: 1 }],
             )
             .unwrap();
         store.export_json_to_file(&json_str).unwrap();
@@ -1548,7 +1626,7 @@ mod full_db_export_tests {
         let store = DriveStore::open_memory().unwrap();
         let pts: Vec<GpsPoint> = vec![[37.7749, -122.4194], [37.7750, -122.4195]];
         store
-            .add_route("2025-01-15/clip.mp4", "2025-01-15", &pts, &[4, 4], &[1, 1], &[25.0, 26.0], &[0.5, 0.6], 0, 2, &[])
+            .add_route("2025-01-15/clip.mp4", "2025-01-15", &pts, &[4, 4], &[1, 1], &[25.0, 26.0], &[0.5, 0.6], 0, 2, &[], &[])
             .unwrap();
         store.with_locked_conn(|conn| seed_telemetry(conn));
         store
@@ -1716,7 +1794,7 @@ mod full_db_export_tests {
         let store = DriveStore::open_memory().unwrap();
         let pts: Vec<GpsPoint> = vec![[37.7749, -122.4194]];
         store
-            .add_route("2025-01-15/clip.mp4", "2025-01-15", &pts, &[4], &[1], &[25.0], &[0.5], 0, 1, &[])
+            .add_route("2025-01-15/clip.mp4", "2025-01-15", &pts, &[4], &[1], &[25.0], &[0.5], 0, 1, &[], &[])
             .unwrap();
         let path = tmp_json("omit");
         let path_str = path.to_string_lossy().to_string();

--- a/crates/drives/src/json_compat.rs
+++ b/crates/drives/src/json_compat.rs
@@ -489,13 +489,6 @@ fn insert_imported_route(
     } else {
         crate::blob::encode_flag_runs(Some(&r.flag_runs))
     };
-    // Same absence rule for per-gear-run speed maxima (Rusty-authored
-    // exports carry them; Drive exports and older backups don't).
-    let grsb = if r.gear_run_speed_max.is_empty() {
-        None
-    } else {
-        crate::blob::encode_f32s(Some(&r.gear_run_speed_max))
-    };
 
     let first_lat: Option<f64> = r.points.first().map(|p| p[0]);
     let first_lon: Option<f64> = r.points.first().map(|p| p[1]);
@@ -532,7 +525,7 @@ fn insert_imported_route(
             location_name_start, location_name_end,
             fsd_pend_ms_end, park_ms_start, fsd_at_end, fsd_accel_pushes_early,
             ap_at_start,
-            flag_runs_blob, sei_speed_abs_max, gear_run_speed_blob)
+            flag_runs_blob, sei_speed_abs_max)
          VALUES(
             ?1, ?2, ?3, ?4, ?5,
             NULL, NULL, ?6, ?7, ?8,
@@ -547,7 +540,7 @@ fn insert_imported_route(
             ?42, ?43, ?44, ?45,
             ?46, ?47, ?48, ?49,
             ?50, ?51, ?52, ?53, ?54,
-            ?55, ?56, ?57)
+            ?55, ?56)
          ON CONFLICT(file) DO UPDATE SET
             date_dir            = excluded.date_dir,
             point_count         = excluded.point_count,
@@ -603,8 +596,7 @@ fn insert_imported_route(
             fsd_accel_pushes_early = excluded.fsd_accel_pushes_early,
             ap_at_start         = excluded.ap_at_start,
             flag_runs_blob      = excluded.flag_runs_blob,
-            sei_speed_abs_max   = excluded.sei_speed_abs_max,
-            gear_run_speed_blob = excluded.gear_run_speed_blob",
+            sei_speed_abs_max   = excluded.sei_speed_abs_max",
         params![
             norm, r.date, r.points.len() as i64, r.raw_park_count as i64, r.raw_frame_count as i64,
             a.distance_m, first_lat, first_lon,
@@ -623,7 +615,7 @@ fn insert_imported_route(
             r.location_name_start, r.location_name_end,
             a.fsd_pend_ms_end, a.park_ms_start, a.fsd_at_end as i64, a.fsd_accel_pushes_early,
             a.ap_at_start,
-            fb, a.sei_speed_abs_max, grsb,
+            fb, a.sei_speed_abs_max,
         ],
     )?;
     Ok(())
@@ -863,7 +855,7 @@ impl<'a> serde::Serialize for RouteStream<'a> {
                         tire_fl_psi, tire_fr_psi, tire_rl_psi, tire_rr_psi,
                         odometer_mi_start, odometer_mi_end,
                         location_name_start, location_name_end,
-                        flag_runs_blob, gear_run_speed_blob
+                        flag_runs_blob
                  FROM routes
                  ORDER BY file",
             )
@@ -1009,10 +1001,6 @@ impl<'a> serde::Serialize for RouteStream<'a> {
                 *self.error.borrow_mut() = Some(e);
                 S::Error::custom("col flag_runs_blob")
             })?;
-            let grsb: Option<Vec<u8>> = row.get(28).map_err(|e| {
-                *self.error.borrow_mut() = Some(e);
-                S::Error::custom("col gear_run_speed_blob")
-            })?;
 
             let points: Vec<GpsPoint> = decode_points(pb.as_deref())
                 .map_err(|e| S::Error::custom(format!("decode points {}: {}", file, e)))?
@@ -1031,11 +1019,6 @@ impl<'a> serde::Serialize for RouteStream<'a> {
             let flag_runs: Vec<FlagRun> = decode_flag_runs(fb.as_deref())
                 .map_err(|e| S::Error::custom(format!("decode flag_runs {}: {}", file, e)))?
                 .unwrap_or_default();
-            let gear_run_speed_max: Vec<f32> = decode_f32s(grsb.as_deref())
-                .map_err(|e| {
-                    S::Error::custom(format!("decode gear_run_speed_max {}: {}", file, e))
-                })?
-                .unwrap_or_default();
 
             let route = Route {
                 file,
@@ -1049,7 +1032,6 @@ impl<'a> serde::Serialize for RouteStream<'a> {
                 raw_frame_count,
                 gear_runs,
                 flag_runs,
-                gear_run_speed_max,
                 source,
                 external_signature,
                 tessie_autopilot_percent,
@@ -1181,8 +1163,10 @@ mod streaming_export_tests {
                 0,
                 2,
                 &[GearRun { gear: 4, frames: 2 }],
-                &[FlagRun { flags: 3, frames: 1 }, FlagRun { flags: 0, frames: 1 }],
-                &[26.0],
+                &[
+                    FlagRun { flags: 3, frames: 1, max_mps: Some(2.7) },
+                    FlagRun { flags: 0, frames: 1, max_mps: None },
+                ],
             )
             .unwrap();
 
@@ -1201,20 +1185,18 @@ mod streaming_export_tests {
         assert_eq!(data.routes[0].speeds, vec![25.0, 26.0]);
         assert_eq!(
             data.routes[0].flag_runs,
-            vec![FlagRun { flags: 3, frames: 1 }, FlagRun { flags: 0, frames: 1 }],
+            vec![
+                FlagRun { flags: 3, frames: 1, max_mps: Some(2.7) },
+                FlagRun { flags: 0, frames: 1, max_mps: None },
+            ],
         );
-        // Wire shape matches Sentry-Drive's flagRuns exactly.
+        // Wire shape matches Sentry-Drive's flagRuns exactly: per-run
+        // maxMps present when known, the KEY absent (not null) when not.
         let raw_str = String::from_utf8(raw.clone()).unwrap();
         assert!(
-            raw_str.contains(r#""flagRuns":[{"flags":3,"frames":1},{"flags":0,"frames":1}]"#),
-            "export json: {raw_str}"
-        );
-        // Rusty-private per-gear-run speed maxima ride the same wire
-        // (Drive ignores unknown keys) so a backup restore keeps the
-        // segment-scoped summon evidence.
-        assert_eq!(data.routes[0].gear_run_speed_max, vec![26.0f32]);
-        assert!(
-            raw_str.contains(r#""gearRunSpeedMax":[26.0]"#),
+            raw_str.contains(
+                r#""flagRuns":[{"flags":3,"frames":1,"maxMps":2.7},{"flags":0,"frames":1}]"#
+            ),
             "export json: {raw_str}"
         );
         assert_eq!(data.processed_files, vec!["2025-01-15/clip.mp4"]);
@@ -1225,11 +1207,14 @@ mod streaming_export_tests {
     #[test]
     fn flag_runs_round_trip_import_then_export() {
         // A Sentry-Drive-authored drive-data.json with flagRuns must
-        // import into SQLite and re-export byte-equal on that field —
-        // and a route WITHOUT flagRuns must stay absent (unverifiable),
-        // not become an empty array.
+        // import into SQLite and re-export byte-equal on that field.
+        // Route 1 mixes a modern run (maxMps, current Drive extraction)
+        // with a legacy one (no maxMps) — both per-run states must
+        // survive, absence staying an ABSENT key, not null. A route
+        // WITHOUT flagRuns must stay absent too (unverifiable), not
+        // become an empty array.
         let json = r#"{"processedFiles":["2026-07-15/2026-07-15_20-50-43-front.mp4","2026-07-15/2026-07-15_20-51-44-front.mp4"],"routes":[
-            {"file":"2026-07-15/2026-07-15_20-50-43-front.mp4","date":"2026-07-15","points":[[37.0,-122.0],[37.0001,-122.0]],"gearStates":"AQE=","autopilotStates":"AAA=","speeds":[1.5,2.7],"accelPositions":[0.0,0.0],"rawParkCount":53,"rawFrameCount":553,"gearRuns":[{"gear":1,"frames":500},{"gear":0,"frames":53}],"flagRuns":[{"flags":0,"frames":471},{"flags":3,"frames":82}]},
+            {"file":"2026-07-15/2026-07-15_20-50-43-front.mp4","date":"2026-07-15","points":[[37.0,-122.0],[37.0001,-122.0]],"gearStates":"AQE=","autopilotStates":"AAA=","speeds":[1.5,2.7],"accelPositions":[0.0,0.0],"rawParkCount":53,"rawFrameCount":553,"gearRuns":[{"gear":1,"frames":500},{"gear":0,"frames":53}],"flagRuns":[{"flags":0,"frames":471,"maxMps":2.7},{"flags":3,"frames":82}]},
             {"file":"2026-07-15/2026-07-15_20-51-44-front.mp4","date":"2026-07-15","points":[[37.0,-122.0],[37.0001,-122.0]],"gearStates":"AQE=","autopilotStates":"AAA=","speeds":[1.5,2.7],"accelPositions":[0.0,0.0],"rawParkCount":0,"rawFrameCount":600,"gearRuns":[{"gear":1,"frames":600}]}
         ],"driveTags":{}}"#;
         let path = std::env::temp_dir().join(format!(
@@ -1248,7 +1233,10 @@ mod streaming_export_tests {
         assert_eq!(data.routes.len(), 2);
         assert_eq!(
             data.routes[0].flag_runs,
-            vec![FlagRun { flags: 0, frames: 471 }, FlagRun { flags: 3, frames: 82 }],
+            vec![
+                FlagRun { flags: 0, frames: 471, max_mps: Some(2.7) },
+                FlagRun { flags: 3, frames: 82, max_mps: None },
+            ],
         );
         assert!(
             data.routes[1].flag_runs.is_empty(),
@@ -1256,7 +1244,9 @@ mod streaming_export_tests {
         );
         let out_str = String::from_utf8(out).unwrap();
         assert!(
-            out_str.contains(r#""flagRuns":[{"flags":0,"frames":471},{"flags":3,"frames":82}]"#),
+            out_str.contains(
+                r#""flagRuns":[{"flags":0,"frames":471,"maxMps":2.7},{"flags":3,"frames":82}]"#
+            ),
             "export: {out_str}"
         );
         // Absent stays absent for the second route — count the key.
@@ -1314,8 +1304,10 @@ mod streaming_export_tests {
                 0,
                 2,
                 &[GearRun { gear: 4, frames: 2 }],
-                &[FlagRun { flags: 3, frames: 1 }, FlagRun { flags: 0, frames: 1 }],
-                &[],
+                &[
+                    FlagRun { flags: 3, frames: 1, max_mps: Some(2.7) },
+                    FlagRun { flags: 0, frames: 1, max_mps: None },
+                ],
             )
             .unwrap();
         store.export_json_to_file(&json_str).unwrap();
@@ -1654,7 +1646,7 @@ mod full_db_export_tests {
         let store = DriveStore::open_memory().unwrap();
         let pts: Vec<GpsPoint> = vec![[37.7749, -122.4194], [37.7750, -122.4195]];
         store
-            .add_route("2025-01-15/clip.mp4", "2025-01-15", &pts, &[4, 4], &[1, 1], &[25.0, 26.0], &[0.5, 0.6], 0, 2, &[], &[], &[])
+            .add_route("2025-01-15/clip.mp4", "2025-01-15", &pts, &[4, 4], &[1, 1], &[25.0, 26.0], &[0.5, 0.6], 0, 2, &[], &[])
             .unwrap();
         store.with_locked_conn(|conn| seed_telemetry(conn));
         store
@@ -1822,7 +1814,7 @@ mod full_db_export_tests {
         let store = DriveStore::open_memory().unwrap();
         let pts: Vec<GpsPoint> = vec![[37.7749, -122.4194]];
         store
-            .add_route("2025-01-15/clip.mp4", "2025-01-15", &pts, &[4], &[1], &[25.0], &[0.5], 0, 1, &[], &[], &[])
+            .add_route("2025-01-15/clip.mp4", "2025-01-15", &pts, &[4], &[1], &[25.0], &[0.5], 0, 1, &[], &[])
             .unwrap();
         let path = tmp_json("omit");
         let path_str = path.to_string_lossy().to_string();

--- a/crates/drives/src/json_compat.rs
+++ b/crates/drives/src/json_compat.rs
@@ -489,6 +489,13 @@ fn insert_imported_route(
     } else {
         crate::blob::encode_flag_runs(Some(&r.flag_runs))
     };
+    // Same absence rule for per-gear-run speed maxima (Rusty-authored
+    // exports carry them; Drive exports and older backups don't).
+    let grsb = if r.gear_run_speed_max.is_empty() {
+        None
+    } else {
+        crate::blob::encode_f32s(Some(&r.gear_run_speed_max))
+    };
 
     let first_lat: Option<f64> = r.points.first().map(|p| p[0]);
     let first_lon: Option<f64> = r.points.first().map(|p| p[1]);
@@ -525,7 +532,7 @@ fn insert_imported_route(
             location_name_start, location_name_end,
             fsd_pend_ms_end, park_ms_start, fsd_at_end, fsd_accel_pushes_early,
             ap_at_start,
-            flag_runs_blob, sei_speed_abs_max)
+            flag_runs_blob, sei_speed_abs_max, gear_run_speed_blob)
          VALUES(
             ?1, ?2, ?3, ?4, ?5,
             NULL, NULL, ?6, ?7, ?8,
@@ -540,7 +547,7 @@ fn insert_imported_route(
             ?42, ?43, ?44, ?45,
             ?46, ?47, ?48, ?49,
             ?50, ?51, ?52, ?53, ?54,
-            ?55, ?56)
+            ?55, ?56, ?57)
          ON CONFLICT(file) DO UPDATE SET
             date_dir            = excluded.date_dir,
             point_count         = excluded.point_count,
@@ -596,7 +603,8 @@ fn insert_imported_route(
             fsd_accel_pushes_early = excluded.fsd_accel_pushes_early,
             ap_at_start         = excluded.ap_at_start,
             flag_runs_blob      = excluded.flag_runs_blob,
-            sei_speed_abs_max   = excluded.sei_speed_abs_max",
+            sei_speed_abs_max   = excluded.sei_speed_abs_max,
+            gear_run_speed_blob = excluded.gear_run_speed_blob",
         params![
             norm, r.date, r.points.len() as i64, r.raw_park_count as i64, r.raw_frame_count as i64,
             a.distance_m, first_lat, first_lon,
@@ -615,7 +623,7 @@ fn insert_imported_route(
             r.location_name_start, r.location_name_end,
             a.fsd_pend_ms_end, a.park_ms_start, a.fsd_at_end as i64, a.fsd_accel_pushes_early,
             a.ap_at_start,
-            fb, a.sei_speed_abs_max,
+            fb, a.sei_speed_abs_max, grsb,
         ],
     )?;
     Ok(())
@@ -855,7 +863,7 @@ impl<'a> serde::Serialize for RouteStream<'a> {
                         tire_fl_psi, tire_fr_psi, tire_rl_psi, tire_rr_psi,
                         odometer_mi_start, odometer_mi_end,
                         location_name_start, location_name_end,
-                        flag_runs_blob
+                        flag_runs_blob, gear_run_speed_blob
                  FROM routes
                  ORDER BY file",
             )
@@ -1001,6 +1009,10 @@ impl<'a> serde::Serialize for RouteStream<'a> {
                 *self.error.borrow_mut() = Some(e);
                 S::Error::custom("col flag_runs_blob")
             })?;
+            let grsb: Option<Vec<u8>> = row.get(28).map_err(|e| {
+                *self.error.borrow_mut() = Some(e);
+                S::Error::custom("col gear_run_speed_blob")
+            })?;
 
             let points: Vec<GpsPoint> = decode_points(pb.as_deref())
                 .map_err(|e| S::Error::custom(format!("decode points {}: {}", file, e)))?
@@ -1019,6 +1031,11 @@ impl<'a> serde::Serialize for RouteStream<'a> {
             let flag_runs: Vec<FlagRun> = decode_flag_runs(fb.as_deref())
                 .map_err(|e| S::Error::custom(format!("decode flag_runs {}: {}", file, e)))?
                 .unwrap_or_default();
+            let gear_run_speed_max: Vec<f32> = decode_f32s(grsb.as_deref())
+                .map_err(|e| {
+                    S::Error::custom(format!("decode gear_run_speed_max {}: {}", file, e))
+                })?
+                .unwrap_or_default();
 
             let route = Route {
                 file,
@@ -1032,6 +1049,7 @@ impl<'a> serde::Serialize for RouteStream<'a> {
                 raw_frame_count,
                 gear_runs,
                 flag_runs,
+                gear_run_speed_max,
                 source,
                 external_signature,
                 tessie_autopilot_percent,
@@ -1164,6 +1182,7 @@ mod streaming_export_tests {
                 2,
                 &[GearRun { gear: 4, frames: 2 }],
                 &[FlagRun { flags: 3, frames: 1 }, FlagRun { flags: 0, frames: 1 }],
+                &[26.0],
             )
             .unwrap();
 
@@ -1188,6 +1207,14 @@ mod streaming_export_tests {
         let raw_str = String::from_utf8(raw.clone()).unwrap();
         assert!(
             raw_str.contains(r#""flagRuns":[{"flags":3,"frames":1},{"flags":0,"frames":1}]"#),
+            "export json: {raw_str}"
+        );
+        // Rusty-private per-gear-run speed maxima ride the same wire
+        // (Drive ignores unknown keys) so a backup restore keeps the
+        // segment-scoped summon evidence.
+        assert_eq!(data.routes[0].gear_run_speed_max, vec![26.0f32]);
+        assert!(
+            raw_str.contains(r#""gearRunSpeedMax":[26.0]"#),
             "export json: {raw_str}"
         );
         assert_eq!(data.processed_files, vec!["2025-01-15/clip.mp4"]);
@@ -1288,6 +1315,7 @@ mod streaming_export_tests {
                 2,
                 &[GearRun { gear: 4, frames: 2 }],
                 &[FlagRun { flags: 3, frames: 1 }, FlagRun { flags: 0, frames: 1 }],
+                &[],
             )
             .unwrap();
         store.export_json_to_file(&json_str).unwrap();
@@ -1626,7 +1654,7 @@ mod full_db_export_tests {
         let store = DriveStore::open_memory().unwrap();
         let pts: Vec<GpsPoint> = vec![[37.7749, -122.4194], [37.7750, -122.4195]];
         store
-            .add_route("2025-01-15/clip.mp4", "2025-01-15", &pts, &[4, 4], &[1, 1], &[25.0, 26.0], &[0.5, 0.6], 0, 2, &[], &[])
+            .add_route("2025-01-15/clip.mp4", "2025-01-15", &pts, &[4, 4], &[1, 1], &[25.0, 26.0], &[0.5, 0.6], 0, 2, &[], &[], &[])
             .unwrap();
         store.with_locked_conn(|conn| seed_telemetry(conn));
         store
@@ -1794,7 +1822,7 @@ mod full_db_export_tests {
         let store = DriveStore::open_memory().unwrap();
         let pts: Vec<GpsPoint> = vec![[37.7749, -122.4194]];
         store
-            .add_route("2025-01-15/clip.mp4", "2025-01-15", &pts, &[4], &[1], &[25.0], &[0.5], 0, 1, &[], &[])
+            .add_route("2025-01-15/clip.mp4", "2025-01-15", &pts, &[4], &[1], &[25.0], &[0.5], 0, 1, &[], &[], &[])
             .unwrap();
         let path = tmp_json("omit");
         let path_str = path.to_string_lossy().to_string();

--- a/crates/drives/src/processor.rs
+++ b/crates/drives/src/processor.rs
@@ -288,6 +288,7 @@ impl Processor {
                         gps.raw_frame_count,
                         &gps.gear_runs,
                         &gps.flag_runs,
+                        &gps.gear_run_speed_max,
                     ) {
                         Ok(()) => routes_found += 1,
                         Err(e) => {

--- a/crates/drives/src/processor.rs
+++ b/crates/drives/src/processor.rs
@@ -287,6 +287,7 @@ impl Processor {
                         gps.raw_park_count,
                         gps.raw_frame_count,
                         &gps.gear_runs,
+                        &gps.flag_runs,
                     ) {
                         Ok(()) => routes_found += 1,
                         Err(e) => {

--- a/crates/drives/src/processor.rs
+++ b/crates/drives/src/processor.rs
@@ -288,7 +288,6 @@ impl Processor {
                         gps.raw_frame_count,
                         &gps.gear_runs,
                         &gps.flag_runs,
-                        &gps.gear_run_speed_max,
                     ) {
                         Ok(()) => routes_found += 1,
                         Err(e) => {

--- a/crates/drives/src/schema.rs
+++ b/crates/drives/src/schema.rs
@@ -83,18 +83,15 @@ use rusqlite::{params, Connection, OptionalExtension};
 /// resolve across clip seams in the drive grouper.
 ///
 /// v15 -> v16: add `flag_runs_blob` (per-frame SEI blinker/brake/accel
-/// flag RLE in RAW frame space — the summon detector's evidence),
-/// `sei_speed_abs_max` (max |SEI speed| per clip; the locked
+/// flag RLE in RAW frame space, each run carrying its max |SEI speed| —
+/// the summon detector's evidence, frame-accurate for the speed gate)
+/// and `sei_speed_abs_max` (max |SEI speed| per clip; the locked
 /// `max_speed_mps` drops negative Reverse samples, so a reverse-only
-/// summon crawl would read 0), and `gear_run_speed_blob` (max |SEI
-/// speed| per gear run, f32 LE array parallel to `gear_runs_blob` —
-/// park splits land on gear-run boundaries, so this scopes summon speed
-/// evidence to the split segment when a summon shares a clip with the
-/// human driving off) to `routes`. All nullable — rows written before
-/// flag extraction stay NULL, which the summon detector reads as
-/// "unverifiable, not summon". No backfill: flags and per-run speeds
-/// can only come from re-extracting the MP4's SEI stream, not from
-/// stored deduped arrays.
+/// summon crawl would read 0 — feeds the detector's legacy fallback) to
+/// `routes`. Both nullable — rows written before flag extraction stay
+/// NULL, which the summon detector reads as "unverifiable, not summon".
+/// No backfill: flags and per-run speeds can only come from
+/// re-extracting the MP4's SEI stream, not from stored deduped arrays.
 pub const CURRENT_SCHEMA_VERSION: i32 = 16;
 
 /// v1 DDL. Each statement is idempotent (`IF NOT EXISTS`) so `migrate()`
@@ -355,13 +352,12 @@ pub const V15_ROUTE_BOUNDARY_COLUMNS: &[(&str, &str)] = &[
 ];
 
 /// v16 summon-evidence columns on `routes` (see `CURRENT_SCHEMA_VERSION`
-/// docs). `flag_runs_blob` follows the `gear_runs_blob` wire shape
-/// (1-byte flags + LE i32 frames per run); `gear_run_speed_blob` is a
-/// plain f32 LE array with one entry per gear run.
+/// docs). `flag_runs_blob` extends the `gear_runs_blob` wire shape with
+/// a per-run speed max (1-byte flags + LE i32 frames + LE f32 max |SEI
+/// speed| per run; NaN = max unknown).
 pub const V16_ROUTE_FLAG_COLUMNS: &[(&str, &str)] = &[
     ("flag_runs_blob", "BLOB"),
     ("sei_speed_abs_max", "REAL"),
-    ("gear_run_speed_blob", "BLOB"),
 ];
 
 /// v9 rollups on `routes`. Odometer start/end let the UI show a

--- a/crates/drives/src/schema.rs
+++ b/crates/drives/src/schema.rs
@@ -83,13 +83,18 @@ use rusqlite::{params, Connection, OptionalExtension};
 /// resolve across clip seams in the drive grouper.
 ///
 /// v15 -> v16: add `flag_runs_blob` (per-frame SEI blinker/brake/accel
-/// flag RLE in RAW frame space — the summon detector's evidence) and
+/// flag RLE in RAW frame space — the summon detector's evidence),
 /// `sei_speed_abs_max` (max |SEI speed| per clip; the locked
 /// `max_speed_mps` drops negative Reverse samples, so a reverse-only
-/// summon crawl would read 0) to `routes`. Both nullable — rows written
-/// before flag extraction stay NULL, which the summon detector reads as
-/// "unverifiable, not summon". No backfill: flags can only come from
-/// re-extracting the MP4's SEI stream, not from stored deduped arrays.
+/// summon crawl would read 0), and `gear_run_speed_blob` (max |SEI
+/// speed| per gear run, f32 LE array parallel to `gear_runs_blob` —
+/// park splits land on gear-run boundaries, so this scopes summon speed
+/// evidence to the split segment when a summon shares a clip with the
+/// human driving off) to `routes`. All nullable — rows written before
+/// flag extraction stay NULL, which the summon detector reads as
+/// "unverifiable, not summon". No backfill: flags and per-run speeds
+/// can only come from re-extracting the MP4's SEI stream, not from
+/// stored deduped arrays.
 pub const CURRENT_SCHEMA_VERSION: i32 = 16;
 
 /// v1 DDL. Each statement is idempotent (`IF NOT EXISTS`) so `migrate()`
@@ -351,10 +356,12 @@ pub const V15_ROUTE_BOUNDARY_COLUMNS: &[(&str, &str)] = &[
 
 /// v16 summon-evidence columns on `routes` (see `CURRENT_SCHEMA_VERSION`
 /// docs). `flag_runs_blob` follows the `gear_runs_blob` wire shape
-/// (1-byte flags + LE i32 frames per run).
+/// (1-byte flags + LE i32 frames per run); `gear_run_speed_blob` is a
+/// plain f32 LE array with one entry per gear run.
 pub const V16_ROUTE_FLAG_COLUMNS: &[(&str, &str)] = &[
     ("flag_runs_blob", "BLOB"),
     ("sei_speed_abs_max", "REAL"),
+    ("gear_run_speed_blob", "BLOB"),
 ];
 
 /// v9 rollups on `routes`. Odometer start/end let the UI show a

--- a/crates/drives/src/schema.rs
+++ b/crates/drives/src/schema.rs
@@ -81,7 +81,16 @@ use rusqlite::{params, Connection, OptionalExtension};
 /// v14 -> v15: add clip-boundary state columns to `routes`
 /// (V15_ROUTE_BOUNDARY_COLUMNS) so FSD disengagements and accel pushes
 /// resolve across clip seams in the drive grouper.
-pub const CURRENT_SCHEMA_VERSION: i32 = 15;
+///
+/// v15 -> v16: add `flag_runs_blob` (per-frame SEI blinker/brake/accel
+/// flag RLE in RAW frame space — the summon detector's evidence) and
+/// `sei_speed_abs_max` (max |SEI speed| per clip; the locked
+/// `max_speed_mps` drops negative Reverse samples, so a reverse-only
+/// summon crawl would read 0) to `routes`. Both nullable — rows written
+/// before flag extraction stay NULL, which the summon detector reads as
+/// "unverifiable, not summon". No backfill: flags can only come from
+/// re-extracting the MP4's SEI stream, not from stored deduped arrays.
+pub const CURRENT_SCHEMA_VERSION: i32 = 16;
 
 /// v1 DDL. Each statement is idempotent (`IF NOT EXISTS`) so `migrate()`
 /// is safe on every startup. Column shapes and names match Go exactly â€”
@@ -340,6 +349,14 @@ pub const V15_ROUTE_BOUNDARY_COLUMNS: &[(&str, &str)] = &[
     ("ap_at_start", "INTEGER"),
 ];
 
+/// v16 summon-evidence columns on `routes` (see `CURRENT_SCHEMA_VERSION`
+/// docs). `flag_runs_blob` follows the `gear_runs_blob` wire shape
+/// (1-byte flags + LE i32 frames per run).
+pub const V16_ROUTE_FLAG_COLUMNS: &[(&str, &str)] = &[
+    ("flag_runs_blob", "BLOB"),
+    ("sei_speed_abs_max", "REAL"),
+];
+
 /// v9 rollups on `routes`. Odometer start/end let the UI show a
 /// per-trip mileage delta that's more accurate than GPS distance
 /// (GPS over-estimates curves, drops in tunnels, can drift).
@@ -484,6 +501,7 @@ pub fn migrate(conn: &Connection) -> Result<()> {
         .chain(V9_ROUTE_COLUMNS.iter())
         .chain(V10_ROUTE_COLUMNS.iter())
         .chain(V15_ROUTE_BOUNDARY_COLUMNS.iter())
+        .chain(V16_ROUTE_FLAG_COLUMNS.iter())
     {
         if existing.contains(*name) {
             continue;
@@ -682,7 +700,7 @@ mod tests {
         migrate(&conn).unwrap();
         assert_eq!(
             meta_get(&conn, "schema_version").unwrap().as_deref(),
-            Some("15"),
+            Some("16"),
         );
         assert!(meta_get(&conn, "created_at").unwrap().is_some());
     }
@@ -720,7 +738,7 @@ mod tests {
         }
         assert_eq!(
             meta_get(&conn, "schema_version").unwrap().as_deref(),
-            Some("15")
+            Some("16")
         );
     }
 
@@ -752,7 +770,7 @@ mod tests {
         }
         assert_eq!(
             meta_get(&conn, "schema_version").unwrap().as_deref(),
-            Some("15")
+            Some("16")
         );
     }
 
@@ -786,7 +804,7 @@ mod tests {
         }
         assert_eq!(
             meta_get(&conn, "schema_version").unwrap().as_deref(),
-            Some("15")
+            Some("16")
         );
     }
 
@@ -893,7 +911,7 @@ mod tests {
         assert!(surviving_processed.starts_with("RecentClips/"));
         assert_eq!(
             meta_get(&conn, "schema_version").unwrap().as_deref(),
-            Some("15")
+            Some("16")
         );
     }
 
@@ -944,7 +962,7 @@ mod tests {
         assert_eq!(count_routes(&conn), 1, "fresh-DB seed must not run v5 cleanup");
         assert_eq!(
             meta_get(&conn, "schema_version").unwrap().as_deref(),
-            Some("15")
+            Some("16")
         );
     }
 
@@ -997,7 +1015,7 @@ mod tests {
         assert_eq!(table_exists, 1, "v6 must create telemetry_samples");
         assert_eq!(
             meta_get(&conn, "schema_version").unwrap().as_deref(),
-            Some("15")
+            Some("16")
         );
     }
 
@@ -1034,7 +1052,45 @@ mod tests {
         }
         assert_eq!(
             meta_get(&conn, "schema_version").unwrap().as_deref(),
-            Some("15")
+            Some("16")
+        );
+    }
+
+    #[test]
+    fn migrate_from_v15_adds_v16_flag_columns() {
+        // Stand up a v15 DB (everything but the v16 flag columns) and
+        // confirm migrate adds them.
+        let conn = open();
+        for stmt in V1_SCHEMA {
+            conn.execute(stmt, []).unwrap();
+        }
+        for stmt in V6_NEW_TABLES {
+            conn.execute(stmt, []).unwrap();
+        }
+        for (name, typ) in V2_ROUTE_AGGREGATE_COLUMNS
+            .iter()
+            .chain(V3_ROUTE_CLOUD_COLUMNS.iter())
+            .chain(V4_ROUTE_TESSIE_COLUMNS.iter())
+            .chain(V6_ROUTE_TELEMETRY_COLUMNS.iter())
+            .chain(V7_ROUTE_TPMS_COLUMNS.iter())
+            .chain(V9_ROUTE_COLUMNS.iter())
+            .chain(V10_ROUTE_COLUMNS.iter())
+            .chain(V15_ROUTE_BOUNDARY_COLUMNS.iter())
+        {
+            conn.execute(&format!("ALTER TABLE routes ADD COLUMN {} {}", name, typ), [])
+                .unwrap();
+        }
+        meta_set(&conn, "schema_version", "15").unwrap();
+
+        migrate(&conn).unwrap();
+
+        let cols = list_route_columns(&conn).unwrap();
+        for (name, _) in V16_ROUTE_FLAG_COLUMNS {
+            assert!(cols.contains(*name), "routes.{} missing after v16", name);
+        }
+        assert_eq!(
+            meta_get(&conn, "schema_version").unwrap().as_deref(),
+            Some("16")
         );
     }
 
@@ -1077,7 +1133,7 @@ mod tests {
         }
         assert_eq!(
             meta_get(&conn, "schema_version").unwrap().as_deref(),
-            Some("15")
+            Some("16")
         );
     }
 

--- a/crates/drives/src/types.rs
+++ b/crates/drives/src/types.rs
@@ -142,6 +142,16 @@ pub struct Route {
     /// detector treats such drives as unverifiable, never as summon.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub flag_runs: Vec<FlagRun>,
+    /// v16: max |SEI speed| (m/s) inside each gear run, parallel to
+    /// `gear_runs`. Park splits always land on gear-run boundaries, so a
+    /// split segment's true max speed is the max over its runs — this is
+    /// what lets a summon crawl that shares a clip with fast human
+    /// driving keep its own speed evidence (real case: 2026-07-27 20:04,
+    /// summon ends and the human drives off seconds later in the same
+    /// clip). Empty when unknown (pre-v16 rows, imports); consumers fall
+    /// back to the clip-level `sei_speed_abs_max`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub gear_run_speed_max: Vec<f32>,
     /// Provenance: "sei" (native dashcam) or "tessie" (imported from Tessie).
     /// Absent / null defaults to "sei" for backwards compatibility.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -476,6 +486,7 @@ pub struct ExtractedGps {
     pub raw_frame_count: u32,
     pub gear_runs: Vec<GearRun>,
     pub flag_runs: Vec<FlagRun>,
+    pub gear_run_speed_max: Vec<f32>,
 }
 
 /// Processing progress status.
@@ -617,6 +628,10 @@ pub struct RouteSummary {
     /// written before flag extraction — those drives are summon-
     /// unverifiable by definition.
     pub flag_runs: Vec<FlagRun>,
+    /// v16: per-gear-run max |SEI speed| (see [`Route::gear_run_speed_max`]).
+    /// Empty when unknown; summon evidence then falls back to the
+    /// clip-level `sei_speed_abs_max`.
+    pub gear_run_speed_max: Vec<f32>,
     pub aggregates: RouteAggregates,
     /// Provenance carried through for grouping: "sei" or "tessie".
     pub source: Option<String>,

--- a/crates/drives/src/types.rs
+++ b/crates/drives/src/types.rs
@@ -114,6 +114,17 @@ pub const FLAG_ACCEL: u8 = 8;
 pub struct FlagRun {
     pub flags: u8,
     pub frames: u32,
+    /// Max |SEI speed| (m/s, 1 decimal) within this run's frames —
+    /// frame-space speed evidence for the summon detector. The park
+    /// splitter's fraction→point slice overshoots on deduped points, so
+    /// a summon segment's *stats* can inherit the following drive's
+    /// speed samples (observed live 2026-07-27 00:34: a 6 mph summon
+    /// read 9 mph); per-run maxima confine the speed gate to the
+    /// segment's own frames. `None` on runs written before this
+    /// evidence existed — the detector then falls back to drive stats.
+    /// Mirrors Sentry-Drive's `computeFlagRuns(flags, speeds)`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_mps: Option<f64>,
 }
 
 /// A single clip's extracted route data (stored in SQLite).
@@ -142,16 +153,6 @@ pub struct Route {
     /// detector treats such drives as unverifiable, never as summon.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub flag_runs: Vec<FlagRun>,
-    /// v16: max |SEI speed| (m/s) inside each gear run, parallel to
-    /// `gear_runs`. Park splits always land on gear-run boundaries, so a
-    /// split segment's true max speed is the max over its runs — this is
-    /// what lets a summon crawl that shares a clip with fast human
-    /// driving keep its own speed evidence (real case: 2026-07-27 20:04,
-    /// summon ends and the human drives off seconds later in the same
-    /// clip). Empty when unknown (pre-v16 rows, imports); consumers fall
-    /// back to the clip-level `sei_speed_abs_max`.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub gear_run_speed_max: Vec<f32>,
     /// Provenance: "sei" (native dashcam) or "tessie" (imported from Tessie).
     /// Absent / null defaults to "sei" for backwards compatibility.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -486,7 +487,6 @@ pub struct ExtractedGps {
     pub raw_frame_count: u32,
     pub gear_runs: Vec<GearRun>,
     pub flag_runs: Vec<FlagRun>,
-    pub gear_run_speed_max: Vec<f32>,
 }
 
 /// Processing progress status.
@@ -628,10 +628,6 @@ pub struct RouteSummary {
     /// written before flag extraction — those drives are summon-
     /// unverifiable by definition.
     pub flag_runs: Vec<FlagRun>,
-    /// v16: per-gear-run max |SEI speed| (see [`Route::gear_run_speed_max`]).
-    /// Empty when unknown; summon evidence then falls back to the
-    /// clip-level `sei_speed_abs_max`.
-    pub gear_run_speed_max: Vec<f32>,
     pub aggregates: RouteAggregates,
     /// Provenance carried through for grouping: "sei" or "tessie".
     pub source: Option<String>,

--- a/crates/drives/src/types.rs
+++ b/crates/drives/src/types.rs
@@ -89,6 +89,33 @@ pub struct GearRun {
     pub frames: u32,
 }
 
+// -----------------------------------------------------------------------------
+// Per-frame SEI flag bits (SeiMetadata fields 7/8/9, plus the derived accel
+// bit). Mirrors Sentry-Drive's drive-calc.cjs FLAG_* constants exactly.
+// -----------------------------------------------------------------------------
+
+/// blinker_on_left (steady switch state, not lamp flash).
+pub const FLAG_BLINKER_LEFT: u8 = 1;
+/// blinker_on_right.
+pub const FLAG_BLINKER_RIGHT: u8 = 2;
+/// brake_applied (pedal-only; summon's own braking never sets it).
+pub const FLAG_BRAKE: u8 = 4;
+/// accelerator_pedal_position > 0 (human-only input).
+pub const FLAG_ACCEL: u8 = 8;
+
+/// A contiguous run of a single per-frame SEI flag byte.
+///
+/// Carried per clip as `flagRuns`: an RLE over RAW SEI frame indices —
+/// the same frame space as `gearRuns`, deliberately computed BEFORE GPS
+/// point dedup. A stationary car with hazards on produces few unique GPS
+/// points, and the summon detector needs those frames, not the survivors.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FlagRun {
+    pub flags: u8,
+    pub frames: u32,
+}
+
 /// A single clip's extracted route data (stored in SQLite).
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -110,6 +137,11 @@ pub struct Route {
     pub raw_frame_count: u32,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub gear_runs: Vec<GearRun>,
+    /// Per-frame SEI flag RLE in RAW frame space (see [`FlagRun`]). Absent
+    /// on routes written before flag extraction existed — the summon
+    /// detector treats such drives as unverifiable, never as summon.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub flag_runs: Vec<FlagRun>,
     /// Provenance: "sei" (native dashcam) or "tessie" (imported from Tessie).
     /// Absent / null defaults to "sei" for backwards compatibility.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -163,6 +195,8 @@ pub struct Route {
 }
 
 fn u32_is_zero(n: &u32) -> bool { *n == 0 }
+
+fn bool_is_false(b: &bool) -> bool { !*b }
 
 /// One telemetry temperature sample inside a clip's 60s window —
 /// uploaded with the route blob so the cloud can chart the drive's
@@ -235,6 +269,11 @@ pub struct Drive {
     pub tacc_distance_mi: f64,
     // Assisted aggregate
     pub assisted_percent: f64,
+    /// Summon / Smart Summon drive (see `grouper::detect_summon`).
+    /// Emitted only when true, matching Sentry-Drive's
+    /// `...(summon ? { summon: true } : {})`.
+    #[serde(default, skip_serializing_if = "bool_is_false")]
+    pub summon: bool,
     // Provenance
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source: Option<String>,
@@ -284,6 +323,11 @@ pub struct DriveSummary {
     pub tacc_distance_mi: f64,
     // Assisted aggregate
     pub assisted_percent: f64,
+    /// Summon / Smart Summon drive (see `grouper::detect_summon`).
+    /// Emitted only when true, matching Sentry-Drive's
+    /// `...(summon ? { summon: true } : {})`.
+    #[serde(default, skip_serializing_if = "bool_is_false")]
+    pub summon: bool,
     // ── v6 BLE telemetry rollup ────────────────────────────────────────
     // Aggregated across the drive's clips from `telemetry_samples`.
     // All optional — pre-telemetry drives, drives that never crossed a
@@ -431,6 +475,7 @@ pub struct ExtractedGps {
     pub raw_park_count: u32,
     pub raw_frame_count: u32,
     pub gear_runs: Vec<GearRun>,
+    pub flag_runs: Vec<FlagRun>,
 }
 
 /// Processing progress status.
@@ -510,6 +555,14 @@ pub struct RouteAggregates {
     pub start_lng: Option<f64>,
     pub end_lat: Option<f64>,
     pub end_lng: Option<f64>,
+    /// v16: max **absolute** SEI speed (m/s) across the clip's samples,
+    /// `None` when the clip has no SEI speed channel. The locked
+    /// `max_speed_mps` drops negative (Reverse) samples; summon detection
+    /// needs the magnitude — a reverse-only summon crawl would otherwise
+    /// read 0 m/s and fail the `> 0` gate. Also distinguishes SEI from
+    /// GPS-derived speed, which jitters past walking pace on a car that
+    /// barely moved (mirrors Sentry-Drive's `hasSeiSpeeds` gate).
+    pub sei_speed_abs_max: Option<f64>,
 }
 
 /// Per-clip telemetry rollup populated from `telemetry_samples` rows
@@ -560,6 +613,10 @@ pub struct RouteSummary {
     pub raw_park_count: u32,
     pub raw_frame_count: u32,
     pub gear_runs: Vec<GearRun>,
+    /// Raw-frame-space SEI flag RLE (see [`FlagRun`]). Empty on rows
+    /// written before flag extraction — those drives are summon-
+    /// unverifiable by definition.
+    pub flag_runs: Vec<FlagRun>,
     pub aggregates: RouteAggregates,
     /// Provenance carried through for grouping: "sei" or "tessie".
     pub source: Option<String>,

--- a/web/src/lib/drive-stats.ts
+++ b/web/src/lib/drive-stats.ts
@@ -64,6 +64,13 @@ export function computeFilteredStats(
       tessieCount += 1
       continue
     }
+    // Summon drives count in the top-line totals but never in FSD
+    // analytics (matches the backend filters and Sentry-Drive's
+    // aggregate builder): the car drives itself with autopilot_state
+    // unset, so they'd dilute the score as fake "0% FSD" drives.
+    if (d.summon) {
+      continue
+    }
     // Every FSD/AP-attributed metric is SEI-only. Imported autopilot
     // distance/time fields carry *inferred* numbers (not from dashcam
     // SEI telemetry), so summing them into the numerator while the

--- a/web/src/types/drives.ts
+++ b/web/src/types/drives.ts
@@ -49,6 +49,8 @@ export interface DriveSummary {
   source?: string
   externalSignature?: string
   tessieAutopilotPercent?: number
+  /** Detected Summon / Smart Summon drive — present only when true. */
+  summon?: boolean
 }
 
 export interface FsdEvent {


### PR DESCRIPTION
## What does this PR do?

Two related changes in `crates/drives`, verified against real footage on the archive (2026-07-29):

### 1. Bug fix: gearRuns silently dropped short trailing Park runs

`compute_gear_runs` ran **after** GPS dedup. A car coming to a stop has a frozen GPS fix, so every trailing Park frame deduped into the last Drive-gear point and the Park run vanished. Live proof from the archive `drive-data.json`: the route for `2026-07-15/2026-07-15_20-50-43-front.mp4` stored `gearRuns:[{"gear":1,"frames":120}]` — a single Drive run summing to the *deduped point count* — while its own `rawParkCount:53` / `rawFrameCount:553` show the extractor saw 53 Park frames. The park-gap splitter therefore never separated the Summon segment from the drive that followed, fusing them into one drive.

Both RLEs now run over **raw SEI frames before dedup** (`assemble_extracted`), matching the frame-domain contract the rest of the crate already assumed (aggregate.rs park intervals, the splitter's `seconds_per_frame`, `SubClipSummary` bounds) and matching Sentry-Drive's worker. Re-extracting the real clip now yields `[Drive x500, Park x53]` — byte-identical to Sentry-Drive's extractor. Trailing frames of a short final clip are real data, not junk.

### 2. Summon detection, ported from Sentry-Drive (drive-calc.cjs / grouper.js)

- **Extraction:** SEI protobuf varint fields 7/8/9 (`blinker_on_left`, `blinker_on_right`, `brake_applied`; proto3 absent = off) → per-frame flags byte (L=1, R=2, BRAKE=4, ACCEL=8 when accel>0), RLE'd as `flagRuns` over raw frame indices — same frame space as `gearRuns`, immune to GPS dedup. Each run also carries **`maxMps`**, the max |SEI speed| within its own frames (1 decimal, Reverse counts via magnitude) — mirroring Drive's `computeFlagRuns(flags, speeds)`.
- **Persistence:** schema v16 adds `flag_runs_blob` (1-byte flags + LE i32 frames + LE f32 maxMps per run; NaN = maxMps unknown) and `sei_speed_abs_max`. The abs-max column exists because the locked `max_speed_mps` drops negative (Reverse) SEI samples — a reverse-only summon crawl would read 0 m/s — and because GPS-derived speed jitters past walking pace on a car that barely moved; it feeds the detector's legacy fallback. `flagRuns` round-trips `drive-data.json` import/export bit-faithfully, including per-run `maxMps` presence/absence; routes without flagRuns stay absent (never an empty array).
- **Detection** (`grouper::detect_summon`): every clip of the drive must carry flagRuns (unverifiable = not summon); no BRAKE/ACCEL bit anywhere in the drive's segment frame ranges; hazards = L and R in the **same** run within 10 s-of-frames of the first segment's start AND the last segment's end (park-split `SubClipSummary` bounds); duration ≤ 10 min. The **speed gate is frame-accurate**: max over per-run `maxMps` of the flag runs overlapping each segment, ≤ **4.5 m/s** — Tesla caps summon at ~6 mph on older firmware and **8 mph (3.58 m/s) on newer cars**, and 4.5 gives the 8 mph ceiling the same headroom the old 3.5 gate gave 6 mph. Runs written before `maxMps` fall back to the clip-level abs max + `has_sei_speeds`. `autopilot_state` is deliberately not consulted (stays 0 during summon).
- **Surface:** `DriveSummary.summon` (computed on the summary path, which owns the segment bounds) serialized as `"summon":true` only when true; the single-drive endpoint overlays it onto `Drive` exactly like the other headline stats.

### Why frame-accurate speed (synced with Drive, 2026-07-30)

Two real drives from 2026-07-27 broke clip-level speed evidence, both shapes where the summon shares a clip with the human driving off seconds later:

- **20:04** — summon ends, human departs at 5.4 m/s in the same clip; a whole-clip max wrongly rejects the summon.
- **00:34** — in Drive, the park splitter's fraction→point slice overshoots on deduped points, so the summon's *stats* inherited the following drive's samples (a 6 mph summon read 9 mph / 4.05 m/s).

Drive's fix (mirrored here exactly) attaches `maxMps` to each flag run so the detector gates speed in frame space, immune to both failure modes. An interim commit on this branch solved 20:04 with a per-**gear**-run maxima column (`gear_run_speed_blob`); it was replaced wholesale by Drive's per-**flag**-run design before merge — v16 was unreleased, so the column is gone, not migrated. Rows without `maxMps` stay conservative: the whole-clip fallback may leave a shared-clip summon unflagged (never wrongly flagged) until reprocessed.

Deliberately **not** ported: Drive's locked display speed stats switched to SEI magnitude (their comment marks it "deliberate divergence from Rusty"); Rusty's locked stats stay untouched — only the summon evidence channels are magnitude-based, which is what detector parity actually requires. Drive's "Check for Summon" backfill is Drive-side tooling compensating for the pre-fix Rusty bug; nothing to port, this PR fixes the bug at the source.

### Summon drives are excluded from the FSD score

A summon drive is driverless with `autopilot_state` unset, so it would read as a fake "0% FSD" drive — diluting the distance-weighted score and padding the per-drive disengagement averages. Mirroring Sentry-Drive's aggregate builder, summon drives still count in top-line totals (drive count, mileage, duration) but are dropped from every FSD-analytics numerator and denominator, on all three surfaces that compute the ratios: the `drive_stats` cache (`/api/drives/stats`), `build_fsd_analytics` (`/api/drives/fsd-analytics`), and the web client's `computeFilteredStats` (which also gains the `summon` field on its `DriveSummary` type). Covered by a test where a 100%-FSD commute plus a summon must score 100.0, not 98.5.

### Verification

- **197 crate tests pass**, including every summon vector from Drive's `drive-calc.test.js` and `grouper.test.js` as of 2026-07-30: `computeFlagRuns` maxMps semantics, `segmentMaxSpeed` (straddling runs, legacy-null), the polluted-stats override (unit + e2e 00:34 shape), the 20:04 reverse-summon split, the conservative no-maxMps fallback, locked constants (4.5 gate), plus the raw-frame trailing-Park regression and the FSD-score exclusion.
- Real footage, via `examples/probe_clip.rs` (now printing per-flag-run maxMps):
  - `2026-07-15_20-49-54` + `20-50-43` (actual Smart Summon): hazards span both gear transitions, flagRuns match Drive's probe fixtures, max SEI 2.69 m/s → **summon**.
  - `2026-07-27_00-34-31` + `00-34-59` (the polluted-stats summon), re-probed off the archive share with the final maxMps extractor: clip A matches Drive's committed fixture **exactly** — frames and maxMps (`[(0,7,0.0),(3,144,0.1),(0,766,2.7)]`); clip B's summon-segment runs match exactly too (`2.7/2.6/2.0/1.8` before the park → segment max 2.7 ≤ 4.5), with only the post-summon human-tail approximations differing from Drive's idealized fixture — frames outside the summon segment, no effect on the verdict.
  - `2026-07-27_20-04-00` + `20-04-46`, same re-probe: summon segment of the shared clip reads per-run maxima 0.4/0.3/0.0 while the clip peaks at 5.4 m/s in the human's departure; every pedal bit sits after the park split. Drive's fixture coarsens the real run shapes slightly (e.g. real hazard tail `[(2,82),(3,33),(2,3),(3,51)]` vs fixture `[(2,81),(3,89)]`); the tests keep Drive's vectors verbatim as the parity contract since the detector's verdict is identical on both.
  - `2026-07-28_21-05-46` (FSD arrival + human reposition): brake/accel pedal runs, 8.78 m/s, individual blinkers only — rejected independently by all three gates → **not summon**.

### Reviewer notes

- `sentryusb-api` (one-line overlay in `drives_handler.rs`) can't compile on Windows (unix-only deps in its tree) — verified by inspection here; CI's Linux build is the check.
- `cargo fmt` intentionally not run: the crate's baseline is hand-formatted and not rustfmt-clean, so a blanket format would bury this diff in unrelated churn. New code matches the surrounding style; clippy warnings introduced by this change were fixed (remaining ones pre-date it).
- DB migration is additive + nullable (v15 → v16), no backfill: flags only exist in the MP4 SEI stream, so pre-v16 rows are simply unverifiable — by design. The v16 `flag_runs_blob` stride changed 5 → 9 bytes mid-branch; v16 has never shipped, so no deployed DB carries the old stride.

## Checklist

- [x] I ran `cargo fmt --all` and `cargo clippy` — clippy yes (no new warnings from this change); fmt deliberately skipped, see reviewer notes
- [x] I have read and agree to the [Contributor License Agreement](../blob/main/CLA.md) (the CLA Assistant bot will prompt me to sign)
- [x] If this PR touches MIT-derived scripts listed in [NOTICE](../blob/main/NOTICE), I noted it above so the license boundary is preserved — no scripts touched (Rust crates only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
