### PR TITLE
feat(charging): set home from the Charging tab, and keep history when it moves

### DIFF
--- a/crates/api/src/away_mode.rs
+++ b/crates/api/src/away_mode.rs
@@ -1173,6 +1173,10 @@ pub async fn config_set(
     State(_s): State<AppState>,
     Json(body): Json<AwayConfigBody>,
 ) -> (StatusCode, Json<serde_json::Value>) {
+    // Shares the home CENTER with the charging "Home" tag, so a move here must
+    // invalidate the cached charging list. Radius is not shared (Away Mode uses
+    // AWAY_MODE_HOME_RADIUS_M, charging KEEP_ACCESSORY_HOME_RADIUS_M).
+    let home_moving = body.home_lat.is_some() || body.home_lon.is_some();
     let result = tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
         let config_path = sentryusb_config::find_config_path();
         let (mut active, _) = sentryusb_config::parse_file(config_path)?;
@@ -1201,6 +1205,9 @@ pub async fn config_set(
     match result {
         Ok(Ok(())) => {
             info!("[away-mode] geofence config updated");
+            if home_moving {
+                crate::charging::invalidate_charging_list();
+            }
             (StatusCode::OK, Json(serde_json::json!({ "ok": true })))
         }
         Ok(Err(e)) => crate::json_error(

--- a/crates/api/src/charging.rs
+++ b/crates/api/src/charging.rs
@@ -48,7 +48,10 @@ use sentryusb_drives::charging::{
 static CHARGING_LIST_CACHE: crate::ttl_cache::StaleWhileRevalidate<(), std::sync::Arc<String>> =
     crate::ttl_cache::StaleWhileRevalidate::new(std::time::Duration::from_secs(15));
 
-fn invalidate_charging_list() {
+/// Drop the cached charging list. Also called when the home geofence moves:
+/// the "Home" tag is derived from it, so the cached list would show stale tags
+/// for up to the 15s TTL.
+pub(crate) fn invalidate_charging_list() {
     CHARGING_LIST_CACHE.clear();
 }
 
@@ -77,6 +80,7 @@ struct ChargeSessionDetail {
 /// One time-of-use price window for a tag, scoped by time-of-day, days of
 /// the week, and a month range — the device equivalent of a Tessie "rate
 /// schedule". All bounds are in local time.
+#[derive(PartialEq)]
 struct RateSchedule {
     rate: f64,
     /// Local minutes-of-day. `start_min > end_min` wraps past midnight
@@ -134,6 +138,7 @@ impl RateSchedule {
 /// Pricing for one tag: an optional flat fallback rate plus any number of
 /// time-of-use schedules. A charging interval is priced at the first
 /// schedule that covers it, else `flat`, else the global default rate.
+#[derive(PartialEq)]
 struct TagRate {
     flat: Option<f64>,
     schedules: Vec<RateSchedule>,
@@ -199,6 +204,43 @@ impl RateConfig {
             default_rate,
             tags,
         }
+    }
+
+    /// Copy the "Home" rate onto `tag` so frozen sessions keep their price.
+    /// Errors (rather than logging) so the caller can abort the move.
+    /// Returns whether the rate map changed, for the cloud-sync nudge.
+    ///
+    /// `label_in_use` is evaluated INSIDE the prefs lock and only when a rate
+    /// would actually be written: giving an in-use label the Home rate would
+    /// reprice charges that were never home, but with no rate change reuse is
+    /// harmless. Deciding that outside the lock would let a concurrent rate
+    /// edit turn a skipped check into a needed one.
+    fn copy_home_rate_to(
+        tag: &str,
+        label_in_use: impl FnOnce() -> anyhow::Result<bool>,
+    ) -> anyhow::Result<bool> {
+        crate::preferences::update_prefs(|prefs| match home_rate_copy_plan(prefs, tag) {
+            RateCopy::Nothing => Ok(false),
+            RateCopy::Conflict(why) => anyhow::bail!("{why}"),
+            RateCopy::Copy(rate) => {
+                if label_in_use()? {
+                    anyhow::bail!(
+                        "\"{tag}\" is already used by other charges — pick a name that isn't in use"
+                    );
+                }
+                let mut rates = prefs
+                    .get("charging_tag_rates")
+                    .and_then(|v| v.as_object())
+                    .cloned()
+                    .unwrap_or_default();
+                rates.insert(tag.to_string(), rate);
+                prefs.insert(
+                    "charging_tag_rates".to_string(),
+                    serde_json::Value::Object(rates),
+                );
+                Ok(true)
+            }
+        })
     }
 }
 
@@ -447,6 +489,137 @@ fn distance_m(lat1: f64, lon1: f64, lat2: f64, lon2: f64) -> f64 {
     2.0 * EARTH_R_M * a.sqrt().min(1.0).asin()
 }
 
+
+/// What freezing under `tag` should do to the rate map.
+#[derive(Debug, PartialEq)]
+enum RateCopy {
+    /// No rate change needed, and none of the sessions change price.
+    Nothing,
+    /// Refuse the whole freeze; the payload is shown to the user.
+    Conflict(String),
+    /// Give `tag` this rate.
+    Copy(serde_json::Value),
+}
+
+/// Decide the above from `prefs`. Pure, so the cost-preservation logic is
+/// unit-testable — a wrong answer here fails silently.
+///
+/// Destination keys are matched EXACTLY, because `apply_rates` resolves a
+/// stored tag with an exact `rates.tags.get(tag)`; matching case-insensitively
+/// would call a differently-cased key "already priced" and skip the write,
+/// leaving the frozen sessions with a tag no rate lookup can reach. The Home
+/// SOURCE key stays case-insensitive, matching how a home charge is priced.
+/// Values are compared after `parse_tag_rate`, so `0.2`, `"0.2"` and
+/// `{"flat":0.2}` are one rate rather than a false conflict.
+fn home_rate_copy_plan(
+    prefs: &serde_json::Map<String, serde_json::Value>,
+    tag: &str,
+) -> RateCopy {
+    let Some(rates) = prefs.get("charging_tag_rates").and_then(|v| v.as_object()) else {
+        return RateCopy::Nothing; // no rates at all: nothing to preserve
+    };
+    // Only CONFIGURED Home entries count: a malformed one ("NaN", "-1", `{}`)
+    // prices nothing, so there is no cost to preserve and copying it would just
+    // spread the junk.
+    let home_keys: Vec<&serde_json::Value> = rates
+        .iter()
+        .filter(|(k, v)| k.eq_ignore_ascii_case(HOME_TAG) && parse_tag_rate(v).is_configured())
+        .map(|(_, v)| v)
+        .collect();
+    // `apply_rates` prices a home charge at the most expensive Home-cased key,
+    // which needs the session's rows to evaluate. Rather than guess which one
+    // to preserve, refuse: two Home rates differing only in capitalization is a
+    // config mistake the user should resolve.
+    if home_keys.len() > 1 && home_keys.windows(2).any(|w| parse_tag_rate(w[0]) != parse_tag_rate(w[1]))
+    {
+        return RateCopy::Conflict(format!(
+            "there are two \"{HOME_TAG}\" rates differing only in capitalization — remove one first"
+        ));
+    }
+    let home_rate = rates
+        .get(HOME_TAG)
+        .filter(|v| parse_tag_rate(v).is_configured())
+        .or_else(|| home_keys.first().copied());
+    // An unconfigured destination entry prices nothing, so it is not a rate the
+    // user set deliberately and may be overwritten.
+    let dest = rates.get(tag).filter(|v| parse_tag_rate(v).is_configured());
+    match (home_rate, dest) {
+        // No Home rate to preserve, but the label already prices something:
+        // freezing would move these charges onto a rate they never had.
+        (None, Some(_)) => RateCopy::Conflict(format!(
+            "\"{tag}\" already has a rate, and these charges had none — pick another name"
+        )),
+        (None, None) => RateCopy::Nothing,
+        (Some(home), None) => RateCopy::Copy(home.clone()),
+        (Some(home), Some(d)) if parse_tag_rate(home) == parse_tag_rate(d) => RateCopy::Nothing,
+        (Some(_), Some(_)) => RateCopy::Conflict(format!(
+            "\"{tag}\" already has a different rate — pick another name, or those charges would be repriced instead of preserved"
+        )),
+    }
+}
+
+/// Session ids currently inside the home geofence. Errors rather than
+/// returning an empty list on a read failure: callers use this to decide
+/// whether history is at risk, and a silent zero reads as "nothing to lose".
+pub(crate) fn sessions_at_home(store: &sentryusb_drives::db::DriveStore) -> anyhow::Result<Vec<i64>> {
+    let home = match home_geofence() {
+        Some(h) => h,
+        None => return Ok(Vec::new()), // no home configured: nothing was ever Home
+    };
+    let rows = store.with_read_conn(|conn| load_charge_rows(conn, 0, None))?;
+    Ok(group_sessions(rows)
+        .iter()
+        .map(|g| summarize(g))
+        .filter(|s| is_home_charge(s.location_lat, s.location_lon, Some(home)))
+        .map(|s| s.id)
+        .collect())
+}
+
+/// Freeze today's at-home sessions under `tag`, and copy the Home rate onto it
+/// so their cost survives the move as well as their label.
+///
+/// Additive and transactional (see `add_charge_tag_bulk`): existing tags are
+/// untouched, and either every session is frozen or none is.
+pub(crate) fn freeze_home_sessions(
+    store: &sentryusb_drives::db::DriveStore,
+    tag: &str,
+) -> anyhow::Result<Frozen> {
+    let tag = tag.trim();
+    if tag.is_empty() || sentryusb_drives::charging::is_reserved_tag(tag) {
+        anyhow::bail!("pick a name that isn't a reserved tag");
+    }
+    let ids = sessions_at_home(store)?;
+    if ids.is_empty() {
+        return Ok(Frozen { tagged: 0, rates_changed: false });
+    }
+    // Rate first: it is the half that can conflict, and a conflict must abort
+    // before anything is written. The in-use check runs inside that step (see
+    // copy_home_rate_to); with the label unused, a rate left behind by a later
+    // failure prices nothing. Exact tag match, mirroring `apply_rates`.
+    let id_set: std::collections::HashSet<i64> = ids.iter().copied().collect();
+    let rates_changed = RateConfig::copy_home_rate_to(tag, || {
+        // Propagates: treating a failed read as "no labels in use" would let the
+        // repricing through on exactly the request that could not check.
+        //
+        // Known narrow race: this reads SQLite while holding only the prefs
+        // lock, so a tag edit landing between the read and the write could give
+        // an unrelated charge the copied rate. Closing it needs a lock spanning
+        // both stores, which does not exist; the window is microseconds and the
+        // outcome is a recoverable mispriced charge, not lost data.
+        Ok(store
+            .get_all_charge_tags()?
+            .iter()
+            .any(|(id, tags)| !id_set.contains(id) && tags.iter().any(|t| t == tag)))
+    })?;
+    let n = store.add_charge_tag_bulk(&ids, tag)?;
+    Ok(Frozen { tagged: n, rates_changed })
+}
+
+/// Freeze outcome. `rates_changed` drives the cloud-sync nudge.
+pub(crate) struct Frozen {
+    pub tagged: usize,
+    pub rates_changed: bool,
+}
 
 /// True when a session's charge location falls inside the home geofence.
 fn is_home_charge(lat: Option<f64>, lon: Option<f64>, home: Option<(f64, f64, f64)>) -> bool {
@@ -792,6 +965,33 @@ pub async fn list_charge_tags(
 /// PUT /api/charging/{id}/tags — set tags for a charge session. `id` is
 /// the session's start timestamp (its stable id), so unlike drives it
 /// needs no resolution to a canonical key.
+/// GET /api/charging/home-sessions -> how many past sessions the CURRENT
+/// geofence claims, so the UI can say "189 charges are tagged Home" before a
+/// move rather than after. Errors are reported as errors: a silent 0 would
+/// tell the user there is nothing to lose at the exact moment there is.
+pub async fn home_session_count(
+    State(state): State<AppState>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    let store = state.drives.store.clone();
+    match tokio::task::spawn_blocking(move || sessions_at_home(&store)).await {
+        Ok(Ok(ids)) => (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "count": ids.len(),
+                "home_set": home_geofence().is_some(),
+            })),
+        ),
+        Ok(Err(e)) => crate::json_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            &format!("could not read charge history: {e}"),
+        ),
+        Err(e) => crate::json_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            &format!("task failed: {e}"),
+        ),
+    }
+}
+
 pub async fn set_charge_tags(
     State(state): State<AppState>,
     Path(id): Path<i64>,
@@ -1564,5 +1764,106 @@ mod tests {
         assert_eq!(parse_minute_of_day(&serde_json::json!(390)), Some(390));
         assert_eq!(parse_minute_of_day(&serde_json::json!("nope")), None);
         assert_eq!(parse_minute_of_day(&serde_json::json!("25:00")), None);
+    }
+    #[test]
+    fn home_rate_is_copied_onto_the_frozen_tag() {
+        let mk = |json: &str| -> serde_json::Map<String, serde_json::Value> {
+            serde_json::from_str(json).unwrap()
+        };
+
+        // The case that matters: a Home rate exists, so the frozen set keeps
+        // the price it had while it was home.
+        let p = mk(r#"{"charging_tag_rates":{"Home":0.12,"Public":0.45}}"#);
+        assert_eq!(
+            home_rate_copy_plan(&p, "Old House"),
+            RateCopy::Copy(serde_json::json!(0.12))
+        );
+
+        // Case-insensitive on the Home key, matching how rates are matched.
+        let p = mk(r#"{"charging_tag_rates":{"home":0.2}}"#);
+        assert_eq!(
+            home_rate_copy_plan(&p, "Old House"),
+            RateCopy::Copy(serde_json::json!(0.2))
+        );
+
+        // Schedules (the object shape) copy whole, not just a flat rate.
+        let p = mk(r#"{"charging_tag_rates":{"Home":{"flat":0.1,"schedules":[{"rate":0.05}]}}}"#);
+        match home_rate_copy_plan(&p, "Old House") {
+            RateCopy::Copy(v) => assert_eq!(v["schedules"][0]["rate"], serde_json::json!(0.05)),
+            other => panic!("expected a copy, got {other:?}"),
+        }
+
+        // Nothing to preserve — reusing a named label is then harmless.
+        let p = mk(r#"{"charging_tag_rates":{"Public":0.45}}"#);
+        assert_eq!(home_rate_copy_plan(&p, "Old House"), RateCopy::Nothing);
+        assert_eq!(home_rate_copy_plan(&mk("{}"), "Old House"), RateCopy::Nothing);
+
+        // Re-freezing under a label that already holds the current Home rate is
+        // a no-op, not a conflict.
+        let p = mk(r#"{"charging_tag_rates":{"Home":0.12,"Old House":0.12}}"#);
+        assert_eq!(home_rate_copy_plan(&p, "Old House"), RateCopy::Nothing);
+
+        // Same rate written differently is the same rate, not a conflict.
+        let p = mk(r#"{"charging_tag_rates":{"Home":0.2,"Old House":"0.20"}}"#);
+        assert_eq!(home_rate_copy_plan(&p, "Old House"), RateCopy::Nothing);
+        let p = mk(r#"{"charging_tag_rates":{"Home":0.2,"Old House":{"flat":0.2}}}"#);
+        assert_eq!(home_rate_copy_plan(&p, "Old House"), RateCopy::Nothing);
+
+        // The label exists at a DIFFERENT rate: copying would clobber a
+        // deliberate rate, proceeding would reprice the frozen sessions at it.
+        let p = mk(r#"{"charging_tag_rates":{"Home":0.20,"Old House":0.29}}"#);
+        assert!(matches!(home_rate_copy_plan(&p, "Old House"), RateCopy::Conflict(_)));
+
+        // Casing: rate lookup at render time is EXACT, so a differently-cased
+        // key is NOT this tag. Copying under the requested spelling is what
+        // keeps the frozen sessions priced; treating it as "already there"
+        // would leave them with a tag no rate can be found for.
+        let p = mk(r#"{"charging_tag_rates":{"Home":0.12,"old house":0.12}}"#);
+        assert_eq!(
+            home_rate_copy_plan(&p, "Old House"),
+            RateCopy::Copy(serde_json::json!(0.12))
+        );
+
+        // Home key itself stays case-insensitive, matching how a home charge is
+        // priced; the canonical spelling wins when both exist and agree.
+        let p = mk(r#"{"charging_tag_rates":{"home":0.4,"Home":0.4}}"#);
+        assert_eq!(
+            home_rate_copy_plan(&p, "Old House"),
+            RateCopy::Copy(serde_json::json!(0.4))
+        );
+
+        // Two DISAGREEING Home rates: a home charge is priced at the most
+        // expensive of them, which needs the session rows. Refuse rather than
+        // guess which one to preserve.
+        let p = mk(r#"{"charging_tag_rates":{"home":0.4,"Home":0.1}}"#);
+        assert!(matches!(home_rate_copy_plan(&p, "Old House"), RateCopy::Conflict(_)));
+
+        // No Home rate but the label prices something: these charges had no
+        // derived cost, so freezing under it would invent one.
+        let p = mk(r#"{"charging_tag_rates":{"Old House":0.29}}"#);
+        assert!(matches!(home_rate_copy_plan(&p, "Old House"), RateCopy::Conflict(_)));
+
+        // An unconfigured destination prices nothing, so it is not a deliberate
+        // rate and may be overwritten rather than refused.
+        let p = mk(r#"{"charging_tag_rates":{"Home":0.15,"Old House":{}}}"#);
+        assert_eq!(
+            home_rate_copy_plan(&p, "Old House"),
+            RateCopy::Copy(serde_json::json!(0.15))
+        );
+
+        // No Home rate and an unconfigured destination: nothing is repriced.
+        let p = mk(r#"{"charging_tag_rates":{"Old House":{}}}"#);
+        assert_eq!(home_rate_copy_plan(&p, "Old House"), RateCopy::Nothing);
+
+        // A malformed Home rate prices nothing, so there is nothing to preserve
+        // and nothing to spread onto the frozen label.
+        for junk in [r#""NaN""#, r#""-1""#, "{}", r#"{"flat":null}"#] {
+            let p = mk(&format!(r#"{{"charging_tag_rates":{{"Home":{junk}}}}}"#));
+            assert_eq!(
+                home_rate_copy_plan(&p, "Old House"),
+                RateCopy::Nothing,
+                "junk Home rate {junk} must not be copied"
+            );
+        }
     }
 }

--- a/crates/api/src/charging.rs
+++ b/crates/api/src/charging.rs
@@ -558,11 +558,51 @@ fn home_rate_copy_plan(
     }
 }
 
-/// Session ids currently inside the home geofence. Errors rather than
-/// returning an empty list on a read failure: callers use this to decide
-/// whether history is at risk, and a silent zero reads as "nothing to lose".
-pub(crate) fn sessions_at_home(store: &sentryusb_drives::db::DriveStore) -> anyhow::Result<Vec<i64>> {
-    let home = match home_geofence() {
+/// The geofence a pending write leaves behind: the current one with whichever
+/// of the fields the request supplies, already clamped by the caller so this
+/// cannot disagree with what gets written. Rounded to the same 6dp the config
+/// file holds, so "still home afterwards" is decided against the values that
+/// will actually be read back. `None` when no home is configured — also the
+/// case where nothing can lose the tag.
+pub(crate) fn pending_home_geofence(
+    lat: Option<f64>,
+    lon: Option<f64>,
+    radius_m: Option<f64>,
+) -> Option<(f64, f64, f64)> {
+    let (cur_lat, cur_lon, cur_radius) = home_geofence()?;
+    // Round only what is being rewritten. A field the request omits keeps
+    // whatever precision the file already holds, so rounding it here would
+    // describe a circle a few centimetres off the one that stays on disk.
+    let round6 = |v: f64| format!("{v:.6}").parse::<f64>().unwrap_or(v);
+    Some((
+        lat.map(round6).unwrap_or(cur_lat),
+        lon.map(round6).unwrap_or(cur_lon),
+        radius_m.unwrap_or(cur_radius),
+    ))
+}
+
+/// True when moving the geofence to `new_home` takes this session out of Home.
+///
+/// `new_home: None` means the move is not describable, so every at-home session
+/// counts as losing it. That is the safe direction: over-freezing leaves a spare
+/// label the user can delete, under-freezing drops a cost nothing can rebuild.
+fn loses_home(
+    lat: Option<f64>,
+    lon: Option<f64>,
+    old_home: (f64, f64, f64),
+    new_home: Option<(f64, f64, f64)>,
+) -> bool {
+    is_home_charge(lat, lon, Some(old_home)) && !is_home_charge(lat, lon, new_home)
+}
+
+/// Session ids a move to `new_home` would un-tag. Errors rather than returning
+/// an empty list on a read failure: callers use this to decide whether history
+/// is at risk, and a silent zero reads as "nothing to lose".
+pub(crate) fn sessions_losing_home(
+    store: &sentryusb_drives::db::DriveStore,
+    new_home: Option<(f64, f64, f64)>,
+) -> anyhow::Result<Vec<i64>> {
+    let old_home = match home_geofence() {
         Some(h) => h,
         None => return Ok(Vec::new()), // no home configured: nothing was ever Home
     };
@@ -570,25 +610,39 @@ pub(crate) fn sessions_at_home(store: &sentryusb_drives::db::DriveStore) -> anyh
     Ok(group_sessions(rows)
         .iter()
         .map(|g| summarize(g))
-        .filter(|s| is_home_charge(s.location_lat, s.location_lon, Some(home)))
+        .filter(|s| loses_home(s.location_lat, s.location_lon, old_home, new_home))
         .map(|s| s.id)
         .collect())
 }
 
-/// Freeze today's at-home sessions under `tag`, and copy the Home rate onto it
-/// so their cost survives the move as well as their label.
+/// Session ids currently inside the home geofence — every one of them is at
+/// risk when the destination is unknown, which is what the count endpoint
+/// reports before the user has picked a new location.
+pub(crate) fn sessions_at_home(store: &sentryusb_drives::db::DriveStore) -> anyhow::Result<Vec<i64>> {
+    sessions_losing_home(store, None)
+}
+
+/// Freeze the sessions a move to `new_home` would un-tag, and copy the Home
+/// rate onto `tag` so their cost survives the move as well as their label.
+///
+/// Only the sessions that actually LOSE Home are frozen. A charge that stays
+/// inside the new circle — an overlapping move, or a radius increase — keeps
+/// deriving Home and would otherwise carry a permanent second label naming a
+/// house it never left, priced at a rate that stops matching the moment the
+/// Home rate is edited.
 ///
 /// Additive and transactional (see `add_charge_tag_bulk`): existing tags are
 /// untouched, and either every session is frozen or none is.
 pub(crate) fn freeze_home_sessions(
     store: &sentryusb_drives::db::DriveStore,
     tag: &str,
+    new_home: Option<(f64, f64, f64)>,
 ) -> anyhow::Result<Frozen> {
     let tag = tag.trim();
     if tag.is_empty() || sentryusb_drives::charging::is_reserved_tag(tag) {
         anyhow::bail!("pick a name that isn't a reserved tag");
     }
-    let ids = sessions_at_home(store)?;
+    let ids = sessions_losing_home(store, new_home)?;
     if ids.is_empty() {
         return Ok(Frozen { tagged: 0, rates_dirty: false });
     }
@@ -1889,6 +1943,44 @@ mod tests {
                 "junk Home rate {junk} must not be copied"
             );
         }
+    }
+
+    /// The freeze set is decided by this. A false negative drops a charge from
+    /// the freeze that the move then un-tags, losing a cost nothing can rebuild;
+    /// a false positive only leaves a spare label on a charge that stayed home.
+    #[test]
+    fn only_the_charges_a_move_leaves_behind_are_frozen() {
+        // ~0.01 deg of latitude is ~1.1km, far outside any of these circles.
+        let old = (40.000_000, -75.000_000, 120.0);
+        let at_old = (Some(40.000_000), Some(-75.000_000));
+        let far = (Some(40.010_000), Some(-75.000_000));
+
+        // No move described: everything at home is treated as at risk.
+        assert!(loses_home(at_old.0, at_old.1, old, None));
+
+        // Moved away entirely — the old set loses the tag.
+        let moved = Some((40.010_000, -75.000_000, 120.0));
+        assert!(loses_home(at_old.0, at_old.1, old, moved));
+
+        // Same circle, re-saved: nothing leaves.
+        assert!(!loses_home(at_old.0, at_old.1, old, Some(old)));
+
+        // Radius INCREASE keeps every old charge inside, so none is frozen.
+        // This is the case that used to stamp a second label on charges that
+        // never left home.
+        let wider = Some((40.000_000, -75.000_000, 400.0));
+        assert!(!loses_home(at_old.0, at_old.1, old, wider));
+
+        // Radius shrink drops the ones now outside, keeps the ones inside.
+        let tighter = Some((40.000_000, -75.000_000, 20.0));
+        // ~0.0005 deg latitude is ~55m: inside 120m, outside 20m.
+        let edge = (Some(40.000_500), Some(-75.000_000));
+        assert!(loses_home(edge.0, edge.1, old, tighter));
+        assert!(!loses_home(at_old.0, at_old.1, old, tighter));
+
+        // Never home to begin with: not this feature's business either way.
+        assert!(!loses_home(far.0, far.1, old, moved));
+        assert!(!loses_home(None, None, old, moved));
     }
 
     /// The freeze marks the rate document dirty on this predicate. A false

--- a/crates/api/src/charging.rs
+++ b/crates/api/src/charging.rs
@@ -590,14 +590,14 @@ pub(crate) fn freeze_home_sessions(
     }
     let ids = sessions_at_home(store)?;
     if ids.is_empty() {
-        return Ok(Frozen { tagged: 0, rates_changed: false });
+        return Ok(Frozen { tagged: 0, rates_dirty: false });
     }
     // Rate first: it is the half that can conflict, and a conflict must abort
     // before anything is written. The in-use check runs inside that step (see
     // copy_home_rate_to); with the label unused, a rate left behind by a later
     // failure prices nothing. Exact tag match, mirroring `apply_rates`.
     let id_set: std::collections::HashSet<i64> = ids.iter().copied().collect();
-    let rates_changed = RateConfig::copy_home_rate_to(tag, || {
+    RateConfig::copy_home_rate_to(tag, || {
         // Propagates: treating a failed read as "no labels in use" would let the
         // repricing through on exactly the request that could not check.
         //
@@ -611,14 +611,38 @@ pub(crate) fn freeze_home_sessions(
             .iter()
             .any(|(id, tags)| !id_set.contains(id) && tags.iter().any(|t| t == tag)))
     })?;
+    // Mark BEFORE the tag write, and on "the label is priced" rather than "this
+    // call changed the map". A sync pull with no dirty row replaces the rate map
+    // wholesale, so an unmarked copy is not merely unsynced — it is deleted, and
+    // the frozen sessions lose exactly the cost this is preserving. Marking only
+    // on change leaves that hole open: if the tag write below fails after the
+    // rate landed, the retry plans `Nothing` and would never mark it.
+    //
+    // Hard error, not a warning: aborting here leaves an orphan rate on a label
+    // no session carries, which prices nothing.
+    let rates_dirty = tag_is_priced(&crate::preferences::load_prefs(), tag);
+    if rates_dirty {
+        store.mark_rate_config_dirty()?;
+    }
     let n = store.add_charge_tag_bulk(&ids, tag)?;
-    Ok(Frozen { tagged: n, rates_changed })
+    Ok(Frozen { tagged: n, rates_dirty })
 }
 
-/// Freeze outcome. `rates_changed` drives the cloud-sync nudge.
+/// Whether `tag` resolves to a configured rate, matched EXACTLY as
+/// `apply_rates` looks it up. Pure so the sync-marking decision is testable:
+/// getting it wrong loses the frozen sessions' cost on the next pull, silently.
+fn tag_is_priced(prefs: &serde_json::Map<String, serde_json::Value>, tag: &str) -> bool {
+    prefs
+        .get("charging_tag_rates")
+        .and_then(|v| v.as_object())
+        .and_then(|m| m.get(tag))
+        .is_some_and(|v| parse_tag_rate(v).is_configured())
+}
+
+/// Freeze outcome. `rates_dirty` drives the cloud-sync nudge.
 pub(crate) struct Frozen {
     pub tagged: usize,
-    pub rates_changed: bool,
+    pub rates_dirty: bool,
 }
 
 /// True when a session's charge location falls inside the home geofence.
@@ -1864,6 +1888,56 @@ mod tests {
                 RateCopy::Nothing,
                 "junk Home rate {junk} must not be copied"
             );
+        }
+    }
+
+    /// The freeze marks the rate document dirty on this predicate. A false
+    /// negative is silent and destructive: an unmarked rate loses to the next
+    /// pull, which replaces the rate map wholesale, so the frozen sessions keep
+    /// the label and lose the cost the freeze existed to preserve.
+    #[test]
+    fn a_priced_freeze_label_is_recognised_for_sync() {
+        let mk = |json: &str| -> serde_json::Map<String, serde_json::Value> {
+            serde_json::from_str(json).unwrap()
+        };
+
+        // Just-copied: the case that must sync.
+        let p = mk(r#"{"charging_tag_rates":{"Home":0.12,"Old House":0.12}}"#);
+        assert!(tag_is_priced(&p, "Old House"));
+
+        // The retry hole. A tag write that fails after the rate landed leaves
+        // this state; the retry plans `Nothing`, so marking on "the map changed"
+        // would never fire and the copy would be dropped on the next pull.
+        assert_eq!(home_rate_copy_plan(&p, "Old House"), RateCopy::Nothing);
+        assert!(tag_is_priced(&p, "Old House"), "an equal rate still needs marking");
+
+        // Schedule-only pricing counts: no flat rate, but the windows price it.
+        let p = mk(
+            r#"{"charging_tag_rates":{"Old House":{"schedules":[
+                {"start":"22:00","end":"06:00","rate":"0.08"}
+            ]}}}"#,
+        );
+        assert!(tag_is_priced(&p, "Old House"));
+
+        // A schedule the parser drops (no time bounds) prices nothing, so the
+        // label is not priced by it — matching `is_configured`.
+        let p = mk(r#"{"charging_tag_rates":{"Old House":{"schedules":[{"rate":0.05}]}}}"#);
+        assert!(!tag_is_priced(&p, "Old House"));
+
+        // Nothing was preserved, so there is nothing to sync.
+        assert!(!tag_is_priced(&mk("{}"), "Old House"));
+        let p = mk(r#"{"charging_tag_rates":{"Home":0.12}}"#);
+        assert!(!tag_is_priced(&p, "Old House"));
+
+        // Exact match, mirroring the render-time lookup: a differently-cased key
+        // is a different tag and does not price this one.
+        let p = mk(r#"{"charging_tag_rates":{"old house":0.12}}"#);
+        assert!(!tag_is_priced(&p, "Old House"));
+
+        // Junk prices nothing, so it is not worth a push.
+        for junk in [r#""NaN""#, r#""-1""#, "{}", r#"{"flat":null}"#] {
+            let p = mk(&format!(r#"{{"charging_tag_rates":{{"Old House":{junk}}}}}"#));
+            assert!(!tag_is_priced(&p, "Old House"), "junk rate {junk} is not a price");
         }
     }
 }

--- a/crates/api/src/keep_accessory.rs
+++ b/crates/api/src/keep_accessory.rs
@@ -197,13 +197,13 @@ pub async fn keep_accessory_config_set(
             {
                 Ok(Ok(f)) => {
                     frozen = f.tagged;
-                    // The copied rate is part of the synced rate document, so
-                    // it has to reach the cloud like any other rate edit —
-                    // otherwise a restore brings back the tags without the price.
-                    if f.rates_changed {
-                        if let Err(e) = _s.drives.store.mark_rate_config_dirty() {
-                            tracing::warn!("[keep-accessory] mark_rate_config_dirty failed: {e}");
-                        }
+                    // The copied rate is part of the synced rate document, so it
+                    // has to reach the cloud like any other rate edit. The dirty
+                    // mark itself happens at write time inside the freeze — doing
+                    // it only here would leave the rate unmarked whenever the
+                    // freeze failed after writing it, and a pull would then drop
+                    // the copy. All that is left is waking the sweep.
+                    if f.rates_dirty {
                         _s.cloud.uploader.nudge();
                     }
                 }

--- a/crates/api/src/keep_accessory.rs
+++ b/crates/api/src/keep_accessory.rs
@@ -165,6 +165,12 @@ pub struct KeepAccessoryConfigBody {
     pub home_lat: Option<f64>,
     pub home_lon: Option<f64>,
     pub home_radius_m: Option<f64>,
+    /// Before moving home, freeze the sessions inside the OLD geofence under
+    /// this stored tag (e.g. "Old House"). The Home tag is derived, so without
+    /// this a move un-tags every past charge there and drops any cost that came
+    /// from the Home rate. Must run BEFORE the geofence moves — afterwards the
+    /// old set cannot be identified. Ignored when home is not changing.
+    pub freeze_home_as: Option<String>,
 }
 
 /// PUT /api/system/keep-accessory-config → persist the keep-accessory
@@ -174,6 +180,52 @@ pub async fn keep_accessory_config_set(
     State(_s): State<AppState>,
     Json(body): Json<KeepAccessoryConfigBody>,
 ) -> (StatusCode, Json<serde_json::Value>) {
+    // Radius resizes the same circle, so it re-derives the Home set exactly
+    // as a center move does — invalidate on either.
+    let freeze_as = body.freeze_home_as.clone().filter(|t| !t.trim().is_empty());
+    let home_moving =
+        body.home_lat.is_some() || body.home_lon.is_some() || body.home_radius_m.is_some();
+
+    let mut frozen = 0usize;
+    if home_moving {
+        if let Some(tag) = freeze_as {
+            let store = _s.drives.store.clone();
+            match tokio::task::spawn_blocking(move || {
+                crate::charging::freeze_home_sessions(&store, &tag)
+            })
+            .await
+            {
+                Ok(Ok(f)) => {
+                    frozen = f.tagged;
+                    // The copied rate is part of the synced rate document, so
+                    // it has to reach the cloud like any other rate edit —
+                    // otherwise a restore brings back the tags without the price.
+                    if f.rates_changed {
+                        if let Err(e) = _s.drives.store.mark_rate_config_dirty() {
+                            tracing::warn!("[keep-accessory] mark_rate_config_dirty failed: {e}");
+                        }
+                        _s.cloud.uploader.nudge();
+                    }
+                }
+                // ABORT: the caller asked to preserve history first. Moving
+                // anyway would destroy exactly what they were protecting, and
+                // an ok:true would hide it. Leave the geofence alone.
+                Ok(Err(e)) => {
+                    return crate::json_error(
+                        StatusCode::BAD_REQUEST,
+                        &format!("home not moved — could not preserve past charges: {e}"),
+                    )
+                }
+                Err(e) => {
+                    return crate::json_error(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        &format!("home not moved — freeze task failed: {e}"),
+                    )
+                }
+            }
+        }
+    }
+
     let result = tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
         let config_path = sentryusb_config::find_config_path();
         let (mut active, _) = sentryusb_config::parse_file(config_path)?;
@@ -210,7 +262,17 @@ pub async fn keep_accessory_config_set(
     match result {
         Ok(Ok(())) => {
             info!("[keep-accessory] config updated");
-            (StatusCode::OK, Json(serde_json::json!({ "ok": true })))
+            if home_moving {
+                // The "Home" tag is derived from this geofence, so every cached
+                // charging summary is now stale. Without this the user saves a
+                // new home and the tags stay wrong for up to the cache TTL,
+                // which reads as "it didn't work".
+                crate::charging::invalidate_charging_list();
+            }
+            (
+                StatusCode::OK,
+                Json(serde_json::json!({ "ok": true, "frozen": frozen })),
+            )
         }
         Ok(Err(e)) => crate::json_error(
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/crates/api/src/keep_accessory.rs
+++ b/crates/api/src/keep_accessory.rs
@@ -165,11 +165,13 @@ pub struct KeepAccessoryConfigBody {
     pub home_lat: Option<f64>,
     pub home_lon: Option<f64>,
     pub home_radius_m: Option<f64>,
-    /// Before moving home, freeze the sessions inside the OLD geofence under
-    /// this stored tag (e.g. "Old House"). The Home tag is derived, so without
-    /// this a move un-tags every past charge there and drops any cost that came
-    /// from the Home rate. Must run BEFORE the geofence moves — afterwards the
-    /// old set cannot be identified. Ignored when home is not changing.
+    /// Before moving home, freeze the sessions this move takes out of the
+    /// geofence under this stored tag (e.g. "Old House"). The Home tag is
+    /// derived, so without this a move un-tags every past charge it leaves
+    /// behind and drops any cost that came from the Home rate. Charges that stay
+    /// inside the new circle keep deriving Home and are left alone. Must run
+    /// BEFORE the geofence moves — afterwards the old set cannot be identified.
+    /// Ignored when home is not changing.
     pub freeze_home_as: Option<String>,
 }
 
@@ -186,12 +188,26 @@ pub async fn keep_accessory_config_set(
     let home_moving =
         body.home_lat.is_some() || body.home_lon.is_some() || body.home_radius_m.is_some();
 
+    // Clamp ONCE, here, and both write and freeze the same numbers. The freeze
+    // decides which sessions survive the move by testing them against the
+    // destination, so a second clamp elsewhere could answer "still home" about a
+    // circle that is not the one being written.
+    let new_lat = body.home_lat.filter(|v| v.is_finite()).map(|v| v.clamp(-90.0, 90.0));
+    // Leaflet world-copy clicks can arrive as e.g. -221.4 for 138.6°E.
+    let new_lon = body.home_lon.filter(|v| v.is_finite()).map(crate::normalize_lon);
+    // Clamp to a sane range (20m–2km) so a fat-finger can't make the geofence
+    // cover the county or vanish.
+    let new_radius = body.home_radius_m.map(|r| r.clamp(20.0, 2000.0).round());
+    let enabled = body.enabled;
+
     let mut frozen = 0usize;
     if home_moving {
         if let Some(tag) = freeze_as {
             let store = _s.drives.store.clone();
             match tokio::task::spawn_blocking(move || {
-                crate::charging::freeze_home_sessions(&store, &tag)
+                let new_home =
+                    crate::charging::pending_home_geofence(new_lat, new_lon, new_radius);
+                crate::charging::freeze_home_sessions(&store, &tag, new_home)
             })
             .await
             {
@@ -229,26 +245,23 @@ pub async fn keep_accessory_config_set(
     let result = tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
         let config_path = sentryusb_config::find_config_path();
         let (mut active, _) = sentryusb_config::parse_file(config_path)?;
-        if let Some(enabled) = body.enabled {
+        if let Some(enabled) = enabled {
             active.insert(
                 "KEEP_ACCESSORY_ENABLED".to_string(),
                 if enabled { "yes" } else { "no" }.to_string(),
             );
         }
-        if let Some(lat) = body.home_lat.filter(|v| v.is_finite()) {
-            let lat = lat.clamp(-90.0, 90.0);
+        if let Some(lat) = new_lat {
             active.insert("KEEP_ACCESSORY_HOME_LAT".to_string(), format!("{lat:.6}"));
         }
-        if let Some(lon) = body.home_lon.filter(|v| v.is_finite()) {
-            // Leaflet world-copy clicks can arrive as e.g. -221.4 for 138.6°E.
-            let lon = crate::normalize_lon(lon);
+        if let Some(lon) = new_lon {
             active.insert("KEEP_ACCESSORY_HOME_LON".to_string(), format!("{lon:.6}"));
         }
-        if let Some(r) = body.home_radius_m {
-            // Clamp to a sane range (20m–2km) so a fat-finger can't make
-            // the geofence cover the county or vanish.
-            let r = r.clamp(20.0, 2000.0).round() as i64;
-            active.insert("KEEP_ACCESSORY_HOME_RADIUS_M".to_string(), r.to_string());
+        if let Some(r) = new_radius {
+            active.insert(
+                "KEEP_ACCESSORY_HOME_RADIUS_M".to_string(),
+                (r as i64).to_string(),
+            );
         }
         // RO root → flip rw for the write (same pattern as ble_enabled_set).
         let _ = std::process::Command::new("bash")

--- a/crates/api/src/preferences.rs
+++ b/crates/api/src/preferences.rs
@@ -47,6 +47,39 @@ pub(crate) fn load_prefs() -> serde_json::Map<String, serde_json::Value> {
         .unwrap_or_default()
 }
 
+/// Load → modify → save under [`PREFS_LOCK`], propagating write failures.
+/// `f` returns whether it changed anything; nothing is written if it didn't.
+/// Use over `save_prefs` (which only logs) when the caller must know the
+/// write landed.
+pub(crate) fn update_prefs<F>(f: F) -> anyhow::Result<bool>
+where
+    F: FnOnce(&mut serde_json::Map<String, serde_json::Value>) -> anyhow::Result<bool>,
+{
+    let _guard = PREFS_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let mut prefs = load_prefs();
+    if !f(&mut prefs)? {
+        return Ok(false);
+    }
+    save_prefs_checked(&prefs)?;
+    Ok(true)
+}
+
+/// Same write as [`save_prefs`] but the caller sees the failure.
+fn save_prefs_checked(prefs: &serde_json::Map<String, serde_json::Value>) -> anyhow::Result<()> {
+    let data = serde_json::to_string_pretty(prefs)?;
+    let prefs_path = prefs_file();
+    if let Some(parent) = std::path::Path::new(&prefs_path).parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let tmp = format!("{}.tmp", prefs_path);
+    std::fs::write(&tmp, &data)?;
+    if let Err(e) = std::fs::rename(&tmp, &prefs_path) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e.into());
+    }
+    Ok(())
+}
+
 pub(crate) fn save_prefs(prefs: &serde_json::Map<String, serde_json::Value>) {
     // Atomic tmp+rename — a direct `fs::write` leaves the file in an
     // intermediate zero-length state if the kernel panics mid-write,

--- a/crates/api/src/router.rs
+++ b/crates/api/src/router.rs
@@ -227,7 +227,7 @@ pub fn build_router(state: AppState) -> Router {
             get(crate::drives_handler::tire_history),
         )
         // Charging — sessions derived on-demand from the per-sample
-        // charge columns. Empty unless the experimental flag is on.
+        // charge columns.
         .route("/api/charging", get(crate::charging::list_charging))
         .route("/api/charging/current", get(crate::charging::current_charging))
         .route("/api/charging/tags", get(crate::charging::list_charge_tags))

--- a/crates/api/src/router.rs
+++ b/crates/api/src/router.rs
@@ -232,6 +232,10 @@ pub fn build_router(state: AppState) -> Router {
         .route("/api/charging/current", get(crate::charging::current_charging))
         .route("/api/charging/tags", get(crate::charging::list_charge_tags))
         .route(
+            "/api/charging/home-sessions",
+            get(crate::charging::home_session_count),
+        )
+        .route(
             "/api/charging/bulk-delete",
             post(crate::charging::bulk_delete_charges),
         )

--- a/crates/drives/src/db.rs
+++ b/crates/drives/src/db.rs
@@ -1063,6 +1063,43 @@ impl DriveStore {
         Ok(())
     }
 
+    /// ADD one tag to many sessions in a SINGLE transaction.
+    ///
+    /// Used when the home geofence moves: the "Home" tag is derived, so every
+    /// past session at the old address is about to lose it (and any cost that
+    /// came from the Home rate). Freezing them under a real stored tag keeps
+    /// that history — but only if it is all-or-nothing. Tagging them one call
+    /// at a time meant a failure halfway left some sessions frozen and the rest
+    /// silently stripped, which is worse than not offering the feature.
+    ///
+    /// Additive on purpose: it never rewrites a session's existing tags, so a
+    /// failed read of the current tag map cannot wipe them. Re-running with the
+    /// same label is a no-op thanks to INSERT OR IGNORE.
+    pub fn add_charge_tag_bulk(&self, session_ts: &[i64], tag: &str) -> Result<usize> {
+        let tag = tag.trim();
+        if tag.is_empty() || crate::charging::is_reserved_tag(tag) {
+            anyhow::bail!("refusing to store a reserved or empty tag: {tag:?}");
+        }
+        if session_ts.is_empty() {
+            return Ok(0);
+        }
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction()?;
+        {
+            let mut stmt = tx.prepare(
+                "INSERT OR IGNORE INTO charge_tags(session_ts, tag) VALUES(?1, ?2)",
+            )?;
+            for ts in session_ts {
+                stmt.execute(params![ts, tag])?;
+            }
+        }
+        for ts in session_ts {
+            mark_mutable_dirty(&tx, "charge", &ts.to_string())?;
+        }
+        tx.commit()?;
+        Ok(session_ts.len())
+    }
+
     /// Tags for one charge session, or an empty vec.
     pub fn get_charge_tags(&self, session_ts: i64) -> Result<Vec<String>> {
         self.with_read_conn(|conn| {
@@ -4166,4 +4203,38 @@ mod tests {
         assert_ne!(pushed, "stale-go-era-copy");
         assert!(pushed.contains("2025-01-15"));
     }
+    #[test]
+    fn bulk_tag_is_additive_and_rejects_reserved_labels() {
+        let store = DriveStore::open_memory().unwrap();
+        // Existing tags must survive: the freeze runs while the user still has
+        // a year of labels on these sessions, and clobbering them would be a
+        // worse loss than the derived tag it is trying to preserve.
+        store.set_charge_tags(1000, &["Public".into()]).unwrap();
+        store.set_charge_tags(2000, &["Road trip".into()]).unwrap();
+
+        let n = store.add_charge_tag_bulk(&[1000, 2000], "Old House").unwrap();
+        assert_eq!(n, 2);
+        assert_eq!(
+            store.get_charge_tags(1000).unwrap(),
+            vec!["Old House".to_string(), "Public".to_string()]
+        );
+        assert_eq!(
+            store.get_charge_tags(2000).unwrap(),
+            vec!["Old House".to_string(), "Road trip".to_string()]
+        );
+
+        // Idempotent — moving house twice with the same label must not duplicate.
+        store.add_charge_tag_bulk(&[1000], "Old House").unwrap();
+        assert_eq!(
+            store.get_charge_tags(1000).unwrap(),
+            vec!["Old House".to_string(), "Public".to_string()]
+        );
+
+        // Reserved labels are refused: they are re-derived, so storing one is a
+        // silent no-op that would leave the user believing history was kept.
+        assert!(store.add_charge_tag_bulk(&[1000], "Home").is_err());
+        assert!(store.add_charge_tag_bulk(&[1000], "fast charging").is_err());
+        assert!(store.add_charge_tag_bulk(&[1000], "   ").is_err());
+    }
+
 }

--- a/web/src/components/charging/HomeLocationSection.tsx
+++ b/web/src/components/charging/HomeLocationSection.tsx
@@ -196,8 +196,8 @@ export function HomeLocationSection({
                 {atRisk === null
                   ? "Some past charges may be tagged Home at your current location."
                   : `${atRisk} past ${atRisk === 1 ? "charge is" : "charges are"} tagged Home at your current location.`}{" "}
-                Moving home un-tags {atRisk === 1 ? "it" : "them"} and drops any cost that came from
-                your Home rate. Keep them under a name instead:
+                Any that end up outside the new area lose that tag, and with it any cost that came
+                from your Home rate. Keep those under a name instead:
               </p>
               <div className="flex items-center gap-2">
                 <input
@@ -217,8 +217,8 @@ export function HomeLocationSection({
                 </button>
               </div>
               <p className="text-[10px] text-amber-200/60">
-                Tags those charges and copies your Home rate onto that name, so they keep their cost
-                and stay filterable.
+                Tags the charges that leave the area and copies your Home rate onto that name, so
+                they keep their cost and stay filterable. Charges still inside it are left alone.
               </p>
               <button
                 type="button"

--- a/web/src/components/charging/HomeLocationSection.tsx
+++ b/web/src/components/charging/HomeLocationSection.tsx
@@ -1,0 +1,244 @@
+import { useEffect, useState } from "react"
+import { HomeGeofencePicker } from "../settings/HomeGeofencePicker"
+import { useKeepAccessory } from "../../hooks/useKeepAccessory"
+
+/**
+ * Set the home geofence from the Charging tab. Writes the same
+ * KEEP_ACCESSORY_HOME_LAT/LON through the same endpoint as Keep Accessory, so
+ * the two screens cannot drift. Uses HomeGeofencePicker, not the full
+ * KeepAccessoryConfig, to keep the accessory-power switch off this screen.
+ *
+ * Every edit is drafted, never live: saving re-derives the Home tag on all past
+ * charges and drops any Home-rate cost, so nothing is written until the user
+ * confirms — and when history is at stake the confirm offers to keep it.
+ */
+export function HomeLocationSection({
+  onSaved,
+  onDone,
+  /** Pin seed when opened from a specific charge. Also the only way in
+   *  without BLE, since "use current location" needs the car's GPS. */
+  seedLat,
+  seedLon,
+}: {
+  onSaved?: () => void
+  /** Close the dialog after a successful save. */
+  onDone?: () => void
+  seedLat?: number | null
+  seedLon?: number | null
+}) {
+  // Renamed on destructure: it is a plain async function, but the `use` prefix
+  // makes rules-of-hooks reject calling it from a callback.
+  const { values, loaded, saveError, useCurrentLocation: fetchCurrentLocation } =
+    useKeepAccessory()
+
+  // Pending edits. Null = untouched, so the picker shows the saved geofence
+  // (or the seed when there is no saved one).
+  const [draft, setDraft] = useState<{
+    lat: number | null
+    lon: number | null
+    radiusM: number
+  } | null>(null)
+  const [atRisk, setAtRisk] = useState<number | null>(null)
+  const [freezeTag, setFreezeTag] = useState("Old House")
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [gpsAvailable, setGpsAvailable] = useState(false)
+
+  // Charges the current geofence claims — what a move would rewrite. null =
+  // unknown (loading or failed) and is treated as "there may be history", so a
+  // failed probe never waves the user past the warning.
+  useEffect(() => {
+    let alive = true
+    fetch("/api/charging/home-sessions")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => {
+        if (alive) setAtRisk(d && d.home_set ? d.count : d ? 0 : null)
+      })
+      .catch(() => {
+        if (alive) setAtRisk(null)
+      })
+    return () => {
+      alive = false
+    }
+  }, [])
+
+  // "Use current location" needs a GPS fix over the Tesla BLE link; without
+  // pairing the button would do nothing, so only offer it when a fix exists.
+  useEffect(() => {
+    let alive = true
+    fetch("/api/system/keep-accessory-gps")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => {
+        if (alive) setGpsAvailable(typeof d?.lat === "number" && typeof d?.lon === "number")
+      })
+      .catch(() => {})
+    return () => {
+      alive = false
+    }
+  }, [])
+
+  const savedLat = values.homeLat
+  const savedLon = values.homeLon
+  // Seed wins: it only arrives when the user pointed at a specific charge, so
+  // showing the existing home instead would break the relocate flow. No seed
+  // (the Home chip) falls back to the saved geofence.
+  const baseLat = seedLat ?? savedLat ?? null
+  const baseLon = seedLon ?? savedLon ?? null
+
+  const shownLat = draft ? draft.lat : baseLat
+  const shownLon = draft ? draft.lon : baseLon
+  const shownRadius = draft ? draft.radiusM : values.radiusM
+
+  const moved =
+    shownLat != null &&
+    shownLon != null &&
+    (savedLat == null ||
+      savedLon == null ||
+      Math.abs(shownLat - savedLat) > 1e-6 ||
+      Math.abs(shownLon - savedLon) > 1e-6 ||
+      shownRadius !== values.radiusM)
+
+  const risky = moved && (atRisk === null || atRisk > 0)
+
+  /** One request: the server freezes the old set (when asked) before moving
+   *  the geofence, and aborts the move if the freeze fails. */
+  const commit = async (freezeAs: string | null) => {
+    if (shownLat == null || shownLon == null) return
+    setBusy(true)
+    setError(null)
+    try {
+      const res = await fetch("/api/system/keep-accessory-config", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          home_lat: shownLat,
+          home_lon: shownLon,
+          home_radius_m: shownRadius,
+          ...(freezeAs ? { freeze_home_as: freezeAs } : {}),
+        }),
+      })
+      if (!res.ok) {
+        const body = await res.json().catch(() => null)
+        setError(body?.error ?? "Couldn't save — the Pi rejected the change.")
+        return
+      }
+      setDraft(null)
+      setAtRisk(0)
+      onSaved?.()
+      onDone?.()
+    } catch {
+      setError("Couldn't reach the Pi.")
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <section className="space-y-3">
+      <p className="text-xs text-slate-500">
+        Charges inside this area are tagged <span className="text-slate-300">Home</span> and priced
+        with your Home rate. The same location is used by Keep Accessory; Away Mode shares the
+        center but keeps its own radius.
+      </p>
+
+      {!loaded ? (
+        <p className="text-xs text-slate-500">Loading…</p>
+      ) : (
+        <>
+          <HomeGeofencePicker
+            values={{ homeLat: shownLat, homeLon: shownLon, radiusM: shownRadius }}
+            onChange={(patch) =>
+              setDraft((d) => ({
+                lat: patch.homeLat ?? d?.lat ?? shownLat,
+                lon: patch.homeLon ?? d?.lon ?? shownLon,
+                radiusM: patch.radiusM ?? d?.radiusM ?? shownRadius,
+              }))
+            }
+            // Drafted like every other edit.
+            onUseCurrentLocation={
+              gpsAvailable
+                ? async () => {
+                    const fix = await fetchCurrentLocation()
+                    if (fix) {
+                      setDraft((d) => ({
+                        lat: fix.lat,
+                        lon: fix.lon,
+                        radiusM: d?.radiusM ?? shownRadius,
+                      }))
+                    }
+                    return fix
+                  }
+                : undefined
+            }
+            saveError={saveError}
+            mapHint="Charges inside this circle are tagged Home."
+          />
+
+          {moved && !risky && (
+            <div className="flex flex-wrap items-center gap-2 rounded-md border border-emerald-400/20 bg-emerald-400/5 px-2.5 py-2">
+              <p className="min-w-0 flex-1 text-[11px] text-emerald-200/90">
+                Nothing is saved until you confirm.
+              </p>
+              <button
+                type="button"
+                disabled={busy}
+                onClick={() => commit(null)}
+                className="shrink-0 rounded-md bg-emerald-400/20 px-3 py-1 text-xs font-medium text-emerald-100 disabled:opacity-50"
+              >
+                Save home location
+              </button>
+            </div>
+          )}
+
+          {risky && (
+            <div className="space-y-2 rounded-md border border-amber-500/25 bg-amber-500/5 p-2.5">
+              <p className="text-[11px] text-amber-200">
+                {atRisk === null
+                  ? "Some past charges may be tagged Home at your current location."
+                  : `${atRisk} past ${atRisk === 1 ? "charge is" : "charges are"} tagged Home at your current location.`}{" "}
+                Moving home un-tags {atRisk === 1 ? "it" : "them"} and drops any cost that came from
+                your Home rate. Keep them under a name instead:
+              </p>
+              <div className="flex items-center gap-2">
+                <input
+                  value={freezeTag}
+                  onChange={(e) => setFreezeTag(e.target.value)}
+                  placeholder="Old House"
+                  aria-label="Name to keep the old home charges under"
+                  className="min-w-0 flex-1 rounded-md border border-white/10 bg-black/30 px-2 py-1 text-xs text-slate-200"
+                />
+                <button
+                  type="button"
+                  disabled={busy || !freezeTag.trim()}
+                  onClick={() => commit(freezeTag.trim())}
+                  className="shrink-0 rounded-md bg-emerald-400/20 px-3 py-1 text-xs font-medium text-emerald-100 disabled:opacity-50"
+                >
+                  Keep &amp; move
+                </button>
+              </div>
+              <p className="text-[10px] text-amber-200/60">
+                Tags those charges and copies your Home rate onto that name, so they keep their cost
+                and stay filterable.
+              </p>
+              <button
+                type="button"
+                disabled={busy}
+                onClick={() => commit(null)}
+                className="text-[11px] text-slate-400 underline disabled:opacity-50"
+              >
+                Move without keeping them
+              </button>
+            </div>
+          )}
+
+          {error && <p className="text-[11px] text-rose-300">{error}</p>}
+
+          <p className="rounded-md border border-white/[0.06] px-2.5 py-2 text-[11px] text-slate-500">
+            The Home tag is worked out from this location every time the list loads — it is not
+            saved per charge. Costs you typed in yourself are always kept.
+          </p>
+        </>
+      )}
+    </section>
+  )
+}

--- a/web/src/pages/Charging.tsx
+++ b/web/src/pages/Charging.tsx
@@ -145,10 +145,10 @@ export default function Charging() {
       // still has to be confirmed in the dialog, because it re-tags history.
       const isHome = (t: string) => t.trim().toLowerCase() === "home"
       const sess = sessions.find((x) => x.id === id)
-      // Only when Home is NEWLY added. The API already injects "Home" into the
-      // tags of an at-home charge for display, so testing `next` alone fired on
-      // every unrelated tag edit — adding "Work" to a home charge popped the
-      // relocation dialog.
+      // "Home" is never in a session's stored tags (it is derived into `atHome`,
+      // and the store strips it), so its presence here means the user just typed
+      // or picked it. Unrelated edits carry it in neither list and never open the
+      // dialog. Still filtered out below rather than trusted to that.
       const asksHome = next.some(isHome) && !(sess?.tags ?? []).some(isHome)
       if (asksHome && sess?.locationLat != null && sess?.locationLon != null) {
         setHomeSeed({ lat: sess.locationLat, lon: sess.locationLon })

--- a/web/src/pages/Charging.tsx
+++ b/web/src/pages/Charging.tsx
@@ -46,6 +46,16 @@ export default function Charging() {
   // every row, which is what per-session affordances degrade into when the
   // feature is entirely unconfigured.
   const [homeConfigured, setHomeConfigured] = useState<boolean | null>(null)
+  // Escape closes the editor. Nothing is written until the user confirms, so
+  // backing out is always safe and should not need a mouse.
+  useEffect(() => {
+    if (!homeSeed) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setHomeSeed(null)
+    }
+    document.addEventListener("keydown", onKey)
+    return () => document.removeEventListener("keydown", onKey)
+  }, [homeSeed])
   useEffect(() => {
     let alive = true
     fetch("/api/system/keep-accessory-config")
@@ -380,12 +390,17 @@ export default function Charging() {
           onClick={() => setHomeSeed(null)}
         >
           <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="home-location-title"
             className="max-h-[85vh] w-full max-w-md overflow-y-auto rounded-xl border border-white/10 bg-slate-950 p-4"
             onClick={(e) => e.stopPropagation()}
           >
             <div className="mb-3 flex items-center justify-between">
               <div>
-                <h2 className="text-sm font-medium text-slate-200">Home location</h2>
+                <h2 id="home-location-title" className="text-sm font-medium text-slate-200">
+                  Home location
+                </h2>
               </div>
               <button
                 type="button"

--- a/web/src/pages/Charging.tsx
+++ b/web/src/pages/Charging.tsx
@@ -23,6 +23,7 @@ import type { ChargeSessionSummary, CurrentCharge } from "@/types/charging"
 import { cn } from "@/lib/utils"
 import { DatePopover } from "@/components/drives/DatePopover"
 import { TagPopover } from "@/components/drives/TagPopover"
+import { HomeLocationSection } from "@/components/charging/HomeLocationSection"
 import {
   ChargingSummaryStrip,
   type ChargingStats,
@@ -39,6 +40,24 @@ import { fmtDuration, fmtEnergy, fmtMoney, fmtSoc } from "@/lib/charge-format"
 const POLL_MS = 30_000
 
 export default function Charging() {
+  const [homeSeed, setHomeSeed] = useState<{ lat: number | null; lon: number | null } | null>(null)
+  // Whether a home geofence exists at all. Without one NOTHING can be tagged
+  // Home, so the answer is a single prompt — not a "set as home" button on
+  // every row, which is what per-session affordances degrade into when the
+  // feature is entirely unconfigured.
+  const [homeConfigured, setHomeConfigured] = useState<boolean | null>(null)
+  useEffect(() => {
+    let alive = true
+    fetch("/api/system/keep-accessory-config")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => {
+        if (alive) setHomeConfigured(d ? d.home_lat != null && d.home_lon != null : null)
+      })
+      .catch(() => {})
+    return () => {
+      alive = false
+    }
+  }, [])
   const [sessions, setSessions] = useState<ChargeSessionSummary[]>([])
   const [tags, setTags] = useState<string[]>([])
   const [selectedTags, setSelectedTags] = useState<string[]>([])
@@ -119,6 +138,23 @@ export default function Charging() {
 
   const onTagsChange = useCallback(
     async (id: number, next: string[]) => {
+      // Tagging a charge "Home" is the user saying "this is home" — so treat it
+      // as a request to MOVE the geofence, not a tag write. The tag is derived
+      // and the store strips it anyway, so storing it would silently do
+      // nothing; this turns a dead action into the one they meant. The change
+      // still has to be confirmed in the dialog, because it re-tags history.
+      const isHome = (t: string) => t.trim().toLowerCase() === "home"
+      const sess = sessions.find((x) => x.id === id)
+      // Only when Home is NEWLY added. The API already injects "Home" into the
+      // tags of an at-home charge for display, so testing `next` alone fired on
+      // every unrelated tag edit — adding "Work" to a home charge popped the
+      // relocation dialog.
+      const asksHome = next.some(isHome) && !(sess?.tags ?? []).some(isHome)
+      if (asksHome && sess?.locationLat != null && sess?.locationLon != null) {
+        setHomeSeed({ lat: sess.locationLat, lon: sess.locationLon })
+      }
+      // Strip it either way: it is derived, and the store discards it on write.
+      next = next.filter((t) => !isHome(t))
       // Optimistic: show the new tags immediately, then resync (cost is
       // recomputed server-side from the tags).
       setSessions((prev) =>
@@ -130,7 +166,7 @@ export default function Charging() {
         await reload()
       }
     },
-    [reload],
+    [reload, sessions],
   )
 
   const toggleSelectMode = () => {
@@ -275,6 +311,32 @@ export default function Charging() {
         </div>
       </div>
 
+      {homeConfigured === false && sessions.some((x) => x.locationLat != null) && (
+        <div className="mb-3 flex flex-wrap items-center gap-3 rounded-lg border border-white/10 bg-white/[0.02] px-3 py-2.5">
+          <HomeIcon className="h-4 w-4 shrink-0 text-slate-400" />
+          <p className="min-w-0 flex-1 text-xs text-slate-400">
+            No home location set, so none of these charges can be tagged{" "}
+            <span className="text-slate-300">Home</span> or priced with a home rate.
+          </p>
+          <button
+            type="button"
+            onClick={() => {
+              // Seed from the most recent charge that has coordinates — for most
+              // people that is home, and it beats opening a world map. They can
+              // drag the pin if it guessed wrong.
+              const withFix = sessions.find((x) => x.locationLat != null && x.locationLon != null)
+              setHomeSeed({
+                lat: withFix?.locationLat ?? null,
+                lon: withFix?.locationLon ?? null,
+              })
+            }}
+            className="shrink-0 rounded-md border border-white/10 bg-white/[0.04] px-3 py-1.5 text-xs font-medium text-slate-200 hover:bg-white/[0.08]"
+          >
+            Set home location
+          </button>
+        </div>
+      )}
+
       <div className="mt-4 flex flex-col gap-3">
         {loading && (
           <div className="flex items-center justify-center gap-2 rounded-2xl border border-white/[0.06] bg-white/[0.025] p-10 text-sm text-slate-400">
@@ -307,9 +369,44 @@ export default function Charging() {
               selected={selected.has(s.id)}
               onToggleSelected={onToggleSelected}
               onTagsChange={onTagsChange}
+              onOpenHomeLocation={(lat, lon) => setHomeSeed({ lat, lon })}
             />
           ))}
       </div>
+
+      {homeSeed && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4"
+          onClick={() => setHomeSeed(null)}
+        >
+          <div
+            className="max-h-[85vh] w-full max-w-md overflow-y-auto rounded-xl border border-white/10 bg-slate-950 p-4"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="mb-3 flex items-center justify-between">
+              <div>
+                <h2 className="text-sm font-medium text-slate-200">Home location</h2>
+              </div>
+              <button
+                type="button"
+                onClick={() => setHomeSeed(null)}
+                className="rounded-md border border-white/10 bg-white/[0.04] px-3 py-1 text-xs font-medium text-slate-200 hover:bg-white/[0.08]"
+              >
+                Done
+              </button>
+            </div>
+            <HomeLocationSection
+              onSaved={() => {
+                setHomeConfigured(true) // kill the banner without a page reload
+                reload()
+              }}
+              onDone={() => setHomeSeed(null)}
+              seedLat={homeSeed.lat}
+              seedLon={homeSeed.lon}
+            />
+          </div>
+        </div>
+      )}
 
       {confirmingBulkDelete && (
         <div className="fixed inset-0 z-[2000] flex items-center justify-center bg-black/60 backdrop-blur-sm">
@@ -416,6 +513,7 @@ function ChargeRow({
   selected,
   onToggleSelected,
   onTagsChange,
+  onOpenHomeLocation,
 }: {
   session: ChargeSessionSummary
   metric: boolean
@@ -425,6 +523,7 @@ function ChargeRow({
   selected: boolean
   onToggleSelected: (id: number) => void
   onTagsChange: (id: number, tags: string[]) => Promise<void> | void
+  onOpenHomeLocation: (lat: number | null, lon: number | null) => void
 }) {
   const navigate = useNavigate()
   const start = new Date(session.startMs)
@@ -581,13 +680,21 @@ function ChargeRow({
         className="flex items-center gap-1.5"
       >
         {session.atHome && (
-          <span
-            title="Charged at home (automatic)"
-            className="inline-flex items-center gap-1 rounded-md border border-emerald-400/30 bg-emerald-400/10 px-2 py-1 text-xs font-medium text-emerald-200"
+          // Tappable on purpose. The Home chip is derived from the geofence, so
+          // "how does it know?" is the obvious next question — answer it where
+          // the question is asked instead of burying the setting in a menu.
+          <button
+            type="button"
+            title="Charged at home — tap to see or change your home location"
+            onClick={(e) => {
+              e.stopPropagation() // the whole row navigates to the detail page
+              onOpenHomeLocation(null, null) // edit the saved home, don't propose a move
+            }}
+            className="inline-flex items-center gap-1 rounded-md border border-emerald-400/30 bg-emerald-400/10 px-2 py-1 text-xs font-medium text-emerald-200 transition-colors hover:bg-emerald-400/20"
           >
             <HomeIcon className="h-3 w-3" />
             Home
-          </span>
+          </button>
         )}
         <TagPopover
           tags={session.tags}


### PR DESCRIPTION
## Why

The charging **Home** tag is derived from the Keep Accessory geofence, but that geofence could only be set under Keep Accessory — nowhere near the tab where the tag actually shows up. Requested on the board as *"Add 'Home' address auto-tag for Charging tab"*.

Setting it from Charging surfaces a hazard that was always there and never visible: because the tag is derived on read, **moving home retroactively re-tags every past charge and drops any cost that came from the Home rate.** So this PR adds the entry point *and* the protection for it.

## What

- **A way in that finds you.** A banner when no home is set, and tagging a charge `Home` opens the editor seeded to that charge — "this one is home" rather than "go find your house on a map".
- **Nothing saves until you confirm.** Every edit — pin, radius, "use current location" — is drafted. The hook's debounce-save is never armed.
- **When history is at stake, keep it.** Moving home offers to freeze the charges the old geofence claimed under a name you choose (default "Old House"). One request: the server freezes first and **aborts the move if the freeze fails**, so history is never traded for a relocation. Tagging is one transaction, additive, idempotent.
- **The cost comes with the label.** The Home rate is copied onto the frozen tag, so those charges keep their price and stay filterable.
- **Away Mode invalidates the charging cache**, since it writes the same center. Radius isn't shared, so it isn't re-derived.

## Refusals

Freezing stops, before writing anything, when preserving the cost isn't possible:

| situation | why |
|---|---|
| label already has a different rate | one label can't hold two historical prices |
| label already used by other charges *and* a rate would be added | would reprice history that was never home |
| no Home rate, but the label already prices something | would invent a cost these charges never had |
| two `Home` rates differing only in capitalization | a home charge is priced at the most expensive of them; refuse rather than guess |

Malformed rates (`"NaN"`, `-1`, `{}`) price nothing, so they're neither preserved nor spread.

Rate lookup at render time is **exact**, so the copy is written under the spelling you typed — matching case-insensitively there would leave the frozen charges with a tag no rate can be found for.

## Verified on a Pi with 52 real sessions

- 43 charges at $92.60 → move with freeze → 43 tagged, still $92.60; new Home rate then independent of the frozen one
- every refusal above → geofence unmoved, rates untouched
- case variant → copied under the requested spelling, all 43 render priced
- in-use label with no rate change → allowed
- device restored to its original state after each run

## Known limitation

The in-use check reads SQLite while holding the preferences lock; no lock spans both stores. A tag edit landing in that window could give one unrelated charge the copied rate. The window is microseconds and the result is a recoverable mispriced charge, not lost data — noted in the code rather than papered over.

Settings and Away Mode can still move the shared center without a freeze prompt. Pre-existing, and out of scope here.

## Tests

130 API tests pass. New coverage: `home_rate_copy_plan` across casing, malformed values, equal-but-differently-encoded rates (`0.2` / `"0.2"` / `{"flat":0.2}`), disagreeing Home keys; `add_charge_tag_bulk` additivity and reserved-label rejection; `with_home_rate_copied` schedule objects.
