### PR TITLE
fix(4c+): stop relinking WiFi NVRAM to AP6256 (TX collapse) + heal existing boxes

### DIFF
--- a/install-pi.sh
+++ b/install-pi.sh
@@ -513,17 +513,9 @@ DTS
         warn "BCM4345C0 .hcd not found — 'apt install --reinstall armbian-firmware', then"
         warn "symlink BCM4345C0.radxa,rock-4c-plus.hcd → the generic BCM4345C0 .hcd."
     fi
-    if [ -e "$BRCM/nvram_ap6256.txt" ]; then
-        ln -sf nvram_ap6256.txt "$BRCM/brcmfmac43455-sdio.radxa,rock-4c-plus.txt"
-        [ -e "$BRCM/brcmfmac43455-sdio.bin" ] && \
-            ln -sf brcmfmac43455-sdio.bin "$BRCM/brcmfmac43455-sdio.radxa,rock-4c-plus.bin"
-        [ -e "$BRCM/brcmfmac43455-sdio.clm_blob" ] && \
-            ln -sf brcmfmac43455-sdio.clm_blob "$BRCM/brcmfmac43455-sdio.radxa,rock-4c-plus.clm_blob"
-        ok "WiFi nvram → nvram_ap6256.txt (AP6256 calibration) — WiFi now survives BT"
-        NEEDS_REBOOT=1
-    else
-        warn "nvram_ap6256.txt not found — WiFi may be unstable with BT (generic calibration)."
-    fi
+    # No WiFi NVRAM relink: nvram_ap6256.txt collapses 4C+ TX to ~6 Mbit/s
+    # (sole TX-power source, no txcap_blob). Driver falls back to the generic
+    # brcmfmac43455-sdio.txt. BT coexistence is the .hcd patch above, not this.
 
     # 4. (Recommended) OpenSSH instead of Dropbear — Dropbear ships no SFTP
     #    subsystem, so scp/sftp to the Pi fail.

--- a/setup/pi/apply-runtime-patches.sh
+++ b/setup/pi/apply-runtime-patches.sh
@@ -862,6 +862,37 @@ RCLONEREACH_EOF
     log "rclone-watchdog: archive scripts refreshed (probe ARCHIVE_SERVER, scoped kill)"
 }
 
+# ── Rock 4C+ WiFi NVRAM: remove the TX-collapsing AP6256 relink ──────────
+# The old 4C+ installer symlinked the board WiFi NVRAM to nvram_ap6256.txt,
+# which collapses TX to ~6 Mbit/s (sole TX-power source, no txcap_blob).
+# Remove it → driver falls back to the generic brcmfmac43455-sdio.txt. Heals
+# existing boxes on OTA (reboots on completion). BT coexistence is the .hcd
+# patch, not this.
+apply_4cplus_wifi_nvram_fix() {
+    is_rock_4cplus || return 0
+    local brcm=/lib/firmware/brcm
+    local link="$brcm/brcmfmac43455-sdio.radxa,rock-4c-plus.txt"
+    # Only our exact relink (symlink -> nvram_ap6256.txt); leave anything else alone.
+    [ -L "$link" ] || { log "4c+ wifi nvram: no board relink — generic in use"; return 0; }
+    if [ "$(basename "$(readlink "$link")")" != "nvram_ap6256.txt" ]; then
+        log "4c+ wifi nvram: board .txt not the AP6256 relink — leaving as-is"
+        return 0
+    fi
+    # Re-lock only if we unlocked (leave root as found).
+    local ro_before=no
+    findmnt -no OPTIONS / 2>/dev/null | grep -qE '(^|,)ro(,|$)' && ro_before=yes
+    [ -x /root/bin/remountfs_rw ] && /root/bin/remountfs_rw >/dev/null 2>&1 || true
+    if rm -f "$link" 2>/dev/null; then
+        log "4c+ wifi nvram: removed AP6256 relink → generic fallback (REBOOT to apply)"
+    else
+        err "4c+ wifi nvram: could not remove $link (read-only fs? check remountfs_rw)"
+    fi
+    if [ "$ro_before" = yes ]; then
+        sync
+        mount -o remount,ro / 2>/dev/null || true
+    fi
+}
+
 # ── Run all patches ─────────────────────────────────────────────────────
 
 apply_ble_nonfatal_adv
@@ -871,6 +902,7 @@ apply_backingfiles_bfq
 apply_hardware_watchdog
 apply_archive_mount_lock_scripts
 apply_rfkill_unblock_wifi
+apply_4cplus_wifi_nvram_fix
 apply_rclone_config_mutable_migration
 apply_rclone_watchdog_fix
 


### PR DESCRIPTION
## What

On the Rock 4C+, the installer symlinked the board-specific WiFi NVRAM
(`brcmfmac43455-sdio.radxa,rock-4c-plus.txt`) to `nvram_ap6256.txt`. That file's
calibration collapses **transmit** to ~6 Mbit/s (lowest OFDM rate) with packet
loss, while receive stays fine. The chip has no `txcap_blob`
(`brcmf_c_process_txcap_blob: no txcap_blob available (err=-2)`), so the NVRAM is
the *sole* TX-power source — a wrong NVRAM tanks TX only.

Removing the relink lets the driver fall back to the distro's generic
`brcmfmac43455-sdio.txt`, which is correct here.

Field testing across multiple 4C+ boards, reverting to the generic NVRAM:
- signal −58/−66 → −53 dBm
- TX 6 → 24 Mbit/s
- RX 81 → 200 Mbit/s
- 5-min ping: packet loss → **zero**

Affects every 4C+ that ran the installer with WiFi in use since 4C+ support
landed. Ethernet-only boxes are unaffected.

## How — two parts

1. **New installs** (`install-pi.sh`) — drop the WiFi NVRAM relink block. The
   BT `.hcd` generic patch is untouched (that's what fixes WiFi-survives-BT
   coexistence; it is separate from this NVRAM).

2. **Existing boxes** (`setup/pi/apply-runtime-patches.sh`) — new
   `apply_4cplus_wifi_nvram_fix` runs on every OTA. It's reactive and
   board-gated: only acts on a 4C+ where the symlink points at exactly
   `nvram_ap6256.txt`; a real file or any other target is left alone. Handles
   RO-root (unlock via `remountfs_rw`, re-lock only if we unlocked). OTA reboots
   on completion, so the fix loads immediately.

Both halves gate on `is_rock_4cplus()` (device-tree model), so this covers
DietPi and Armbian equally — it keys on the board, not the OS.

## Testing
- Removal + regeneration verified on a 4C+; `bash -n` clean on both scripts.
- Reactive patch is a no-op on non-4C+ and on boards that never got the relink.
