### PR TITLE
fix(archiveloop): away_mode_active never matches the Rust server's flag file — wifi_cycle kills the AP while away

### DIFF
--- a/run/archiveloop
+++ b/run/archiveloop
@@ -324,10 +324,18 @@ function connect_usb_drives_to_host_locked() {
 function away_mode_active () {
   local flag="/mutable/sentryusb_away_mode.json"
   [ -f "$flag" ] || return 1
-  # The Go server updates remaining_sec in the flag file every 30s,
-  # so this works reliably regardless of whether the Pi has an RTC.
+  # Automatic (geofence) mode: the flag file's existence IS the away
+  # decision — the server writes it on leaving home and removes it on
+  # arrival. There is no timer, so there is no remaining_sec to check.
+  if grep -q '"mode":[[:space:]]*"auto"' "$flag" 2>/dev/null; then
+    return 0
+  fi
+  # Manual timer: the server refreshes remaining_sec every 30s, so this
+  # works with or without an RTC. Tolerate pretty-printed JSON — the Rust
+  # server writes the flag with to_vec_pretty ("remaining_sec": 300), whose
+  # space after the colon the old compact-JSON grep silently never matched.
   local remaining
-  remaining=$(grep -o '"remaining_sec":[0-9]*' "$flag" | cut -d: -f2)
+  remaining=$(grep -o '"remaining_sec":[[:space:]]*[0-9]*' "$flag" | grep -o '[0-9]*$')
   [ -n "$remaining" ] && [ "$remaining" -gt 0 ] 2>/dev/null
 }
 


### PR DESCRIPTION
In Automatic Away Mode the AP comes up on leaving home, then dies ~5 minutes later and never comes back. Every away session in my logs shows the same sequence:

```
[away-mode] Automatic: away from home — starting AP
[away-mode] AP started
(~300s later) Archive still unreachable after 300s, cycling WiFi...
Tearing down ap0 to free radio for wlan0 reconnect...
(no re-up; on arriving home:) nmcli con down failed ... 'SENTRYUSB_AP' is not an active connection.
```

Cause: `away_mode_active()` in `run/archiveloop` greps the flag file for `"remaining_sec":[0-9]*` — and that never matches what the Rust server actually writes:

1. The Automatic-mode flag (`write_auto_flag_file`) is `{"mode": "auto", "enabled_at": ...}` — no `remaining_sec` at all, so auto-away always reads as "inactive".
2. Even the Manual-timer flag breaks: the server writes pretty-printed JSON (`"remaining_sec": 300`, space after the colon), which the compact-JSON grep silently fails to match. The comment still says "The Go server updates remaining_sec…" — this helper predates the Rust rewrite and was never updated.

So while away, `wait_for_archive_to_be_reachable` thinks Away Mode is off, runs `wifi_cycle` every 300s, tears the AP down, and the `if away_mode_active` re-up guard inside `wifi_cycle` is false too — the AP stays dead until the car returns home.

**Fix:** recognize the auto flag by its `"mode": "auto"` marker (its existence is the away decision; the server removes it on arrival), and make the manual `remaining_sec` check whitespace-tolerant. Compact Go-era JSON still matches; an expired manual flag (`remaining_sec: 0`) still reads inactive.

**Verified on-device (v3.15.2, Pi with NetworkManager):**

- The real server-written auto flag: old check reads "inactive" (the bug), patched check reads "active".
- Full dress rehearsal — archive host blackholed so `wait_for_archive_to_be_reachable` runs exactly like a real trip, patched script loaded: at the 300s tick it now logs `Away Mode active, skipping WiFi scan/cycle` and the AP stays up (same day, same device, the unpatched code had logged `Tearing down ap0` at its 300s tick and killed the AP).
- Return home: flag removed → check flips back to inactive → AP stops cleanly (`AP stopped`, no "not an active connection" error) → normal scanning/archiving resumes.

## Relation to #154 / #169

This is the third layer of the Away Mode AP chain (#153):

- **#154** made Automatic mode start the AP when the Pi boots while already away (`restore_from_file` never called `start_ap_bg`).
- **#169** made that boot-time start take the right path (`start_ap_bg` probed NetworkManager before it finished activating at early boot, and fell through to the ifupdown branch).
- **This PR** fixes why the AP *still* died on real trips with both fixes in: however the AP came up — live geofence flip or boot restore — archiveloop tore it down ~5 minutes later, because `away_mode_active()` couldn't parse the flag.

All three only reproduce away from home. The killer path here additionally needs the archive to be unreachable, which is why at-home testing never caught it and the layers surfaced one trip at a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
