### PR TITLE
feat(api): add /api/profile vehicle-identity endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2015,7 +2015,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.25.13+spec-1.1.0",
 ]
 
 [[package]]
@@ -2635,6 +2635,7 @@ dependencies = [
  "sentryusb-notify",
  "sentryusb-setup",
  "sentryusb-shell",
+ "sentryusb-vehicle-profile",
  "sentryusb-ws",
  "serde",
  "serde_json",
@@ -2807,6 +2808,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sentryusb-vehicle-profile"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "regex",
+ "sentryusb-config",
+ "serde",
+ "toml",
+ "tracing",
+]
+
+[[package]]
 name = "sentryusb-ws"
 version = "0.1.0"
 dependencies = [
@@ -2880,6 +2894,15 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -3294,6 +3317,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3304,14 +3348,28 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -3320,8 +3378,14 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.4",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -3991,6 +4055,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "crates/sentryusb",
     "crates/config",
+    "crates/vehicle_profile",
     "crates/shell",
     "crates/ws",
     "crates/drives",

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -29,6 +29,7 @@ tokio-util = { version = "0.7", features = ["io"] }
 rusqlite = { version = "0.40", features = ["bundled", "chrono", "blob"] }
 
 sentryusb-config = { path = "../config", package = "sentryusb-config" }
+sentryusb-vehicle-profile = { path = "../vehicle_profile", package = "sentryusb-vehicle-profile" }
 sentryusb-shell = { path = "../shell", package = "sentryusb-shell" }
 sentryusb-ws = { path = "../ws", package = "sentryusb-ws" }
 sentryusb-drives = { path = "../drives", package = "sentryusb-drives" }

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -30,6 +30,7 @@ pub mod snapshots;
 pub mod keep_accessory;
 pub mod charging;
 pub mod storage_repair;
+pub mod profile;
 
 pub use auth::{AuthState, init_auth};
 pub use router::build_router;

--- a/crates/api/src/profile.rs
+++ b/crates/api/src/profile.rs
@@ -1,0 +1,26 @@
+//! Active vehicle profile as a client needs it: identity (so SC knows this is
+//! a Tesla/SentryUSB box vs a GM/Dash-USB one), camera set + playback grid for
+//! the viewer, and the filename pattern for client-side grouping. Same shape
+//! the Dash-USB sibling serves at `/api/profile`.
+
+use axum::http::StatusCode;
+use axum::Json;
+
+use sentryusb_vehicle_profile::Profile;
+
+pub async fn get_profile() -> (StatusCode, Json<serde_json::Value>) {
+    let p = Profile::active();
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({
+            "id": p.profile.id,
+            "display_name": p.profile.display_name,
+            "brand": p.profile.brand,
+            "cameras": p.cameras,
+            "grid": p.viewer.grid,
+            "filename_regex": p.recording.filename_regex,
+            "segment_seconds": p.recording.segment_seconds,
+            "rolling_window_minutes": p.recording.rolling_window_minutes,
+        })),
+    )
+}

--- a/crates/api/src/router.rs
+++ b/crates/api/src/router.rs
@@ -27,6 +27,7 @@ pub fn build_router(state: AppState) -> Router {
         // Status & config
         .route("/api/status", get(crate::status::get_status))
         .route("/api/status/storage", get(crate::status::get_storage_breakdown))
+        .route("/api/profile", get(crate::profile::get_profile))
         .route("/api/config", get(crate::status::get_config))
         .route("/api/wifi", get(crate::status::get_wifi_config))
         // Auth

--- a/crates/vehicle_profile/Cargo.toml
+++ b/crates/vehicle_profile/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "sentryusb-vehicle-profile"
+version = "0.1.0"
+edition = "2021"
+license-file.workspace = true
+
+[lib]
+name = "sentryusb_vehicle_profile"
+path = "src/lib.rs"
+
+[dependencies]
+sentryusb-config = { path = "../config", package = "sentryusb-config" }
+anyhow = { workspace = true }
+serde = { workspace = true }
+chrono = { workspace = true }
+tracing = { workspace = true }
+regex = "1"
+toml = "0.8"

--- a/crates/vehicle_profile/src/lib.rs
+++ b/crates/vehicle_profile/src/lib.rs
@@ -1,0 +1,258 @@
+//! Vehicle profiles: how a car brand records dashcam footage onto the USB
+//! drive (recording path, filename format, camera set, viewer grid). SentryUSB
+//! is always Tesla; the profile exists so the `/api/profile` endpoint can tell
+//! a client (SC) which ecosystem it's talking to, using the same schema the
+//! Dash-USB sibling serves.
+//!
+//! Profiles are TOML under `profiles/`, embedded at compile time. Add a brand
+//! by adding a file and listing it in [`EMBEDDED`]. `VEHICLE_PROFILE` in the
+//! conf selects one by id; `SENTRYUSB_PROFILE_PATH` overrides with an on-disk
+//! TOML for dev/bench. Anything invalid falls back to the default with a log.
+
+use std::sync::OnceLock;
+
+use anyhow::{Context, Result};
+use chrono::NaiveDate;
+use serde::{Deserialize, Serialize};
+
+pub const DEFAULT_PROFILE_ID: &str = "tesla";
+
+/// Compiled-in profiles, keyed by `profile.id`.
+const EMBEDDED: &[(&str, &str)] = &[("tesla", include_str!("../../../profiles/tesla.toml"))];
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Profile {
+    pub profile: Meta,
+    pub recording: Recording,
+    pub cameras: Vec<Camera>,
+    pub viewer: Viewer,
+    pub virtual_drive: VirtualDrive,
+    pub snapshots: Snapshots,
+    pub features: Features,
+    #[serde(skip)]
+    compiled_regex: OnceLock<regex::Regex>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Meta {
+    pub id: String,
+    pub display_name: String,
+    pub brand: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Recording {
+    /// Recording root inside the virtual drive, relative, no leading slash.
+    pub root: String,
+    /// Must expose named captures `camera`, `y`, `mo`, `d`, `h`, `mi`, `s`.
+    pub filename_regex: String,
+    pub segment_seconds: u32,
+    pub rolling_window_minutes: u32,
+    pub approx_bytes_per_camera_segment: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Camera {
+    pub id: String,
+    pub label: String,
+    #[serde(default)]
+    pub optional: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Viewer {
+    /// Row-major camera grid; empty string = empty cell.
+    pub grid: Vec<Vec<String>>,
+}
+
+/// Not consumed by SentryUSB (it manages its virtual drive via setup config);
+/// present only for schema parity with the Dash-USB profile.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VirtualDrive {
+    pub default_size: String,
+    pub min_size: String,
+    pub min_free_bytes: u64,
+    pub filesystem: String,
+    pub label: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Snapshots {
+    pub default_interval_secs: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Features {
+    pub event_folders: bool,
+    pub archive_everything_default: bool,
+    pub nofua: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClipInfo {
+    /// Camera id exactly as captured (e.g. "front").
+    pub camera: String,
+    pub timestamp: chrono::NaiveDateTime,
+}
+
+impl ClipInfo {
+    /// Date bucket for the recordings tree ("2026-07-17").
+    pub fn date_str(&self) -> String {
+        self.timestamp.format("%Y-%m-%d").to_string()
+    }
+}
+
+impl Profile {
+    pub fn from_toml(s: &str) -> Result<Self> {
+        let p: Profile = toml::from_str(s).context("parsing vehicle profile TOML")?;
+        p.validate()?;
+        Ok(p)
+    }
+
+    fn validate(&self) -> Result<()> {
+        let re = regex::Regex::new(&self.recording.filename_regex)
+            .context("filename_regex does not compile")?;
+        for cap in ["camera", "y", "mo", "d", "h", "mi", "s"] {
+            anyhow::ensure!(
+                re.capture_names().flatten().any(|n| n == cap),
+                "filename_regex missing named capture `{cap}`"
+            );
+        }
+        for row in &self.viewer.grid {
+            for cell in row.iter().filter(|c| !c.is_empty()) {
+                anyhow::ensure!(
+                    self.cameras.iter().any(|c| &c.id == cell),
+                    "viewer.grid references unknown camera `{cell}`"
+                );
+            }
+        }
+        anyhow::ensure!(
+            self.recording.root.starts_with(|c: char| c.is_ascii_alphanumeric()),
+            "recording.root must be a relative path"
+        );
+        Ok(())
+    }
+
+    pub fn embedded(id: &str) -> Option<Result<Self>> {
+        EMBEDDED
+            .iter()
+            .find(|(pid, _)| *pid == id)
+            .map(|(_, s)| Self::from_toml(s))
+    }
+
+    /// The process-wide active profile.
+    ///
+    /// Resolution: `SENTRYUSB_PROFILE_PATH` env (dev/bench override), then the
+    /// `VEHICLE_PROFILE` conf key, then the default. Every failure path logs
+    /// and falls back to the embedded default, which unit tests guarantee
+    /// parses.
+    pub fn active() -> &'static Profile {
+        static ACTIVE: OnceLock<Profile> = OnceLock::new();
+        ACTIVE.get_or_init(|| {
+            if let Ok(path) = std::env::var("SENTRYUSB_PROFILE_PATH") {
+                match std::fs::read_to_string(&path)
+                    .map_err(anyhow::Error::from)
+                    .and_then(|s| Self::from_toml(&s))
+                {
+                    Ok(p) => {
+                        tracing::info!("vehicle profile: {} (from {})", p.profile.id, path);
+                        return p;
+                    }
+                    Err(e) => {
+                        tracing::warn!("SENTRYUSB_PROFILE_PATH={path} unusable ({e:#}); falling back")
+                    }
+                }
+            }
+            let (active, _) = sentryusb_config::parse_file(sentryusb_config::find_config_path())
+                .unwrap_or_default();
+            let id = active
+                .get("VEHICLE_PROFILE")
+                .map(|s| s.trim())
+                .filter(|s| !s.is_empty())
+                .unwrap_or(DEFAULT_PROFILE_ID)
+                .to_string();
+            match Self::embedded(&id) {
+                Some(Ok(p)) => {
+                    tracing::info!("vehicle profile: {}", p.profile.id);
+                    return p;
+                }
+                Some(Err(e)) => tracing::warn!("embedded profile `{id}` invalid ({e:#})"),
+                None => tracing::warn!("VEHICLE_PROFILE=`{id}` unknown; using default"),
+            }
+            Self::embedded(DEFAULT_PROFILE_ID)
+                .expect("default profile is embedded")
+                .expect("default profile parses (covered by unit test)")
+        })
+    }
+
+    pub fn clip_regex(&self) -> &regex::Regex {
+        self.compiled_regex.get_or_init(|| {
+            // validate() already proved this compiles.
+            regex::Regex::new(&self.recording.filename_regex).expect("validated regex")
+        })
+    }
+
+    /// Parse a bare clip filename (no path components) into camera + timestamp.
+    pub fn parse_clip_filename(&self, name: &str) -> Option<ClipInfo> {
+        let caps = self.clip_regex().captures(name)?;
+        let num = |k: &str| caps.name(k).and_then(|m| m.as_str().parse::<u32>().ok());
+        let date = NaiveDate::from_ymd_opt(num("y")? as i32, num("mo")?, num("d")?)?;
+        let ts = date.and_hms_opt(num("h")?, num("mi")?, num("s")?)?;
+        Some(ClipInfo {
+            camera: caps.name("camera")?.as_str().to_string(),
+            timestamp: ts,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tesla() -> Profile {
+        Profile::embedded(DEFAULT_PROFILE_ID).unwrap().unwrap()
+    }
+
+    #[test]
+    fn default_profile_parses_and_validates() {
+        let p = tesla();
+        assert_eq!(p.profile.id, "tesla");
+        assert_eq!(p.profile.brand, "Tesla");
+        assert_eq!(p.recording.segment_seconds, 60);
+        // front, back, left/right repeater always present; pillars optional.
+        assert!(p.cameras.iter().any(|c| c.id == "front" && !c.optional));
+        assert!(p.cameras.iter().find(|c| c.id == "left_pillar").unwrap().optional);
+    }
+
+    #[test]
+    fn parses_real_tesla_filenames() {
+        let p = tesla();
+        let info = p.parse_clip_filename("2026-07-17_19-34-53-front.mp4").unwrap();
+        assert_eq!(info.camera, "front");
+        assert_eq!(info.date_str(), "2026-07-17");
+        for name in [
+            "2026-07-17_19-04-53-back.mp4",
+            "2026-07-17_19-39-53-left_repeater.mp4",
+            "2026-07-17_19-04-19-right_repeater.mp4",
+            "2026-07-17_19-04-19-left_pillar.mp4",
+            "2026-07-17_19-04-19-right_pillar.mp4",
+        ] {
+            assert!(p.parse_clip_filename(name).is_some(), "{name} must parse");
+        }
+    }
+
+    #[test]
+    fn rejects_foreign_and_malformed_names() {
+        let p = tesla();
+        for name in [
+            "FRONT_2026_07_17_T_19_34_53.mp4",   // GM format
+            "2026-07-17_19-34-53-FRONT.mp4",     // uppercase camera
+            "2026-07-17_19-34-53-selfie.mp4",    // unknown camera
+            "2026-13-40_25-61-61-front.mp4",     // impossible date/time
+            "2026-07-17_19-34-53-front.mp4.tmp",
+            "thumbnail.jpg",
+        ] {
+            assert!(p.parse_clip_filename(name).is_none(), "{name} must be rejected");
+        }
+    }
+}

--- a/profiles/tesla.toml
+++ b/profiles/tesla.toml
@@ -1,0 +1,69 @@
+# Vehicle profile: Tesla TeslaCam (Sentry + Dashcam). Describes how Tesla
+# writes footage to the drive so a client can identify the ecosystem and
+# render the correct camera layout. Same schema as the Dash-USB sibling.
+
+[profile]
+id = "tesla"
+display_name = "Tesla TeslaCam"
+brand = "Tesla"
+
+[recording]
+root = "TeslaCam"
+# Segment filenames: 2026-07-17_19-34-53-front.mp4
+filename_regex = '^(?P<y>\d{4})-(?P<mo>\d{2})-(?P<d>\d{2})_(?P<h>\d{2})-(?P<mi>\d{2})-(?P<s>\d{2})-(?P<camera>front|back|left_repeater|right_repeater|left_pillar|right_pillar)\.mp4$'
+segment_seconds = 60
+# RecentClips holds roughly the last hour of continuous footage.
+rolling_window_minutes = 60
+# ~35 MB per camera per 60 s segment (HW3/HW4 average, H.265).
+approx_bytes_per_camera_segment = 35000000
+
+[[cameras]]
+id = "front"
+label = "Front"
+
+[[cameras]]
+id = "back"
+label = "Rear"
+
+[[cameras]]
+id = "left_repeater"
+label = "Left Repeater"
+
+[[cameras]]
+id = "right_repeater"
+label = "Right Repeater"
+
+# Pillar cameras are HW4-only. Optional: the viewer only shows them when
+# files for them exist.
+[[cameras]]
+id = "left_pillar"
+label = "Left Pillar"
+optional = true
+
+[[cameras]]
+id = "right_pillar"
+label = "Right Pillar"
+optional = true
+
+[viewer]
+# Row-major playback grid; "" is an empty cell. Optional cameras (pillars)
+# not in the grid are appended by the viewer when present.
+grid = [["left_repeater", "front", "right_repeater"], ["", "back", ""]]
+
+# Not consumed by SentryUSB (it manages the virtual drive via its own setup
+# config); present only for schema parity with the Dash-USB profile.
+[virtual_drive]
+default_size = "64G"
+min_size = "32G"
+min_free_bytes = 0
+filesystem = "exfat"
+label = "TESLACAM"
+
+[snapshots]
+default_interval_secs = 0
+
+[features]
+# Tesla has persistent SentryClips/SavedClips event tiers.
+event_folders = true
+archive_everything_default = false
+nofua = true


### PR DESCRIPTION
## What

The SC Android client is one app for both this (Tesla) and the Dash-USB sibling
(GM dashcam). It needs to know which ecosystem a box is so it loads the right
camera model / API behavior and hides Tesla-only tabs (Drives, Charging, FSD)
on a non-Tesla box.

Add `GET /api/profile` to SentryUSB, serving the same JSON shape Dash-USB
already serves, so one client parser covers both.

## How

- Port the `vehicle_profile` crate from Dash-USB (identical struct schema) with
  a `profiles/tesla.toml` describing Tesla's cameras, viewer grid, and clip
  filename pattern.
- Serve it at `GET /api/profile` with the byte-identical field set Dash-USB
  returns: `id / display_name / brand`, `cameras`, `grid`, `filename_regex`,
  `segment_seconds`, `rolling_window_minutes`.
- Client rule is one-directional and future-proof: `brand == Tesla` -> SentryUSB
  (full surface); anything else -> Dash-USB (subset). New Dash vehicles never
  break it.

## Safety

- **Additive only** — a new crate, a new route, a new profile. No existing
  endpoint or behavior changes; regular users are unaffected.
- `/api/profile` is **gated** (not in `EXEMPT_ALWAYS`), matching Dash-USB. On a
  passwordless box the whole auth layer is skipped, so it's reachable there too.
- `virtual_drive` / `snapshots` toml fields exist for schema parity and are not
  consumed by SentryUSB (it manages its drive via setup config). The Dash-USB
  recording-pipeline methods (profile_env rendering) are dropped — SentryUSB has
  its own path.

## Testing

- Unit tests: the Tesla profile parses + validates (grid references real
  cameras, root is relative, regex has all named captures), real Tesla
  filenames parse, foreign/malformed names reject. Full workspace builds clean.
