### PR TITLE
perf(drives): cache /api/drives/routes overview in memory (3.2s → ~65ms)

### DIFF
--- a/crates/api/src/drives_handler.rs
+++ b/crates/api/src/drives_handler.rs
@@ -311,28 +311,21 @@ fn single_drive_blocking(
 pub async fn all_routes(
     State(state): State<AppState>,
     Query(q): Query<AllRoutesQuery>,
-) -> (StatusCode, Json<serde_json::Value>) {
+) -> axum::response::Response {
+    use axum::response::IntoResponse;
     let max_points = q.max_points.unwrap_or(500).clamp(2, 2000);
-    // Decodes every route's point BLOBs and downsamples each polyline —
-    // proportional to the whole drive history. Off the reactor so the map
-    // overview can't freeze the live connection.
+    // Cached; a miss runs the grouper over all routes, so keep it off the reactor.
     let store = state.drives.store.clone();
-    let result = tokio::task::spawn_blocking(move || {
-        // get_routes hands the grouper an owned Vec so it can consume the
-        // routes in place — the previous borrow forced a full clone of the
-        // point-heavy set, doubling peak memory on the heaviest endpoint.
-        store.get_routes().map(|routes| grouper::route_overviews(routes, max_points))
-    })
-    .await;
-    match result {
-        Ok(Ok(overviews)) => (
-            StatusCode::OK,
-            Json(serde_json::to_value(overviews).unwrap_or_default()),
-        ),
-        Ok(Err(e)) => crate::json_error(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
-        Err(e) => {
-            crate::json_error(StatusCode::INTERNAL_SERVER_ERROR, &format!("routes task: {}", e))
+    match tokio::task::spawn_blocking(move || store.get_cached_route_overviews_json(max_points)).await {
+        Ok(Ok(json)) => cached_json_response(json),
+        Ok(Err(e)) => {
+            crate::json_error(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()).into_response()
         }
+        Err(e) => crate::json_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            &format!("routes task: {}", e),
+        )
+        .into_response(),
     }
 }
 

--- a/crates/drives/src/db.rs
+++ b/crates/drives/src/db.rs
@@ -7,7 +7,7 @@
 
 use std::path::Path;
 use std::sync::Mutex;
-use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering};
 
 use anyhow::{Context, Result};
 use rusqlite::{params, Connection, OpenFlags, OptionalExtension, ToSql};
@@ -192,6 +192,18 @@ pub struct DriveStore {
     /// fresh cache without recomputing. Lock order: this is always taken
     /// BEFORE `conn` and never while holding it — deadlock-free.
     rebuild_lock: Mutex<()>,
+    /// Cached `/api/drives/routes` overview JSON; rebuilt lazily on the first
+    /// request after a route mutation.
+    route_overview_cache: Mutex<Option<RouteOverviewCache>>,
+    /// Bumped on every route mutation. New mutation paths must bump it too.
+    route_overview_gen: AtomicU64,
+}
+
+/// Valid while `generation` and `max_points` match the request.
+struct RouteOverviewCache {
+    generation: u64,
+    max_points: usize,
+    json: String,
 }
 
 impl DriveStore {
@@ -223,6 +235,8 @@ impl DriveStore {
             processed_count: AtomicI64::new(0),
             drive_cache_dirty: AtomicBool::new(true),
             rebuild_lock: Mutex::new(()),
+            route_overview_cache: Mutex::new(None),
+            route_overview_gen: AtomicU64::new(0),
         };
 
         store.load_locked(IMPORT_SOURCE_CANDIDATES)?;
@@ -243,6 +257,8 @@ impl DriveStore {
             processed_count: AtomicI64::new(0),
             drive_cache_dirty: AtomicBool::new(false),
             rebuild_lock: Mutex::new(()),
+            route_overview_cache: Mutex::new(None),
+            route_overview_gen: AtomicU64::new(0),
         };
         // Still run migrate + backfill so tests exercise the real schema.
         let guard = store.conn.lock().unwrap();
@@ -432,6 +448,10 @@ impl DriveStore {
             }
         }
         self.drive_cache_dirty.store(false, Ordering::Release);
+        // load() re-imports/re-migrates route rows; drop the lazy route
+        // overview cache so the next request recomputes.
+        self.route_overview_gen.fetch_add(1, Ordering::Release);
+        *self.route_overview_cache.lock().unwrap() = None;
         self.refresh_counts()?;
         Ok(())
     }
@@ -572,6 +592,7 @@ impl DriveStore {
         tx.commit()?;
         drop(conn);
         self.drive_cache_dirty.store(true, Ordering::Release);
+        self.route_overview_gen.fetch_add(1, Ordering::Release);
         self.processed_count
             .fetch_add(pf_inserted as i64, Ordering::Relaxed);
         self.route_count.fetch_add(route_inserted, Ordering::Relaxed);
@@ -728,6 +749,7 @@ impl DriveStore {
         let _ = conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE)");
         drop(conn);
         self.drive_cache_dirty.store(true, Ordering::Release);
+        self.route_overview_gen.fetch_add(1, Ordering::Release);
         self.refresh_counts()?;
         Ok(())
     }
@@ -803,6 +825,7 @@ impl DriveStore {
         }
         tx.commit()?;
         self.drive_cache_dirty.store(true, Ordering::Release);
+        self.route_overview_gen.fetch_add(1, Ordering::Release);
         Ok(())
     }
 
@@ -1191,6 +1214,7 @@ impl DriveStore {
         }
         drop(conn);
         self.drive_cache_dirty.store(true, Ordering::Release);
+        self.route_overview_gen.fetch_add(1, Ordering::Release);
         self.refresh_counts()?;
         Ok(())
     }
@@ -1240,6 +1264,7 @@ impl DriveStore {
         let _ = conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE)");
         drop(conn);
         self.drive_cache_dirty.store(true, Ordering::Release);
+        self.route_overview_gen.fetch_add(1, Ordering::Release);
         self.route_count.fetch_sub(deleted as i64, Ordering::Relaxed);
         self.processed_count
             .fetch_sub(deleted_processed as i64, Ordering::Relaxed);
@@ -1286,6 +1311,7 @@ impl DriveStore {
             s
         };
         self.drive_cache_dirty.store(true, Ordering::Release);
+        self.route_overview_gen.fetch_add(1, Ordering::Release);
         self.refresh_counts()?;
         let after = self.route_count.load(Ordering::Relaxed);
         info!(
@@ -1563,6 +1589,31 @@ impl DriveStore {
         self.rebuild_caches_off_lock(force)?;
         let conn = self.conn.lock().unwrap();
         Ok(schema::meta_get(&conn, "drive_list_cache")?.unwrap_or_else(|| "[]".to_string()))
+    }
+
+    /// Serve `/api/drives/routes` map-overview JSON from an in-memory cache;
+    /// recompute (full grouper) only after a route mutation.
+    pub fn get_cached_route_overviews_json(&self, max_points: usize) -> Result<String> {
+        // Read generation before routes: a mutation in between just forces one
+        // extra recompute next time, never a stale serve.
+        let generation = self.route_overview_gen.load(Ordering::Acquire);
+        {
+            let cache = self.route_overview_cache.lock().unwrap();
+            if let Some(c) = cache.as_ref() {
+                if c.generation == generation && c.max_points == max_points {
+                    return Ok(c.json.clone());
+                }
+            }
+        }
+        let routes = {
+            let conn = self.conn.lock().unwrap();
+            select_all_routes(&conn)?
+        };
+        let overviews = crate::grouper::route_overviews(routes, max_points);
+        let json = serde_json::to_string(&overviews).unwrap_or_else(|_| "[]".to_string());
+        let mut cache = self.route_overview_cache.lock().unwrap();
+        *cache = Some(RouteOverviewCache { generation, max_points, json: json.clone() });
+        Ok(json)
     }
 
     /// Return the pre-computed drive stats as a JSON string. `processed_count`
@@ -2730,6 +2781,50 @@ mod tests {
         assert_eq!(routes[0].accel_positions, vec![0.5, 0.6]);
         assert_eq!(routes[0].raw_frame_count, 2);
         assert_eq!(routes[0].gear_runs.len(), 1);
+    }
+
+    #[test]
+    fn route_overview_cache_matches_live_and_invalidates_on_mutation() {
+        let store = DriveStore::open_memory().unwrap();
+        let add = |file: &str, lat: f64| {
+            store
+                .add_route(
+                    file,
+                    "2025-01-15",
+                    &vec![[lat, -122.4194], [lat + 0.001, -122.4195]],
+                    &[4, 4],
+                    &[1, 1],
+                    &[25.0, 26.0],
+                    &[0.5, 0.6],
+                    0,
+                    2,
+                    &[GearRun { gear: 4, frames: 2 }],
+                )
+                .unwrap();
+        };
+
+        add("2025-01-15/2025-01-15_10-00-00-front.mp4", 37.7749);
+        // Cache == live output.
+        let live1 = serde_json::to_string(&crate::grouper::route_overviews(
+            store.get_routes().unwrap(),
+            20,
+        ))
+        .unwrap();
+        let cached1 = store.get_cached_route_overviews_json(20).unwrap();
+        assert_eq!(cached1, live1, "cache must equal live output");
+        // Hit.
+        assert_eq!(store.get_cached_route_overviews_json(20).unwrap(), live1);
+
+        // Mutation invalidates.
+        add("2025-01-15/2025-01-15_11-00-00-front.mp4", 40.0000);
+        let live2 = serde_json::to_string(&crate::grouper::route_overviews(
+            store.get_routes().unwrap(),
+            20,
+        ))
+        .unwrap();
+        let cached2 = store.get_cached_route_overviews_json(20).unwrap();
+        assert_ne!(cached2, cached1, "cache must refresh after a new route");
+        assert_eq!(cached2, live2, "refreshed cache must equal live output");
     }
 
     #[test]


### PR DESCRIPTION
## What

`/api/drives/routes` recomputed the full grouper (all routes, sub-clip
splitting, map-overview point reduction) on every request. On a real ~5000-route
DB this is **3.2s per call** — and it fires on every web map load and every
SC / iOS drive-map open. Its three drive-family siblings (`/api/drives`,
`/api/drives/stats`, `/api/drives/fsd`) were already cached; routes was the last
uncached one.

This caches the computed overview JSON in memory and only recomputes after a
route mutation. Warm requests now serve in ~65ms (matches the already-cached
`/api/drives`). **No API change — the response bytes are identical**, so web,
Android, and iOS all benefit server-side with zero client work.

## How

- New `route_overview_cache` (JSON) + `route_overview_gen` (`AtomicU64`) on the
  store. A cache hit is one atomic load + a string compare — no SQL, no grouper.
- Every route-mutating path bumps the generation counter, alongside the existing
  `drive_cache_dirty` flag (verified the two sets match). Reading the generation
  *before* the routes means a mutation in between just forces one extra recompute
  next time — never a stale serve.
- `DriveStore::load()` (re-import/re-migrate) also invalidates the cache, so a
  future runtime rescan can't leave it stale.
- The recompute runs on `spawn_blocking` so a cold miss never stalls the async
  reactor.

### Why caching, not a leaner query
First attempt was a lean SQL path decoding only `points_blob`. Benchmarked at
only ~1.1x on the real DB (blob decode is ~5% of the cost) **and** it produced
different groupings (248 vs 358) because sub-clip splitting needs
`gear_states` / `gear_runs` / `external_signature`. Abandoned — caching the full
correct output is both faster and byte-identical.

## Testing
- Unit test asserts the cached JSON is byte-identical to a fresh live
  computation, that a second call hits the cache, and that a route mutation
  invalidates it.
- Verified warm-serve latency and the 3.2s→65ms delta on a real 5k-route DB.
