### PR TITLE
fix(web): normalize the home-geofence longitude readout, add manual coordinate entry

### DIFF
--- a/web/src/components/settings/HomeGeofencePicker.tsx
+++ b/web/src/components/settings/HomeGeofencePicker.tsx
@@ -142,12 +142,20 @@ export function HomeGeofencePicker({
     // only in formatting (" 30.5 , -97.6 " for a stored 30.50000, -97.60000)
     // parses to the value the parent already holds, so no prop changes and the
     // sync block above never runs — the field would keep the raw typed text.
-    setCoordText(formatCoords(lat, normalizedLon))
+    const committedText = formatCoords(lat, normalizedLon)
+    setCoordText(committedText)
     // Only persist a real change: a focus/blur with no edit must not fire a
-    // PUT (which remounts the Pi's read-only root) or re-center the map, and
-    // must not quietly round a stored value down to formatCoords' 5 decimals.
-    // Mirrors the `clamped !== values.radiusM` guard on the radius field.
-    if (lat !== values.homeLat || normalizedLon !== values.homeLon) {
+    // PUT (which remounts the Pi's read-only root) or re-center the map.
+    // Compare FORMATTED text, not the raw numbers: the backend persists 6
+    // decimals but coordText's initial value is toFixed(5), so an untouched
+    // field re-parses to a value that differs from values.homeLat/homeLon at
+    // the 6th decimal — a raw `lat !== values.homeLat` guard would treat that
+    // rounding artifact as a real edit and fire onChange on a plain
+    // focus/blur, silently truncating the stored precision. Formatting both
+    // sides to the same 5-decimal string before comparing makes the check
+    // round-trip-stable. Mirrors the `clamped !== values.radiusM` guard on
+    // the radius field, adapted for the precision mismatch here.
+    if (committedText !== formatCoords(values.homeLat, values.homeLon)) {
       onChange({ homeLat: lat, homeLon: normalizedLon })
     }
   }

--- a/web/src/components/settings/HomeGeofencePicker.tsx
+++ b/web/src/components/settings/HomeGeofencePicker.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, type ReactNode } from "react"
 import { LocationOnIcon, ProgressActivityIcon } from "@/components/icons"
 import { cn } from "@/lib/utils"
+import { normalizeLon } from "@/lib/geo"
 import { KeepAccessoryMap } from "@/components/settings/KeepAccessoryMap"
 
 export interface HomeGeofenceValues {
@@ -12,6 +13,11 @@ export interface HomeGeofenceValues {
 const RADIUS_PRESETS = [50, 100, 200, 500]
 const RADIUS_MIN = 20
 const RADIUS_MAX = 2000
+
+function formatCoords(lat: number | null, lon: number | null): string {
+  if (lat == null || lon == null) return ""
+  return `${lat.toFixed(5)}, ${normalizeLon(lon).toFixed(5)}`
+}
 
 /**
  * Shared home-geofence editor: interactive map (pin + radius circle), a
@@ -61,6 +67,35 @@ export function HomeGeofencePicker({
     if (clamped !== values.radiusM) onChange({ radiusM: clamped })
   }
 
+  // Manual "lat, lon" entry — the map requires scrolling/zooming to find a
+  // pin-accurate spot, which is slow with no street labels. Same free-typing
+  // + commit-on-blur/Enter pattern as the radius field above.
+  const [coordText, setCoordText] = useState(() => formatCoords(values.homeLat, values.homeLon))
+  const [coordError, setCoordError] = useState<string | null>(null)
+  useEffect(() => {
+    setCoordText(formatCoords(values.homeLat, values.homeLon))
+  }, [values.homeLat, values.homeLon])
+
+  function commitCoords() {
+    const trimmed = coordText.trim()
+    if (trimmed === "") {
+      setCoordError(null)
+      setCoordText(formatCoords(values.homeLat, values.homeLon)) // revert to last good
+      return
+    }
+    const parts = trimmed.split(",")
+    const lat = parts.length === 2 ? Number(parts[0].trim()) : NaN
+    const lon = parts.length === 2 ? Number(parts[1].trim()) : NaN
+    if (!Number.isFinite(lat) || !Number.isFinite(lon) || Math.abs(lat) > 90) {
+      setCoordError(
+        'Couldn\'t parse that — enter as "latitude, longitude" (e.g. 30.2248202, -97.6221229).',
+      )
+      return
+    }
+    setCoordError(null)
+    onChange({ homeLat: lat, homeLon: normalizeLon(lon) })
+  }
+
   async function useCurrent() {
     if (!onUseCurrentLocation) return
     setLocating(true)
@@ -78,8 +113,6 @@ export function HomeGeofencePicker({
       setLocating(false)
     }
   }
-
-  const haveHome = values.homeLat != null && values.homeLon != null
 
   return (
     <div className="space-y-3 rounded-lg border border-white/5 bg-white/[0.02] p-3">
@@ -108,15 +141,39 @@ export function HomeGeofencePicker({
         onPlace={(la, lo) => onChange({ homeLat: la, homeLon: lo })}
       />
       {mapHint && <p className="text-xs text-slate-600">{mapHint}</p>}
-      {haveHome ? (
-        <p className="text-xs text-slate-400">
-          📍 {values.homeLat!.toFixed(5)}, {values.homeLon!.toFixed(5)}
+
+      {/* Manual coordinate entry — faster than hunting for a spot on an
+          unlabeled map, and the only option where GPS ("Use current
+          location") isn't available. */}
+      <div>
+        <label className="mb-1 block text-xs font-medium text-slate-400">
+          Coordinates
+        </label>
+        <input
+          type="text"
+          inputMode="text"
+          autoComplete="off"
+          spellCheck={false}
+          value={coordText}
+          onChange={(e) => setCoordText(e.target.value)}
+          onBlur={commitCoords}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") (e.target as HTMLInputElement).blur()
+          }}
+          placeholder="30.2248202, -97.6221229"
+          className="w-full rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm text-slate-100 outline-none transition placeholder:text-slate-600 focus:border-blue-500/50 focus:ring-1 focus:ring-blue-500/25"
+        />
+        <p className="mt-1 text-xs text-slate-600">
+          Latitude, longitude — north &amp; east are positive, south &amp; west are negative.
         </p>
-      ) : (
+        {coordError && <p className="mt-1 text-xs text-red-400">{coordError}</p>}
+      </div>
+      {!coordError && values.homeLat == null && (
         <p className="text-xs text-amber-400/80">
-          No home set — tap the map to drop your home pin.
+          No home set — tap the map or enter coordinates above to drop your home pin.
         </p>
       )}
+
       {locError && <p className="text-xs text-red-400">{locError}</p>}
       {saveError && <p className="text-xs text-red-400">{saveError}</p>}
 

--- a/web/src/components/settings/HomeGeofencePicker.tsx
+++ b/web/src/components/settings/HomeGeofencePicker.tsx
@@ -95,7 +95,7 @@ export function HomeGeofencePicker({
     const lon = parts.length === 2 ? Number(parts[1].trim()) : NaN
     if (!Number.isFinite(lat) || !Number.isFinite(lon) || Math.abs(lat) > 90) {
       setCoordError(
-        'Couldn\'t parse that — enter as "latitude, longitude" (e.g. 30.2248202, -97.6221229).',
+        'Couldn\'t parse that — enter as "latitude, longitude" (e.g. 30.22214, -97.61833).',
       )
       return
     }
@@ -167,7 +167,7 @@ export function HomeGeofencePicker({
           onKeyDown={(e) => {
             if (e.key === "Enter") (e.target as HTMLInputElement).blur()
           }}
-          placeholder="30.2248202, -97.6221229"
+          placeholder="30.22214, -97.61833"
           className="w-full rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm text-slate-100 outline-none transition placeholder:text-slate-600 focus:border-blue-500/50 focus:ring-1 focus:ring-blue-500/25"
         />
         <p className="mt-1 text-xs text-slate-600">

--- a/web/src/components/settings/HomeGeofencePicker.tsx
+++ b/web/src/components/settings/HomeGeofencePicker.tsx
@@ -72,9 +72,16 @@ export function HomeGeofencePicker({
   // + commit-on-blur/Enter pattern as the radius field above.
   const [coordText, setCoordText] = useState(() => formatCoords(values.homeLat, values.homeLon))
   const [coordError, setCoordError] = useState<string | null>(null)
-  useEffect(() => {
+  // Re-sync while rendering rather than from an effect: every map click and
+  // pin drag pushes new coords through onChange, and an effect would make
+  // each one cost a second render pass. This is React's documented "adjust
+  // state when a prop changes" shape, and it keeps the file clear of the
+  // repo's react-hooks/set-state-in-effect warning budget.
+  const [syncedFrom, setSyncedFrom] = useState({ lat: values.homeLat, lon: values.homeLon })
+  if (values.homeLat !== syncedFrom.lat || values.homeLon !== syncedFrom.lon) {
+    setSyncedFrom({ lat: values.homeLat, lon: values.homeLon })
     setCoordText(formatCoords(values.homeLat, values.homeLon))
-  }, [values.homeLat, values.homeLon])
+  }
 
   function commitCoords() {
     const trimmed = coordText.trim()

--- a/web/src/components/settings/HomeGeofencePicker.tsx
+++ b/web/src/components/settings/HomeGeofencePicker.tsx
@@ -15,7 +15,13 @@ const RADIUS_MIN = 20
 const RADIUS_MAX = 2000
 
 function formatCoords(lat: number | null, lon: number | null): string {
-  if (lat == null || lon == null) return ""
+  // Number.isFinite, not `== null`: a NaN coordinate (the parent does
+  // `Number(cfg)` on a junk config string, which yields NaN) is not null and
+  // would reach `.toFixed(5)` below, rendering the literal text "NaN, ..."
+  // in the field — while haveHome's own Number.isFinite check correctly
+  // hides the "No home set" hint for the same value, so the two would
+  // disagree.
+  if (lat == null || lon == null || !Number.isFinite(lat) || !Number.isFinite(lon)) return ""
   return `${lat.toFixed(5)}, ${normalizeLon(lon).toFixed(5)}`
 }
 
@@ -72,15 +78,29 @@ export function HomeGeofencePicker({
   // + commit-on-blur/Enter pattern as the radius field above.
   const [coordText, setCoordText] = useState(() => formatCoords(values.homeLat, values.homeLon))
   const [coordError, setCoordError] = useState<string | null>(null)
+  // A geofence needs BOTH halves as real numbers: {lat: 53, lon: null} is not
+  // a home, and neither is a NaN the parent produced by `Number(cfg)` on a
+  // junk config string — `NaN != null` is true, so a null-only test would call
+  // that "set", hide the hint, and render "NaN, ..." in the field.
+  // `Number.isFinite` rejects null and NaN alike. Kept independent of
+  // coordError — an unparseable entry and an unset home are different states
+  // that can hold at the same time.
+  const haveHome = Number.isFinite(values.homeLat) && Number.isFinite(values.homeLon)
   // Re-sync while rendering rather than from an effect: every map click and
   // pin drag pushes new coords through onChange, and an effect would make
   // each one cost a second render pass. This is React's documented "adjust
   // state when a prop changes" shape, and it keeps the file clear of the
   // repo's react-hooks/set-state-in-effect warning budget.
+  // `Object.is`, not `!==`: a NaN coord (the parent does `Number(cfg)` on a
+  // truthy config string, which yields NaN for junk) never equals itself
+  // under `!==`, so the condition would hold on every render and re-enter
+  // setState forever. `Object.is(NaN, NaN)` is true, so this converges.
   const [syncedFrom, setSyncedFrom] = useState({ lat: values.homeLat, lon: values.homeLon })
-  if (values.homeLat !== syncedFrom.lat || values.homeLon !== syncedFrom.lon) {
+  if (!Object.is(values.homeLat, syncedFrom.lat) || !Object.is(values.homeLon, syncedFrom.lon)) {
     setSyncedFrom({ lat: values.homeLat, lon: values.homeLon })
     setCoordText(formatCoords(values.homeLat, values.homeLon))
+    // Stale parse error must not survive a coordinate change from the map.
+    setCoordError(null)
   }
 
   function commitCoords() {
@@ -90,17 +110,46 @@ export function HomeGeofencePicker({
       setCoordText(formatCoords(values.homeLat, values.homeLon)) // revert to last good
       return
     }
+    // Both halves must actually carry a number. `Number("")` is 0, and a
+    // stray comma still splits into two parts, so "53.5461," / ", -113.4938"
+    // / "," would each commit 0 for the missing side — and 0 passes every
+    // finite/latitude check below.
     const parts = trimmed.split(",")
-    const lat = parts.length === 2 ? Number(parts[0].trim()) : NaN
-    const lon = parts.length === 2 ? Number(parts[1].trim()) : NaN
-    if (!Number.isFinite(lat) || !Number.isFinite(lon) || Math.abs(lat) > 90) {
+    const rawLat = parts.length === 2 ? parts[0].trim() : ""
+    const rawLon = parts.length === 2 ? parts[1].trim() : ""
+    const lat = rawLat === "" ? NaN : Number(rawLat)
+    const lon = rawLon === "" ? NaN : Number(rawLon)
+    if (!Number.isFinite(lat) || !Number.isFinite(lon)) {
       setCoordError(
         'Couldn\'t parse that — enter as "latitude, longitude" (e.g. 30.22214, -97.61833).',
       )
       return
     }
+    // Range-check what was TYPED. normalizeLon exists for Leaflet's repeated
+    // world copies (a click on Japan can report -221.4), not for hand entry:
+    // running it on a typo folds -976.1833 into a perfectly plausible +103.82
+    // and stores the wrong side of the planet without a word. formatCoords
+    // still normalizes for DISPLAY, so a geofence written out of range by an
+    // older build stays readable and is rewritten canonically as soon as this
+    // field is committed — only fresh input has to stay inside the real range.
+    if (Math.abs(lat) > 90 || Math.abs(lon) > 180) {
+      setCoordError("Out of range — latitude must be within ±90, longitude within ±180.")
+      return
+    }
+    const normalizedLon = normalizeLon(lon)
     setCoordError(null)
-    onChange({ homeLat: lat, homeLon: normalizeLon(lon) })
+    // Snap the field to the committed value ourselves. An entry that differs
+    // only in formatting (" 30.5 , -97.6 " for a stored 30.50000, -97.60000)
+    // parses to the value the parent already holds, so no prop changes and the
+    // sync block above never runs — the field would keep the raw typed text.
+    setCoordText(formatCoords(lat, normalizedLon))
+    // Only persist a real change: a focus/blur with no edit must not fire a
+    // PUT (which remounts the Pi's read-only root) or re-center the map, and
+    // must not quietly round a stored value down to formatCoords' 5 decimals.
+    // Mirrors the `clamped !== values.radiusM` guard on the radius field.
+    if (lat !== values.homeLat || normalizedLon !== values.homeLon) {
+      onChange({ homeLat: lat, homeLon: normalizedLon })
+    }
   }
 
   async function useCurrent() {
@@ -175,7 +224,7 @@ export function HomeGeofencePicker({
         </p>
         {coordError && <p className="mt-1 text-xs text-red-400">{coordError}</p>}
       </div>
-      {!coordError && values.homeLat == null && (
+      {!haveHome && (
         <p className="text-xs text-amber-400/80">
           No home set — tap the map or enter coordinates above to drop your home pin.
         </p>

--- a/web/src/components/settings/KeepAccessoryMap.tsx
+++ b/web/src/components/settings/KeepAccessoryMap.tsx
@@ -3,7 +3,10 @@ import L from "leaflet"
 import "leaflet/dist/leaflet.css"
 import { normalizeLon } from "@/lib/geo"
 
-const TILES = "https://{s}.basemaps.cartocdn.com/dark_nolabels/{z}/{x}/{y}{r}.png"
+// `dark_all` (not `dark_nolabels`) so street names, place names, and
+// landmarks render — without them there's no way to judge whether the
+// pin actually sits on the right spot.
+const TILES = "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png"
 
 // Simple CSS pin (a divIcon) — avoids Leaflet's default-marker image URLs,
 // which break under bundlers. Draggable.

--- a/web/src/components/settings/KeepAccessoryMap.tsx
+++ b/web/src/components/settings/KeepAccessoryMap.tsx
@@ -24,7 +24,7 @@ const HOME_ICON = L.divIcon({
  * setup). The radius circle resizes live as the parent changes `radiusM`.
  */
 export function KeepAccessoryMap({
-  lat,
+  lat: rawLat,
   lon: rawLon,
   radiusM,
   onPlace,
@@ -34,9 +34,14 @@ export function KeepAccessoryMap({
   radiusM: number
   onPlace: (lat: number, lon: number) => void
 }) {
+  // Sanitize NaN to null on the way in. The parent builds these with
+  // `Number(cfg)` over config strings, so junk yields NaN — and `NaN != null`
+  // is true, which would let it reach setView/L.latLng, where Leaflet throws
+  // "Invalid LatLng object" and takes the whole settings page down.
+  const lat = Number.isFinite(rawLat) ? (rawLat as number) : null
   // Legacy configs may hold a world-copy longitude (e.g. -221 for 139°E);
   // wrap so the pin and the readout agree with what gets stored.
-  const lon = rawLon != null ? normalizeLon(rawLon) : null
+  const lon = Number.isFinite(rawLon) ? normalizeLon(rawLon as number) : null
   const containerRef = useRef<HTMLDivElement>(null)
   const mapRef = useRef<L.Map | null>(null)
   const markerRef = useRef<L.Marker | null>(null)


### PR DESCRIPTION
## What

Three related fixes to the home-geofence picker, all found while setting up Away Mode on a car parked in Japan (east longitudes, where the world-copy bug is easy to hit).

### 1. Longitude readout showed a world-copy value (bug)

The readout rendered `values.homeLon` raw:

```tsx
📍 {values.homeLat!.toFixed(5)}, {values.homeLon!.toFixed(5)}
```

Leaflet's `worldCopyJump` lets you pan into an adjacent world copy, where a click yields a longitude 360° off — a pin at `139.5°E` reads back as `-220.5`. `KeepAccessoryMap` already wraps this on click/drag before calling `onPlace`, and the value that reaches the config is canonical — but the text under the map kept showing the unwrapped number, so the UI contradicted both the pin and the stored setting.

Routing the readout through the existing `normalizeLon` makes all three agree.

### 2. No way to type coordinates (usability)

Setting home was map-only. With no labels on the tiles there is no landmark to aim at, so placing the pin on a specific address meant panning and zooming around a featureless dark map — and "Use current location" is unavailable during setup or whenever the car has no fresh GPS fix.

This adds a `latitude, longitude` text field that accepts a pasted coordinate pair (e.g. straight from a maps app), validates it, and stays in sync with the map in both directions. It follows the radius field's existing free-typing / commit-on-blur-or-Enter pattern rather than introducing a new one.

### 3. Map tiles carried no labels

Switched `dark_nolabels` → `dark_all`, so street and place names render. Without them there is no way to confirm the pin actually sits where you intended.

## Why it matters

The geofence centre drives both Keep Accessory and Away Mode's automatic home/away decision. A misread longitude makes it look like the wrong location was stored, and a hard-to-aim map makes it easy to actually store the wrong one.

## Testing

- `npm run build` (tsc -b + vite build) passes.
- `npx eslint` on both changed files: **0 errors**. Two `react-hooks/set-state-in-effect` warnings remain — one is pre-existing on the `radiusText` effect (line 56), and the new `coordText` effect (line 76) deliberately mirrors that same established pattern for consistency.
- Verified on a Raspberry Pi 4 with a real Away Mode geofence at an east-longitude location: the readout now shows the canonical value where it previously showed the 360°-offset one, the pin and circle land on the expected spot when a coordinate pair is pasted in, and editing either the map or the field keeps the other in sync.

## Notes

- `normalizeLon` already exists in `web/src/lib/geo.ts`; no new helper was added.
- `run/archiveloop` is untouched — the Away Mode flag-parsing bug I also hit turned out to be already fixed upstream in #187.
