### PR TITLE
fix(setup): commit drive sizes on change, not just on blur (mobile setup wizard)

### DIFF
--- a/web/src/components/setup/SizeInput.tsx
+++ b/web/src/components/setup/SizeInput.tsx
@@ -41,6 +41,14 @@ export function SizeInput({
     if (!focused) setLocalVal(numericVal)
   }, [numericVal, focused])
 
+  // Seed the default into form data so an untouched required field (e.g.
+  // Dashcam) isn't validated as 0 before the user ever focuses it. Only when
+  // empty and not locked; never overwrites an existing value.
+  useEffect(() => {
+    if (!disabled && !raw.trim() && defaultVal) onChange(field, defaultVal)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
   const handleFocus = () => {
     if (disabled) return
     setFocused(true)
@@ -56,14 +64,24 @@ export function SizeInput({
 
   const handleChange = (v: string) => {
     if (disabled) return
-    setLocalVal(v.replace(/[^0-9]/g, ""))
+    const cleaned = v.replace(/[^0-9]/g, "")
+    setLocalVal(cleaned)
+    // Commit on every keystroke, not just onBlur: mobile browsers don't
+    // reliably fire blur before the wizard's Next/validation reads the form,
+    // so a blur-only commit left the value empty and tripped "Dashcam drive
+    // size must be greater than 0 GB" even though a value was typed. Empty
+    // commits "" (not the default) so the stored value+unit never disagree;
+    // blur + the mount seed restore the default for an untouched field.
+    onChange(field, cleaned ? cleaned + unit : "")
   }
 
   const handleUnitChange = (newUnit: Unit) => {
     if (disabled) return
     setUnit(newUnit)
-    const currentNum = focused ? localVal : numericVal
-    if (currentNum) onChange(field, currentNum + newUnit)
+    // Commit on a unit toggle with the NEW unit so the label and stored value
+    // stay in sync; empty commits "" (default is restored on blur / mount).
+    const currentNum = (focused ? localVal : numericVal).replace(/[^0-9]/g, "")
+    onChange(field, currentNum ? currentNum + newUnit : "")
   }
 
   const unitLabel = unit === "M" ? "MB" : "GB"


### PR DESCRIPTION
## Bug
On a **mobile browser** at `sentryusb.local`, the Setup Wizard's Storage step shows **"Dashcam drive size must be greater than 0 GB"** no matter what size is entered (60/100/1000), and toggling MB/GB doesn't help. It works on desktop. (Reported: RPi 4B + 2TB SSD, v3.16.8, Android browser.)

## Root cause
`SizeInput` committed its value into the form **only in `onBlur`**. Mobile browsers don't reliably fire `blur` before the wizard's Next button / validation reads the form, so `CAM_SIZE` stayed empty → `parseFloat("")` = `NaN` ≤ 0 → the error, even though a value was displayed. The MB/GB toggle didn't help because it, too, only committed an already-committed value.

## Fix
- **Commit on every keystroke** (`handleChange`), not just on blur — removes the blur dependency entirely.
- **Commit on every unit toggle** with the new unit (`handleUnitChange`), so a bare MB/GB toggle can't leave the value uncommitted, and the label + stored value stay in sync.
- **Seed the default** into an untouched required field on mount, so accepting the shown default without focusing it isn't validated as 0. Only when empty + not locked; never overwrites an existing value. Optional drives (`defaultVal=""`) are correctly left unseeded.
- Empty commits `""` (honest validation feedback for a cleared required field); the default is restored on blur / mount.

Desktop behavior is unchanged. Frontend-only, `tsc` clean.
