### PR TITLE
fix(ble): recover interrupted key generation and helper installs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -307,6 +307,10 @@ jobs:
           echo '<!DOCTYPE html><html><body>test</body></html>' > crates/sentryusb/static/index.html
       - name: Run tests
         run: cargo test --workspace
+      - name: Run installer safety regressions
+        run: |
+          bash test/install-pi-safety.test.sh
+          bash test/sentryusb-pick-binary.test.sh
 
   lint-web:
     name: Lint web

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2772,6 +2772,7 @@ dependencies = [
  "btleplug",
  "futures",
  "hex",
+ "libc",
  "p256",
  "pem",
  "prost",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2626,6 +2626,7 @@ dependencies = [
  "sentryusb-notify",
  "sentryusb-setup",
  "sentryusb-shell",
+ "sentryusb-tesla-ble",
  "sentryusb-vehicle-profile",
  "sentryusb-ws",
  "serde",

--- a/check.sh
+++ b/check.sh
@@ -7,6 +7,7 @@ shellcheck -V
 
 # Runtime-sourced files are absent in the checkout.
 shellcheck --exclude=SC1091 \
+           ./install-pi.sh \
            ./setup/pi/setup-sentryusb \
            ./pi-gen-sources/00-sentryusb-tweaks/files/rc.local \
            ./pi-gen-sources/00-sentryusb-tweaks/files/sentryusb-pick-binary \
@@ -19,4 +20,6 @@ shellcheck --exclude=SC1091 \
            ./run/remountfs_rw \
            ./run/send-push-message \
            ./run/temperature_monitor \
-           ./run/waitforidle
+           ./run/waitforidle \
+           ./test/install-pi-safety.test.sh \
+           ./test/sentryusb-pick-binary.test.sh

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -35,6 +35,10 @@ sentryusb-setup = { path = "../setup", package = "sentryusb-setup" }
 sentryusb-gadget = { path = "../usb_gadget", package = "sentryusb-gadget" }
 sentryusb-cloud-uploader = { path = "../cloud_uploader", package = "sentryusb-cloud-uploader" }
 sentryusb-ble-health = { path = "../ble_health", package = "sentryusb-ble-health" }
+# Already in the tree transitively via sentryusb-setup; declared directly so
+# the BLE key-validity check (keys::key_is_usable) uses the real loader
+# instead of a duplicated, weaker "file exists" test.
+sentryusb-tesla-ble = { path = "../tesla_ble", package = "sentryusb-tesla-ble" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/api/src/ble.rs
+++ b/crates/api/src/ble.rs
@@ -995,7 +995,7 @@ pub async fn ble_install(
     State(s): State<AppState>,
 ) -> (StatusCode, Json<serde_json::Value>) {
     // Native binaries ship with the image; the keypair is the durable install state.
-    let already_installed = std::path::Path::new("/root/.ble/key_private.pem").exists();
+    let already_installed = sentryusb_setup::archive::tesla_ble_keypair_is_valid();
 
     let hub = s.hub.clone();
     tokio::spawn(async move {

--- a/crates/api/src/lock_chime.rs
+++ b/crates/api/src/lock_chime.rs
@@ -823,8 +823,14 @@ async fn query_ble_shift_state() -> Result<String, String> {
         return Err("BLE not paired -- pair your Pi in Settings first".into());
     }
 
-    if !Path::new("/root/.ble/key_private.pem").exists() {
-        return Err("BLE private key missing at /root/.ble/key_private.pem".into());
+    // Usability, not existence: a 0-byte key left by an interrupted keygen
+    // would otherwise pass here and fail later with an opaque PEM error.
+    if !sentryusb_tesla_ble::keys::key_is_usable(Path::new("/root/.ble/key_private.pem")) {
+        return Err(
+            "BLE private key at /root/.ble/key_private.pem is missing or unusable -- \
+             regenerate it in Settings, then pair with the car again"
+                .into(),
+        );
     }
 
     // Read the gear via sentryusb-ble-action, which routes through the

--- a/crates/api/src/system.rs
+++ b/crates/api/src/system.rs
@@ -171,6 +171,22 @@ pub async fn ble_pair(State(s): State<AppState>, _body: String) -> (StatusCode, 
                      the car (and move other paired phones away), make sure the car is awake \
                      and within a few metres, then retry pairing."
                         .to_string()
+                } else if lower.contains("is empty (0 bytes)")
+                    || lower.contains("malformedframing")
+                    || lower.contains("parsing pem envelope")
+                {
+                    // A truncated/empty key file. Previously this fell through
+                    // to the raw `detail`, so the UI showed the bare upstream
+                    // string "parsing PEM envelope: malformedframing", which
+                    // tells a user nothing. Pairing cannot proceed until the
+                    // key is rebuilt, and rebuilding invalidates any existing
+                    // enrolment, so say both things.
+                    "The BLE key file is empty or corrupt — key generation was interrupted \
+                     (most often by a power cut or a read-only filesystem). Regenerate the \
+                     key from Settings, or on the Pi run: sentryusb-ble-action keygen. \
+                     You will then need to pair with the car again — hold your NFC key card \
+                     against the card reader when the car prompts you."
+                        .to_string()
                 } else {
                     detail
                 };

--- a/crates/sentryusb/src/migrate.rs
+++ b/crates/sentryusb/src/migrate.rs
@@ -47,7 +47,7 @@ pub async fn run_startup_migration() {
         MIGRATE_REPO, script_ref
     );
 
-    let script = build_migration_script(&tarball_url);
+    let script = build_migration_script(&tarball_url, &script_ref);
 
     // Retry up to 3 times with exponential backoff. The script itself
     // fails fast on `curl: Could not resolve host: github.com` when DNS
@@ -140,7 +140,12 @@ pub async fn run_startup_migration() {
     // Don't write marker — retry on next boot.
 }
 
-fn build_migration_script(tarball_url: &str) -> String {
+fn build_migration_script(tarball_url: &str, release_ref: &str) -> String {
+    let helper_release_base = if release_ref == MIGRATE_BRANCH {
+        format!("https://github.com/{MIGRATE_REPO}/releases/latest/download")
+    } else {
+        format!("https://github.com/{MIGRATE_REPO}/releases/download/{release_ref}")
+    };
     format!(
         r#"set -e
 
@@ -428,20 +433,31 @@ if [ -f "$TMPDIR/server/ble/sentryusb-telemetry.service" ]; then
   fi
   if [ -n "$_suffix" ]; then
     for _name in sentryusb-tesla-telemetry sentryusb-ble-action; do
-      # Symlink already in place → the picker owns it now; skip.
-      if [ -L "/root/bin/$_name" ]; then
+      _dest="/opt/sentryusb/$_name-$_suffix"
+      _link="/root/bin/$_name"
+      # Skip only a healthy link to the expected executable. A dangling
+      # symlink satisfies -L but execve returns ENOENT; older code skipped it
+      # forever and still wrote the per-version migration marker.
+      if [ -L "$_link" ] \
+        && [ "$(readlink "$_link" 2>/dev/null || true)" = "$_dest" ] \
+        && [ -x "$_link" ] \
+        && [ -x "$_dest" ]; then
         continue
       fi
-      _url="https://github.com/{repo}/releases/latest/download/$_name-$_suffix"
-      if curl -sfI --max-time 10 "$_url" >/dev/null 2>&1; then
-        mkdir -p /root/bin /opt/sentryusb
-        if curl -fsSL --max-time 120 "$_url" -o "/tmp/$_name.migrate" 2>/dev/null; then
-          chmod +x "/tmp/$_name.migrate"
-          mv "/tmp/$_name.migrate" "/opt/sentryusb/$_name-$_suffix"
-          ln -sfn "/opt/sentryusb/$_name-$_suffix" "/root/bin/$_name"
-          echo "migrate: installed $_name-$_suffix and linked /root/bin/$_name"
-        fi
-      fi
+      _url="{helper_release_base}/$_name-$_suffix"
+      _staged="/opt/sentryusb/.$_name.migrate.new"
+      mkdir -p /root/bin /opt/sentryusb
+      rm -f "$_staged"
+      # Stage on the destination filesystem so the final rename is atomic.
+      # Any failure aborts the migration, so Rust does not write .migrated-*;
+      # the next boot can retry instead of preserving a half-install.
+      curl -fsSL --max-time 120 "$_url" -o "$_staged"
+      [ -s "$_staged" ]
+      chmod +x "$_staged"
+      mv -f "$_staged" "$_dest"
+      ln -sfn "$_dest" "$_link"
+      [ -x "$_link" ]
+      echo "migrate: installed $_name-$_suffix and linked $_link"
     done
   fi
 
@@ -494,6 +510,7 @@ rm -f /root/bin/tesla-control /root/bin/tesla-keygen \
 "#,
         tarball_url = tarball_url,
         repo = MIGRATE_REPO,
+        helper_release_base = helper_release_base,
         branch = MIGRATE_BRANCH
     )
 }
@@ -509,6 +526,7 @@ mod tests {
     fn migration_script_parses() {
         let script = build_migration_script(
             "https://github.com/Sentry-Six/Sentry-USB-Rusty/archive/v0.0.0.tar.gz",
+            "v0.0.0",
         );
         // Placeholders must all have been substituted.
         assert!(!script.contains("{repo}"), "unsubstituted {{repo}}");
@@ -525,5 +543,45 @@ mod tests {
             .status()
             .expect("bash not available");
         assert!(status.success(), "bash -n rejected the migration script");
+    }
+
+    #[test]
+    fn migration_script_repairs_dangling_aux_links() {
+        let script = build_migration_script(
+            "https://github.com/Sentry-Six/Sentry-USB-Rusty/archive/v0.0.0.tar.gz",
+            "v0.0.0",
+        );
+
+        assert!(
+            script.contains("&& [ -x \"$_link\" ]") && script.contains("&& [ -x \"$_dest\" ]"),
+            "auxiliary migration must not treat a dangling symlink as healthy"
+        );
+        assert!(
+            script.contains("_staged=\"/opt/sentryusb/.$_name.migrate.new\""),
+            "auxiliary downloads must be staged on the destination filesystem"
+        );
+        assert!(
+            script.contains("[ -x \"$_link\" ]\n      echo \"migrate: installed"),
+            "migration must verify the published executable before succeeding"
+        );
+    }
+
+    #[test]
+    fn migration_downloads_helpers_from_the_installed_release() {
+        let script = build_migration_script(
+            "https://github.com/Sentry-Six/Sentry-USB-Rusty/archive/v0.0.0.tar.gz",
+            "v0.0.0",
+        );
+
+        assert!(
+            script.contains(
+                "https://github.com/Sentry-Six/Sentry-USB-Rusty/releases/download/v0.0.0/$_name-$_suffix"
+            ),
+            "migration must keep auxiliary binaries on the installed release"
+        );
+        assert!(
+            !script.contains("releases/latest/download/$_name-$_suffix"),
+            "a migration for an exact version must not install latest helpers"
+        );
     }
 }

--- a/crates/setup/src/archive.rs
+++ b/crates/setup/src/archive.rs
@@ -235,6 +235,7 @@ where
     if tesla_ble_keypair_is_valid() {
         return Ok(());
     }
+    let had_usable_private_key = sentryusb_tesla_ble::keys::key_is_usable(&private_key);
 
     // Persist keys on read-only-root installations.
     let _ = std::process::Command::new("bash")
@@ -261,16 +262,11 @@ where
         }
     }
 
-    // A valid private key is authoritative. Repair a missing/malformed public
-    // half without rotating a key that may already be paired; never overwrite
-    // an invalid existing private key without explicit operator action.
-    if private_key.exists() {
-        sentryusb_tesla_ble::keys::ensure_keypair_files(key_dir)
-            .context("validating or repairing Tesla BLE keypair")?;
+    sentryusb_tesla_ble::keys::regenerate_keypair(key_dir)
+        .context("generating or repairing Tesla BLE keypair")?;
+    if had_usable_private_key {
         progress("Repaired Tesla BLE public key from the existing private key.");
     } else {
-        sentryusb_tesla_ble::keys::generate_keypair(key_dir)
-            .context("generating Tesla BLE keypair")?;
         std::fs::write("/root/.ble/key_pending_pairing", "")?;
         progress("Generated Tesla BLE keys. Pairing required via web UI.");
     }

--- a/crates/setup/src/archive.rs
+++ b/crates/setup/src/archive.rs
@@ -267,7 +267,6 @@ where
     if had_usable_private_key {
         progress("Repaired Tesla BLE public key from the existing private key.");
     } else {
-        std::fs::write("/root/.ble/key_pending_pairing", "")?;
         progress("Generated Tesla BLE keys. Pairing required via web UI.");
     }
 

--- a/crates/setup/src/archive.rs
+++ b/crates/setup/src/archive.rs
@@ -215,12 +215,24 @@ fn validate_sentry_case(env: &SetupEnv) -> Result<()> {
     Ok(())
 }
 
-/// Installs BlueZ and generates a native BLE keypair when absent.
+/// Whether both Tesla BLE key files are valid and belong to the same pair.
+pub fn tesla_ble_keypair_is_valid() -> bool {
+    sentryusb_tesla_ble::keys::load_keypair(std::path::Path::new("/root/.ble")).is_ok()
+}
+
+static TESLA_BLE_INSTALL_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+/// Installs BlueZ and generates or repairs a native BLE keypair when needed.
 pub async fn install_tesla_ble_binaries<F>(progress: F) -> Result<()>
 where
     F: Fn(&str),
 {
-    if std::path::Path::new("/root/.ble/key_private.pem").exists() {
+    // Serialise API/setup callers before package installation as well as key
+    // publication. The on-disk flock in tesla_ble also covers other processes.
+    let _guard = TESLA_BLE_INSTALL_LOCK.lock().await;
+    let key_dir = std::path::Path::new("/root/.ble");
+    let private_key = key_dir.join("key_private.pem");
+    if tesla_ble_keypair_is_valid() {
         return Ok(());
     }
 
@@ -249,10 +261,15 @@ where
         }
     }
 
-    // New keys use PKCS#8; the loader retains SEC1 compatibility.
-    if !std::path::Path::new("/root/.ble/key_private.pem").exists() {
-        let dir = std::path::Path::new("/root/.ble");
-        sentryusb_tesla_ble::keys::generate_keypair(dir)
+    // A valid private key is authoritative. Repair a missing/malformed public
+    // half without rotating a key that may already be paired; never overwrite
+    // an invalid existing private key without explicit operator action.
+    if private_key.exists() {
+        sentryusb_tesla_ble::keys::ensure_keypair_files(key_dir)
+            .context("validating or repairing Tesla BLE keypair")?;
+        progress("Repaired Tesla BLE public key from the existing private key.");
+    } else {
+        sentryusb_tesla_ble::keys::generate_keypair(key_dir)
             .context("generating Tesla BLE keypair")?;
         std::fs::write("/root/.ble/key_pending_pairing", "")?;
         progress("Generated Tesla BLE keys. Pairing required via web UI.");
@@ -275,7 +292,7 @@ pub async fn configure_tesla_ble(env: &SetupEnv, emitter: &SetupEmitter) -> Resu
     }
 
     // Native action binaries ship with the image; only the keypair is durable.
-    if std::path::Path::new("/root/.ble/key_private.pem").exists() {
+    if tesla_ble_keypair_is_valid() {
         return Ok(false);
     }
 

--- a/crates/tesla_ble/Cargo.toml
+++ b/crates/tesla_ble/Cargo.toml
@@ -79,6 +79,9 @@ pem = "4"
 # crypto-common, so we now request it directly.
 aes-gcm = { version = "0.10", features = ["std"] }
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [build-dependencies]
 prost-build = "0.14"
 # Vendored protoc so users don't need to apt install protobuf-compiler.

--- a/crates/tesla_ble/src/bin/sentryusb_ble_action.rs
+++ b/crates/tesla_ble/src/bin/sentryusb_ble_action.rs
@@ -275,47 +275,62 @@ async fn try_via_ipc(verb: &str) -> Result<(), IpcError> {
 /// (PKCS#8 private + SPKI public PEM) via the native generator — the
 /// drop-in replacement for `tesla-keygen … create`. Idempotent and
 /// safe: a valid pair is left untouched, a missing/malformed public key is
-/// derived again from the existing private key, and an invalid private key is
-/// never clobbered automatically.
+/// derived again from the existing private key, and this explicit command
+/// atomically replaces an unusable regular private-key file.
 /// Marks the keys freshly generated so the UI knows pairing is pending.
 ///
 /// Exit codes: 0 keys present/created, 2 filesystem/keygen error.
 fn run_keygen() -> ExitCode {
     let dir = Path::new("/root/.ble");
+    let priv_path = dir.join("key_private.pem");
+
     if sentryusb_tesla_ble::keys::load_keypair(dir).is_ok() {
         info!(
-            "keygen: keypair already present at {} — leaving it untouched",
+            "keygen: valid keypair already present at {} — leaving it untouched",
             dir.display()
         );
         println!("OK");
         return ExitCode::SUCCESS;
     }
-    if dir.join("key_private.pem").exists() {
-        return match sentryusb_tesla_ble::keys::ensure_keypair_files(dir) {
-            Ok(_) => {
-                info!(
-                    "keygen: repaired public key from existing private key at {}",
-                    dir.display()
-                );
-                println!("OK");
-                ExitCode::SUCCESS
-            }
-            Err(e) => {
-                error!("keygen: existing private key is invalid; refusing to overwrite it: {e:#}");
-                ExitCode::from(2)
-            }
-        };
+
+    let had_usable_private_key = sentryusb_tesla_ble::keys::key_is_usable(&priv_path);
+    if had_usable_private_key {
+        warn!(
+            "keygen: public key at {} is missing or invalid — repairing it from the existing private key",
+            dir.display()
+        );
+    } else if priv_path.exists() {
+        warn!(
+            "keygen: existing key at {} is unusable — regenerating. The car must be re-paired afterwards.",
+            priv_path.display()
+        );
     }
+
+    // Persist keys on read-only-root installations. Without this, keygen
+    // hits EROFS mid-write; that is precisely what produces the 0-byte
+    // key this function now has to recover from. Mirrors the remount in
+    // crates/setup/src/archive.rs before its own generate_keypair call.
+    let _ = std::process::Command::new("bash")
+        .args(["-c", "/root/bin/remountfs_rw"])
+        .status();
+
     if let Err(e) = std::fs::create_dir_all(dir) {
         error!("keygen: creating {}: {e:#}", dir.display());
         return ExitCode::from(2);
     }
-    match sentryusb_tesla_ble::keys::generate_keypair(dir) {
+    match sentryusb_tesla_ble::keys::regenerate_keypair(dir) {
         Ok(_) => {
-            // Mark not-yet-paired so the web UI doesn't falsely show
-            // "BLE Paired" on a fresh keypair (matches the wizard).
-            let _ = std::fs::write(dir.join("key_pending_pairing"), "");
-            info!("keygen: generated BLE keypair under {}", dir.display());
+            if !had_usable_private_key {
+                // Mark not-yet-paired so the web UI doesn't falsely show
+                // "BLE Paired" after a new private key is published.
+                if let Err(e) = std::fs::write(dir.join("key_pending_pairing"), "") {
+                    error!("keygen: writing pairing marker: {e:#}");
+                    return ExitCode::from(2);
+                }
+                info!("keygen: generated BLE keypair under {}", dir.display());
+            } else {
+                info!("keygen: repaired BLE public key under {}", dir.display());
+            }
             println!("OK");
             ExitCode::SUCCESS
         }

--- a/crates/tesla_ble/src/bin/sentryusb_ble_action.rs
+++ b/crates/tesla_ble/src/bin/sentryusb_ble_action.rs
@@ -321,12 +321,6 @@ fn run_keygen() -> ExitCode {
     match sentryusb_tesla_ble::keys::regenerate_keypair(dir) {
         Ok(_) => {
             if !had_usable_private_key {
-                // Mark not-yet-paired so the web UI doesn't falsely show
-                // "BLE Paired" after a new private key is published.
-                if let Err(e) = std::fs::write(dir.join("key_pending_pairing"), "") {
-                    error!("keygen: writing pairing marker: {e:#}");
-                    return ExitCode::from(2);
-                }
                 info!("keygen: generated BLE keypair under {}", dir.display());
             } else {
                 info!("keygen: repaired BLE public key under {}", dir.display());

--- a/crates/tesla_ble/src/bin/sentryusb_ble_action.rs
+++ b/crates/tesla_ble/src/bin/sentryusb_ble_action.rs
@@ -274,17 +274,37 @@ async fn try_via_ipc(verb: &str) -> Result<(), IpcError> {
 /// `keygen` verb. Generates the P-256 BLE keypair under /root/.ble
 /// (PKCS#8 private + SPKI public PEM) via the native generator — the
 /// drop-in replacement for `tesla-keygen … create`. Idempotent and
-/// safe: if a private key already exists it is left untouched (never
-/// clobber a key that may already be paired with the car) and we exit 0.
+/// safe: a valid pair is left untouched, a missing/malformed public key is
+/// derived again from the existing private key, and an invalid private key is
+/// never clobbered automatically.
 /// Marks the keys freshly generated so the UI knows pairing is pending.
 ///
 /// Exit codes: 0 keys present/created, 2 filesystem/keygen error.
 fn run_keygen() -> ExitCode {
     let dir = Path::new("/root/.ble");
-    if dir.join("key_private.pem").exists() {
-        info!("keygen: keypair already present at {} — leaving it untouched", dir.display());
+    if sentryusb_tesla_ble::keys::load_keypair(dir).is_ok() {
+        info!(
+            "keygen: keypair already present at {} — leaving it untouched",
+            dir.display()
+        );
         println!("OK");
         return ExitCode::SUCCESS;
+    }
+    if dir.join("key_private.pem").exists() {
+        return match sentryusb_tesla_ble::keys::ensure_keypair_files(dir) {
+            Ok(_) => {
+                info!(
+                    "keygen: repaired public key from existing private key at {}",
+                    dir.display()
+                );
+                println!("OK");
+                ExitCode::SUCCESS
+            }
+            Err(e) => {
+                error!("keygen: existing private key is invalid; refusing to overwrite it: {e:#}");
+                ExitCode::from(2)
+            }
+        };
     }
     if let Err(e) = std::fs::create_dir_all(dir) {
         error!("keygen: creating {}: {e:#}", dir.display());

--- a/crates/tesla_ble/src/keys.rs
+++ b/crates/tesla_ble/src/keys.rs
@@ -303,8 +303,9 @@ pub fn generate_keypair(dir: &Path) -> Result<KeyPair> {
 
 /// Explicitly make the directory contain one usable keypair. A valid private
 /// key is preserved and its public half is repaired; an unusable regular
-/// private-key file is atomically replaced. Symlinks and other non-files are
-/// always rejected.
+/// private-key file is atomically replaced. Private-key replacement also
+/// clears the stale paired marker and marks pairing as pending. Symlinks and
+/// other non-files are always rejected.
 pub fn regenerate_keypair(dir: &Path) -> Result<KeyPair> {
     std::fs::create_dir_all(dir).with_context(|| format!("creating key dir {}", dir.display()))?;
     let _lock = KeyDirectoryLock::acquire(dir)?;
@@ -318,7 +319,40 @@ pub fn regenerate_keypair(dir: &Path) -> Result<KeyPair> {
         return load_keypair(dir).context("validating repaired Tesla BLE keypair");
     }
 
-    generate_keypair_locked(dir, true)
+    // Validate the replacement target before changing pairing state. A
+    // symlink or directory is rejected without touching an existing marker.
+    match std::fs::symlink_metadata(&priv_path) {
+        Ok(metadata) if !metadata.file_type().is_file() => {
+            bail!(
+                "existing Tesla BLE private key path {} is not a regular file; refusing to overwrite it",
+                priv_path.display()
+            );
+        }
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("reading private key metadata {}", priv_path.display()));
+        }
+    }
+
+    // An unusable private key cannot authenticate an existing enrolment. Clear
+    // the durable paired state before publishing its replacement so no failure
+    // path can leave the new key falsely reported as paired.
+    let paired_path = dir.join("paired");
+    if let Err(error) = std::fs::remove_file(&paired_path)
+        && error.kind() != std::io::ErrorKind::NotFound
+    {
+        return Err(error)
+            .with_context(|| format!("clearing stale paired marker {}", paired_path.display()));
+    }
+
+    let keypair = generate_keypair_locked(dir, true)?;
+    let pending_path = dir.join("key_pending_pairing");
+    std::fs::write(&pending_path, "")
+        .with_context(|| format!("writing pairing marker {}", pending_path.display()))?;
+    sync_key_directory(dir)?;
+    Ok(keypair)
 }
 
 /// Hand-parse SEC1 ECPrivateKey DER to extract the 32-byte scalar.
@@ -491,11 +525,14 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("key_private.pem"), b"").unwrap();
         std::fs::write(dir.path().join("key_public.pem"), b"").unwrap();
+        std::fs::write(dir.path().join("paired"), b"1").unwrap();
 
         regenerate_keypair(dir.path()).unwrap();
 
         assert!(key_is_usable(&dir.path().join("key_private.pem")));
         load_keypair(dir.path()).unwrap();
+        assert!(!dir.path().join("paired").exists());
+        assert!(dir.path().join("key_pending_pairing").exists());
     }
 
     #[test]
@@ -505,11 +542,32 @@ mod tests {
         let priv_path = dir.path().join("key_private.pem");
         let private_before = std::fs::read(&priv_path).unwrap();
         std::fs::write(dir.path().join("key_public.pem"), b"broken-public-key").unwrap();
+        std::fs::write(dir.path().join("paired"), b"1").unwrap();
 
         regenerate_keypair(dir.path()).unwrap();
 
         assert_eq!(std::fs::read(priv_path).unwrap(), private_before);
         load_keypair(dir.path()).unwrap();
+        assert!(dir.path().join("paired").exists());
+        assert!(!dir.path().join("key_pending_pairing").exists());
+    }
+
+    #[test]
+    fn explicit_regeneration_fails_if_paired_marker_cannot_be_cleared() {
+        let dir = tempfile::tempdir().unwrap();
+        let priv_path = dir.path().join("key_private.pem");
+        std::fs::write(&priv_path, b"").unwrap();
+        std::fs::write(dir.path().join("key_public.pem"), b"").unwrap();
+        std::fs::create_dir(dir.path().join("paired")).unwrap();
+
+        let error = match regenerate_keypair(dir.path()) {
+            Ok(_) => panic!("regeneration should fail when the paired marker cannot be removed"),
+            Err(error) => error,
+        };
+
+        assert!(error.to_string().contains("clearing stale paired marker"));
+        assert_eq!(std::fs::read(priv_path).unwrap(), b"");
+        assert!(!dir.path().join("key_pending_pairing").exists());
     }
 
     #[cfg(unix)]
@@ -559,8 +617,10 @@ mod tests {
 
         assert!(load_keypair(install.path()).is_err());
         assert!(ensure_keypair_files(install.path()).is_err());
+        std::fs::write(install.path().join("paired"), b"1").unwrap();
         assert!(regenerate_keypair(install.path()).is_err());
         assert!(install.path().join("key_private.pem").is_symlink());
+        assert!(install.path().join("paired").exists());
     }
 
     #[test]

--- a/crates/tesla_ble/src/keys.rs
+++ b/crates/tesla_ble/src/keys.rs
@@ -1,11 +1,13 @@
 //! Load the user's Tesla BLE NIST P-256 private key and derive the
 //! public key for SessionInfoRequest. Also generates fresh keypairs.
 
-use std::path::Path;
+use std::fs::{File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
 use p256::SecretKey;
-use p256::pkcs8::{DecodePrivateKey, EncodePrivateKey, LineEnding};
+use p256::pkcs8::{DecodePrivateKey, DecodePublicKey, EncodePrivateKey, LineEnding};
 
 /// Loaded ECDH keypair. The private key is for signing/ECDH; the
 /// `pub_uncompressed` bytes are the 65-byte SEC1 format Tesla expects
@@ -41,6 +43,171 @@ impl KeyPair {
     }
 }
 
+/// Load and validate the complete on-disk Tesla BLE keypair. The private key
+/// is authoritative, but a usable installation also requires a parseable SPKI
+/// public key derived from that same private scalar.
+pub fn load_keypair(dir: &Path) -> Result<KeyPair> {
+    load_keypair_paths(&dir.join("key_private.pem"), &dir.join("key_public.pem"))
+}
+
+fn load_keypair_paths(priv_path: &Path, pub_path: &Path) -> Result<KeyPair> {
+    let keypair = load_regular_private_key(priv_path)?;
+    require_regular_file(pub_path, "public key")?;
+    let public_pem = std::fs::read_to_string(pub_path)
+        .with_context(|| format!("reading public key file {}", pub_path.display()))?;
+    let public = p256::PublicKey::from_public_key_pem(&public_pem)
+        .with_context(|| format!("parsing public key file {}", pub_path.display()))?;
+    if public.to_sec1_bytes().as_ref() != keypair.pub_uncompressed.as_slice() {
+        bail!("Tesla BLE public key does not match the private key");
+    }
+    Ok(keypair)
+}
+
+fn require_regular_file(path: &Path, description: &str) -> Result<()> {
+    let metadata = std::fs::symlink_metadata(path)
+        .with_context(|| format!("reading {description} metadata {}", path.display()))?;
+    if !metadata.file_type().is_file() {
+        bail!(
+            "{description} path {} is not a regular file",
+            path.display()
+        );
+    }
+    Ok(())
+}
+
+fn load_regular_private_key(path: &Path) -> Result<KeyPair> {
+    require_regular_file(path, "private key")?;
+    KeyPair::load(path).context("loading Tesla BLE private key")
+}
+
+struct KeyDirectoryLock {
+    file: File,
+}
+
+impl KeyDirectoryLock {
+    fn acquire(dir: &Path) -> Result<Self> {
+        let path = dir.join(".keygen.lock");
+        let mut options = OpenOptions::new();
+        options.read(true).write(true).create(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let file = options
+            .open(&path)
+            .with_context(|| format!("opening BLE key lock {}", path.display()))?;
+        #[cfg(unix)]
+        {
+            use std::os::fd::AsRawFd;
+            let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) };
+            if rc != 0 {
+                return Err(std::io::Error::last_os_error())
+                    .with_context(|| format!("locking BLE key directory {}", dir.display()));
+            }
+        }
+        Ok(Self { file })
+    }
+}
+
+impl Drop for KeyDirectoryLock {
+    fn drop(&mut self) {
+        #[cfg(unix)]
+        {
+            use std::os::fd::AsRawFd;
+            let _ = unsafe { libc::flock(self.file.as_raw_fd(), libc::LOCK_UN) };
+        }
+    }
+}
+
+fn stage_key_file(dir: &Path, name: &str, contents: &[u8], mode: u32) -> Result<PathBuf> {
+    use p256::elliptic_curve::rand_core::{OsRng, RngCore};
+
+    for _ in 0..16 {
+        let mut rng = OsRng;
+        let path = dir.join(format!(".{name}.{:016x}.tmp", rng.next_u64()));
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(mode);
+        }
+        match options.open(&path) {
+            Ok(mut file) => {
+                let result = (|| -> Result<()> {
+                    file.write_all(contents)
+                        .with_context(|| format!("writing staged key {}", path.display()))?;
+                    #[cfg(unix)]
+                    std::fs::set_permissions(
+                        &path,
+                        std::os::unix::fs::PermissionsExt::from_mode(mode),
+                    )
+                    .with_context(|| format!("setting permissions on {}", path.display()))?;
+                    file.sync_all()
+                        .with_context(|| format!("syncing staged key {}", path.display()))?;
+                    Ok(())
+                })();
+                if let Err(error) = result {
+                    let _ = std::fs::remove_file(&path);
+                    return Err(error);
+                }
+                return Ok(path);
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => {
+                return Err(error)
+                    .with_context(|| format!("creating staged key {}", path.display()));
+            }
+        }
+    }
+    bail!("could not allocate a unique staged BLE key file")
+}
+
+#[cfg(unix)]
+fn sync_key_directory(dir: &Path) -> Result<()> {
+    File::open(dir)
+        .with_context(|| format!("opening key directory {} for sync", dir.display()))?
+        .sync_all()
+        .with_context(|| format!("syncing key directory {}", dir.display()))
+}
+
+#[cfg(not(unix))]
+fn sync_key_directory(_dir: &Path) -> Result<()> {
+    Ok(())
+}
+
+fn publish_public_key(dir: &Path, keypair: &KeyPair) -> Result<()> {
+    use p256::pkcs8::EncodePublicKey;
+
+    let public_pem = keypair
+        .secret
+        .public_key()
+        .to_public_key_pem(LineEnding::LF)
+        .context("encoding SPKI public key")?;
+    let staged = stage_key_file(dir, "key_public.pem", public_pem.as_bytes(), 0o644)?;
+    let destination = dir.join("key_public.pem");
+    if let Err(error) = std::fs::rename(&staged, &destination) {
+        let _ = std::fs::remove_file(&staged);
+        return Err(error).with_context(|| format!("publishing {}", destination.display()));
+    }
+    sync_key_directory(dir)
+}
+
+/// Validate the private key and repair a missing, malformed, or mismatched
+/// public key without rotating the private key that may already be paired.
+pub fn ensure_keypair_files(dir: &Path) -> Result<KeyPair> {
+    std::fs::create_dir_all(dir).with_context(|| format!("creating key dir {}", dir.display()))?;
+    let _lock = KeyDirectoryLock::acquire(dir)?;
+    let priv_path = dir.join("key_private.pem");
+    let keypair = load_regular_private_key(&priv_path)?;
+    if load_keypair(dir).is_ok() {
+        return Ok(keypair);
+    }
+    publish_public_key(dir, &keypair)?;
+    load_keypair(dir).context("validating repaired Tesla BLE keypair")
+}
+
 /// Generate a fresh P-256 BLE keypair, write both halves to disk, and
 /// return the loaded keypair. Writes:
 ///   * `<dir>/key_private.pem` — PKCS#8 PEM, 0600. (`KeyPair::load` also
@@ -50,8 +217,19 @@ pub fn generate_keypair(dir: &Path) -> Result<KeyPair> {
     use p256::elliptic_curve::rand_core::OsRng;
     use p256::pkcs8::EncodePublicKey;
 
-    std::fs::create_dir_all(dir)
-        .with_context(|| format!("creating key dir {}", dir.display()))?;
+    std::fs::create_dir_all(dir).with_context(|| format!("creating key dir {}", dir.display()))?;
+    let _lock = KeyDirectoryLock::acquire(dir)?;
+
+    let priv_path = dir.join("key_private.pem");
+    let pub_path = dir.join("key_public.pem");
+    if std::fs::symlink_metadata(&priv_path).is_ok() {
+        return load_keypair(dir).with_context(|| {
+            format!(
+                "existing Tesla BLE private key {} is invalid or incomplete; refusing to overwrite it",
+                priv_path.display()
+            )
+        });
+    }
 
     let secret = SecretKey::random(&mut OsRng);
     let private_pem = secret
@@ -62,29 +240,36 @@ pub fn generate_keypair(dir: &Path) -> Result<KeyPair> {
         .to_public_key_pem(LineEnding::LF)
         .context("encoding SPKI public key")?;
 
-    let priv_path = dir.join("key_private.pem");
-    let pub_path = dir.join("key_public.pem");
-    std::fs::write(&priv_path, private_pem.as_bytes())
-        .with_context(|| format!("writing {}", priv_path.display()))?;
-    std::fs::write(&pub_path, public_pem.as_bytes())
-        .with_context(|| format!("writing {}", pub_path.display()))?;
-
-    // 0600 / 0644 — only matters on Unix; on other targets the chmod
-    // is a no-op.
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let _ = std::fs::set_permissions(
-            &priv_path,
-            std::fs::Permissions::from_mode(0o600),
-        );
-        let _ = std::fs::set_permissions(
-            &pub_path,
-            std::fs::Permissions::from_mode(0o644),
-        );
+    let staged_private = stage_key_file(dir, "key_private.pem", private_pem.as_bytes(), 0o600)?;
+    let staged_public = match stage_key_file(dir, "key_public.pem", public_pem.as_bytes(), 0o644) {
+        Ok(path) => path,
+        Err(error) => {
+            let _ = std::fs::remove_file(&staged_private);
+            return Err(error);
+        }
+    };
+    if let Err(error) = load_keypair_paths(&staged_private, &staged_public) {
+        let _ = std::fs::remove_file(&staged_private);
+        let _ = std::fs::remove_file(&staged_public);
+        return Err(error).context("validating staged Tesla BLE keypair");
     }
 
-    KeyPair::load(&priv_path)
+    // The private key is the durable source of truth. Publish it first, then
+    // the derivable public key; if the second rename is interrupted, the next
+    // install safely repairs the public half without rotating the private key.
+    if let Err(error) = std::fs::rename(&staged_private, &priv_path) {
+        let _ = std::fs::remove_file(&staged_private);
+        let _ = std::fs::remove_file(&staged_public);
+        return Err(error).with_context(|| format!("publishing {}", priv_path.display()));
+    }
+    sync_key_directory(dir)?;
+    if let Err(error) = std::fs::rename(&staged_public, &pub_path) {
+        let _ = std::fs::remove_file(&staged_public);
+        return Err(error).with_context(|| format!("publishing {}", pub_path.display()));
+    }
+    sync_key_directory(dir)?;
+
+    load_keypair(dir).context("validating published Tesla BLE keypair")
 }
 
 /// Hand-parse SEC1 ECPrivateKey DER to extract the 32-byte scalar.
@@ -183,6 +368,123 @@ mod tests {
             "uncompressed SEC1 pubkey is 65 bytes"
         );
         assert_eq!(loaded.pub_uncompressed, kp.pub_uncompressed);
+    }
+
+    #[test]
+    fn empty_key_files_are_not_a_valid_pair() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("key_private.pem"), b"").unwrap();
+        std::fs::write(dir.path().join("key_public.pem"), b"").unwrap();
+
+        let error = match load_keypair(dir.path()) {
+            Ok(_) => panic!("empty PEM files must be rejected"),
+            Err(error) => error,
+        };
+        assert!(
+            error.to_string().contains("private key"),
+            "unexpected validation error: {error:#}"
+        );
+    }
+
+    #[test]
+    fn valid_private_key_repairs_a_missing_public_key_without_rotation() {
+        let dir = tempfile::tempdir().unwrap();
+        generate_keypair(dir.path()).unwrap();
+        let priv_path = dir.path().join("key_private.pem");
+        let pub_path = dir.path().join("key_public.pem");
+        let private_before = std::fs::read(&priv_path).unwrap();
+        std::fs::remove_file(&pub_path).unwrap();
+
+        let repaired = ensure_keypair_files(dir.path()).unwrap();
+
+        assert_eq!(std::fs::read(&priv_path).unwrap(), private_before);
+        assert_eq!(
+            load_keypair(dir.path()).unwrap().pub_uncompressed,
+            repaired.pub_uncompressed
+        );
+    }
+
+    #[test]
+    fn concurrent_generation_converges_on_one_valid_keypair() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = std::sync::Arc::new(dir.path().to_path_buf());
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+        let mut workers = Vec::new();
+        for _ in 0..2 {
+            let path = path.clone();
+            let barrier = barrier.clone();
+            workers.push(std::thread::spawn(move || {
+                barrier.wait();
+                generate_keypair(&path)
+            }));
+        }
+
+        for worker in workers {
+            worker.join().unwrap().unwrap();
+        }
+        load_keypair(dir.path()).unwrap();
+    }
+
+    #[test]
+    fn invalid_existing_private_key_is_never_overwritten() {
+        let dir = tempfile::tempdir().unwrap();
+        let priv_path = dir.path().join("key_private.pem");
+        std::fs::write(&priv_path, b"broken-private-key").unwrap();
+
+        assert!(ensure_keypair_files(dir.path()).is_err());
+        assert_eq!(std::fs::read(&priv_path).unwrap(), b"broken-private-key");
+        assert!(generate_keypair(dir.path()).is_err());
+        assert_eq!(std::fs::read(&priv_path).unwrap(), b"broken-private-key");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn generated_key_files_have_safe_modes_and_no_staging_remnants() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        generate_keypair(dir.path()).unwrap();
+
+        let private_mode = std::fs::metadata(dir.path().join("key_private.pem"))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        let public_mode = std::fs::metadata(dir.path().join("key_public.pem"))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(private_mode, 0o600);
+        assert_eq!(public_mode, 0o644);
+        let staged: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .flatten()
+            .filter(|entry| entry.file_name().to_string_lossy().ends_with(".tmp"))
+            .collect();
+        assert!(staged.is_empty(), "staging files remain: {staged:?}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn private_key_symlinks_are_not_accepted_as_install_state() {
+        let source = tempfile::tempdir().unwrap();
+        generate_keypair(source.path()).unwrap();
+        let install = tempfile::tempdir().unwrap();
+        std::os::unix::fs::symlink(
+            source.path().join("key_private.pem"),
+            install.path().join("key_private.pem"),
+        )
+        .unwrap();
+        std::fs::copy(
+            source.path().join("key_public.pem"),
+            install.path().join("key_public.pem"),
+        )
+        .unwrap();
+
+        assert!(load_keypair(install.path()).is_err());
+        assert!(ensure_keypair_files(install.path()).is_err());
+        assert!(install.path().join("key_private.pem").is_symlink());
     }
 
     #[test]

--- a/crates/tesla_ble/src/keys.rs
+++ b/crates/tesla_ble/src/keys.rs
@@ -80,6 +80,18 @@ fn load_regular_private_key(path: &Path) -> Result<KeyPair> {
     KeyPair::load(path).context("loading Tesla BLE private key")
 }
 
+/// Is there a usable private key at `path`?
+///
+/// Prefer this over `Path::exists()` for every "do we need to generate a
+/// key?" decision. A bare existence test caused an unrecoverable deadlock:
+/// an interrupted keygen leaves a 0-byte `key_private.pem`, which "exists"
+/// but cannot be parsed, so pairing failed forever while every guard
+/// happily reported the key was already installed. This actually parses
+/// the key, so empty, truncated and corrupt files all read as unusable.
+pub fn key_is_usable(path: &Path) -> bool {
+    load_regular_private_key(path).is_ok()
+}
+
 struct KeyDirectoryLock {
     file: File,
 }
@@ -213,22 +225,33 @@ pub fn ensure_keypair_files(dir: &Path) -> Result<KeyPair> {
 ///   * `<dir>/key_private.pem` — PKCS#8 PEM, 0600. (`KeyPair::load` also
 ///     accepts the SEC1 PEM that older tesla-keygen installs use.)
 ///   * `<dir>/key_public.pem` — SPKI PEM, 0644 (what the pair flow reads).
-pub fn generate_keypair(dir: &Path) -> Result<KeyPair> {
+fn generate_keypair_locked(dir: &Path, replace_unusable: bool) -> Result<KeyPair> {
     use p256::elliptic_curve::rand_core::OsRng;
     use p256::pkcs8::EncodePublicKey;
 
-    std::fs::create_dir_all(dir).with_context(|| format!("creating key dir {}", dir.display()))?;
-    let _lock = KeyDirectoryLock::acquire(dir)?;
-
     let priv_path = dir.join("key_private.pem");
     let pub_path = dir.join("key_public.pem");
-    if std::fs::symlink_metadata(&priv_path).is_ok() {
-        return load_keypair(dir).with_context(|| {
-            format!(
-                "existing Tesla BLE private key {} is invalid or incomplete; refusing to overwrite it",
+    match std::fs::symlink_metadata(&priv_path) {
+        Ok(metadata) if !metadata.file_type().is_file() => {
+            bail!(
+                "existing Tesla BLE private key path {} is not a regular file; refusing to overwrite it",
                 priv_path.display()
-            )
-        });
+            );
+        }
+        Ok(_) if !replace_unusable => {
+            return load_keypair(dir).with_context(|| {
+                format!(
+                    "existing Tesla BLE private key {} is invalid or incomplete; refusing to overwrite it",
+                    priv_path.display()
+                )
+            });
+        }
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("reading private key metadata {}", priv_path.display()));
+        }
     }
 
     let secret = SecretKey::random(&mut OsRng);
@@ -270,6 +293,32 @@ pub fn generate_keypair(dir: &Path) -> Result<KeyPair> {
     sync_key_directory(dir)?;
 
     load_keypair(dir).context("validating published Tesla BLE keypair")
+}
+
+pub fn generate_keypair(dir: &Path) -> Result<KeyPair> {
+    std::fs::create_dir_all(dir).with_context(|| format!("creating key dir {}", dir.display()))?;
+    let _lock = KeyDirectoryLock::acquire(dir)?;
+    generate_keypair_locked(dir, false)
+}
+
+/// Explicitly make the directory contain one usable keypair. A valid private
+/// key is preserved and its public half is repaired; an unusable regular
+/// private-key file is atomically replaced. Symlinks and other non-files are
+/// always rejected.
+pub fn regenerate_keypair(dir: &Path) -> Result<KeyPair> {
+    std::fs::create_dir_all(dir).with_context(|| format!("creating key dir {}", dir.display()))?;
+    let _lock = KeyDirectoryLock::acquire(dir)?;
+
+    let priv_path = dir.join("key_private.pem");
+    if let Ok(keypair) = load_regular_private_key(&priv_path) {
+        if load_keypair(dir).is_ok() {
+            return Ok(keypair);
+        }
+        publish_public_key(dir, &keypair)?;
+        return load_keypair(dir).context("validating repaired Tesla BLE keypair");
+    }
+
+    generate_keypair_locked(dir, true)
 }
 
 /// Hand-parse SEC1 ECPrivateKey DER to extract the 32-byte scalar.
@@ -437,6 +486,32 @@ mod tests {
         assert_eq!(std::fs::read(&priv_path).unwrap(), b"broken-private-key");
     }
 
+    #[test]
+    fn explicit_regeneration_replaces_empty_key_files() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("key_private.pem"), b"").unwrap();
+        std::fs::write(dir.path().join("key_public.pem"), b"").unwrap();
+
+        regenerate_keypair(dir.path()).unwrap();
+
+        assert!(key_is_usable(&dir.path().join("key_private.pem")));
+        load_keypair(dir.path()).unwrap();
+    }
+
+    #[test]
+    fn explicit_regeneration_repairs_public_key_without_rotation() {
+        let dir = tempfile::tempdir().unwrap();
+        generate_keypair(dir.path()).unwrap();
+        let priv_path = dir.path().join("key_private.pem");
+        let private_before = std::fs::read(&priv_path).unwrap();
+        std::fs::write(dir.path().join("key_public.pem"), b"broken-public-key").unwrap();
+
+        regenerate_keypair(dir.path()).unwrap();
+
+        assert_eq!(std::fs::read(priv_path).unwrap(), private_before);
+        load_keypair(dir.path()).unwrap();
+    }
+
     #[cfg(unix)]
     #[test]
     fn generated_key_files_have_safe_modes_and_no_staging_remnants() {
@@ -484,6 +559,7 @@ mod tests {
 
         assert!(load_keypair(install.path()).is_err());
         assert!(ensure_keypair_files(install.path()).is_err());
+        assert!(regenerate_keypair(install.path()).is_err());
         assert!(install.path().join("key_private.pem").is_symlink());
     }
 

--- a/install-pi.sh
+++ b/install-pi.sh
@@ -13,9 +13,12 @@
 # Or with a local binary:
 #   bash install-pi.sh /path/to/sentryusb-binary
 
+set -Eeuo pipefail
+
 REPO="${REPO:-Sentry-Six/Sentry-USB-Rusty}"
-INSTALL_DIR="/opt/sentryusb"
+INSTALL_DIR="${SENTRYUSB_INSTALL_DIR:-/opt/sentryusb}"
 BINARY_NAME="sentryusb"
+REMOUNT_HELPER="${SENTRYUSB_REMOUNT_HELPER:-/root/bin/remountfs_rw}"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -28,9 +31,116 @@ ok()    { echo -e "${GREEN}[OK]${NC} $1"; }
 warn()  { echo -e "${YELLOW}[WARN]${NC} $1"; }
 error_exit() { echo -e "${RED}[ERROR]${NC} $1"; exit 1; }
 
+mount_is_writable() {
+    local mountpoint="$1"
+    local options
+
+    options=$(findmnt -no OPTIONS "$mountpoint" 2>/dev/null) || return 1
+    case ",$options," in
+        *,rw,*) return 0 ;;
+        *)      return 1 ;;
+    esac
+}
+
+ensure_install_filesystems_writable() {
+    ROOT_WAS_READONLY=0
+    BOOT_WAS_READONLY=0
+    BOOT_MOUNT=""
+
+    for candidate in /boot/firmware /boot; do
+        if findmnt -no TARGET "$candidate" >/dev/null 2>&1; then
+            BOOT_MOUNT="$candidate"
+            break
+        fi
+    done
+
+    mount_is_writable / || ROOT_WAS_READONLY=1
+    if [ -n "$BOOT_MOUNT" ] && ! mount_is_writable "$BOOT_MOUNT"; then
+        BOOT_WAS_READONLY=1
+    fi
+
+    if [ "$ROOT_WAS_READONLY" = 1 ] || [ "$BOOT_WAS_READONLY" = 1 ]; then
+        info "Existing read-only SentryUSB install detected; preparing filesystems..."
+        if [ -x "$REMOUNT_HELPER" ]; then
+            "$REMOUNT_HELPER" >/dev/null 2>&1 || true
+        fi
+    fi
+
+    if ! mount_is_writable /; then
+        mount -o remount,rw / >/dev/null 2>&1 \
+            || error_exit "Root filesystem is read-only and could not be remounted read-write."
+    fi
+    mount_is_writable / \
+        || error_exit "Root filesystem is still read-only after the remount attempt."
+
+    if [ -n "$BOOT_MOUNT" ] && ! mount_is_writable "$BOOT_MOUNT"; then
+        mount -o remount,rw "$BOOT_MOUNT" >/dev/null 2>&1 \
+            || error_exit "$BOOT_MOUNT is read-only and could not be remounted read-write."
+    fi
+    if [ -n "$BOOT_MOUNT" ]; then
+        mount_is_writable "$BOOT_MOUNT" \
+            || error_exit "$BOOT_MOUNT is still read-only after the remount attempt."
+    fi
+}
+
+install_release_asset() {
+    local name="$1"
+    local suffix="$2"
+    local download_url="https://github.com/${REPO}/releases/download/${RELEASE_TAG}/${name}-${suffix}"
+    local destination="${INSTALL_DIR}/${name}-${suffix}"
+    local staged="${INSTALL_DIR}/.${name}-${suffix}.new"
+    local attempt
+
+    for attempt in $(seq 1 5); do
+        rm -f "$staged"
+        if curl -fsSL "$download_url" -o "$staged" 2>/dev/null \
+            && [ -s "$staged" ] \
+            && chmod +x "$staged" \
+            && mv -f "$staged" "$destination" \
+            && [ -x "$destination" ]; then
+            ok "Downloaded $name-$suffix"
+            return 0
+        fi
+        rm -f "$staged"
+        warn "Install of $name-$suffix failed (attempt $attempt/5), retrying..."
+        sleep 3
+    done
+
+    error_exit "Failed to install $name-$suffix after 5 attempts"
+}
+
+install_release_bundle() {
+    local suffix
+    local name
+
+    for suffix in $SUFFIXES; do
+        install_release_asset "$BINARY_NAME" "$suffix"
+    done
+    for suffix in $SUFFIXES; do
+        for name in sentryusb-tesla-telemetry sentryusb-ble-action; do
+            install_release_asset "$name" "$suffix"
+        done
+    done
+}
+
+readonly_reinstall_exit_notice() {
+    local exit_status="${1:-0}"
+
+    if [ "${ROOT_WAS_READONLY:-0}" = 1 ] || [ "${BOOT_WAS_READONLY:-0}" = 1 ]; then
+        if [ "$exit_status" -ne 0 ]; then
+            warn "The installation failed after remounting a read-only SentryUSB. Reboot now to restore the read-only mounts."
+        else
+            warn "This was a read-only SentryUSB reinstall. Reboot now to restore the read-only mounts."
+        fi
+    fi
+}
+
 if [[ $EUID -ne 0 ]]; then
     error_exit "This script must be run as root. Try: sudo -i"
 fi
+
+trap 'readonly_reinstall_exit_notice "$?"' EXIT
+ensure_install_filesystems_writable
 
 # Backward-compat: the Go install.sh accepted `norootshrink` as its
 # first arg to skip the root-partition shrink step (used when an
@@ -118,42 +228,33 @@ if [ -n "${1:-}" ] && [ -f "${1:-}" ]; then
         cp "$1" "$INSTALL_DIR/$BINARY_NAME-$sfx"
         chmod +x "$INSTALL_DIR/$BINARY_NAME-$sfx"
     done
-    ok "Local binary staged under $(echo $SUFFIXES | tr ' ' '\n' | wc -l) variant(s)"
+    ok "Local binary staged under $(echo "$SUFFIXES" | tr ' ' '\n' | wc -l) variant(s)"
 else
     info "Downloading SentryUSB binary variants from GitHub..."
-
-    for sfx in $SUFFIXES; do
-        DOWNLOAD_URL="https://github.com/${REPO}/releases/latest/download/${BINARY_NAME}-${sfx}"
-        TMP="/tmp/${BINARY_NAME}-${sfx}.new"
-        success=false
-        for attempt in $(seq 1 5); do
-            if curl -fsSL "$DOWNLOAD_URL" -o "$TMP" 2>/dev/null; then
-                chmod +x "$TMP"
-                mv "$TMP" "$INSTALL_DIR/$BINARY_NAME-$sfx"
-                ok "Downloaded $BINARY_NAME-$sfx"
-                success=true
-                break
-            fi
-            warn "Download of $sfx failed (attempt $attempt/5), retrying..."
-            sleep 3
-        done
-        if [ "$success" != true ]; then
-            error_exit "Failed to download $BINARY_NAME-$sfx after 5 attempts"
-        fi
-    done
 
     RELEASE_TAG=$(curl -fsSL --max-time 10 \
         "https://api.github.com/repos/${REPO}/releases/latest" 2>/dev/null \
         | grep '"tag_name"' | head -1 \
         | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/' || true)
-    if [ -n "${RELEASE_TAG:-}" ]; then
-        echo "$RELEASE_TAG" > "$INSTALL_DIR/version"
-        ok "Version: $RELEASE_TAG"
+    if [ -z "${RELEASE_TAG:-}" ]; then
+        RELEASE_URL=$(curl -fsSL --max-time 10 -o /dev/null -w '%{url_effective}' \
+            "https://github.com/${REPO}/releases/latest" 2>/dev/null || true)
+        RELEASE_TAG="${RELEASE_URL##*/}"
     fi
+    [ -n "${RELEASE_TAG:-}" ] && [ "$RELEASE_TAG" != latest ] \
+        || error_exit "Could not resolve the latest SentryUSB release tag"
+
+    install_release_bundle
+    echo "$RELEASE_TAG" > "$INSTALL_DIR/version"
+    ok "Version: $RELEASE_TAG"
 fi
 
+# Keep scripts and services on the same source tag as the release binaries.
+# Local-binary development installs intentionally follow main.
+SOURCE_REF="${RELEASE_TAG:-main}"
+
 # ── Picker script (selects the right binary at every service start) ──
-PICKER_URL="https://raw.githubusercontent.com/${REPO}/main/pi-gen-sources/00-sentryusb-tweaks/files/sentryusb-pick-binary"
+PICKER_URL="https://raw.githubusercontent.com/${REPO}/${SOURCE_REF}/pi-gen-sources/00-sentryusb-tweaks/files/sentryusb-pick-binary"
 PICKER_DST="/usr/local/bin/sentryusb-pick-binary"
 PICKER_LOCAL_FALLBACK="$(dirname "${1:-/dev/null}")/sentryusb-pick-binary"
 if [ -f "$PICKER_LOCAL_FALLBACK" ]; then
@@ -220,7 +321,7 @@ ok "sentryusb.service installed and enabled"
 # ── Step 3b: BLE daemon (Python) ───────────────────────────────────
 
 info "Installing SentryUSB BLE daemon..."
-BLE_REPO_URL="https://raw.githubusercontent.com/${REPO}/main/server/ble"
+BLE_REPO_URL="https://raw.githubusercontent.com/${REPO}/${SOURCE_REF}/server/ble"
 # Install at /root/bin/ — matches both the vendored service unit's
 # hardcoded ExecStart path AND what pi-gen 00-run.sh installs, so the
 # binary is reachable whether the user came via image-flash or
@@ -289,7 +390,7 @@ ok "Gadget shims installed at /root/bin/{enable,disable}_gadget.sh"
 # pi-gen image build deploys it as part of the image; install-pi.sh users never
 # get it, so sentryusb-archive.service fails fast with "envsetup.sh: No such
 # file or directory" and respawns until systemd gives up.
-if curl -fsSL "https://raw.githubusercontent.com/${REPO}/main/setup/pi/envsetup.sh" \
+if curl -fsSL "https://raw.githubusercontent.com/${REPO}/${SOURCE_REF}/setup/pi/envsetup.sh" \
        -o /root/bin/envsetup.sh 2>/dev/null; then
     chmod +x /root/bin/envsetup.sh
     ok "envsetup.sh installed (archiveloop runtime config)"
@@ -334,7 +435,7 @@ fi
 # Rust binary's update.rs invokes after every binary swap so install-time
 # fixes — BLE non-fatal-adv on BCM4345C0 (4C+), EATT disable on all
 # boards, etc. — heal automatically on update instead of silently rotting.
-PATCHES_URL="https://raw.githubusercontent.com/${REPO}/main/setup/pi/apply-runtime-patches.sh"
+PATCHES_URL="https://raw.githubusercontent.com/${REPO}/${SOURCE_REF}/setup/pi/apply-runtime-patches.sh"
 PATCHES_DST="/usr/local/bin/sentryusb-apply-runtime-patches"
 PATCHES_LOCAL="$(dirname "${1:-/dev/null}")/setup/pi/apply-runtime-patches.sh"
 if [ -f "$PATCHES_LOCAL" ]; then
@@ -503,7 +604,11 @@ DTS
              BCM4345C0.raspberrypi,4-compute-module.hcd; do
         [ -e "$BRCM/$c" ] && { HCD="$c"; break; }
     done
-    [ -z "$HCD" ] && HCD=$(cd "$BRCM" 2>/dev/null && ls BCM4345C0*.hcd 2>/dev/null | grep -vE 'radxa,rock-4c-plus|raspberrypi' | head -1)
+    [ -z "$HCD" ] && HCD=$(find "$BRCM" -maxdepth 1 -type f \
+        -name 'BCM4345C0*.hcd' \
+        ! -name '*radxa,rock-4c-plus*' \
+        ! -name '*raspberrypi*' \
+        -print -quit 2>/dev/null)
     if [ -n "$HCD" ] && [ -e "$BRCM/$HCD" ]; then
         ln -sf "$HCD" "$BRCM/BCM4345C0.radxa,rock-4c-plus.hcd"
         ln -sf "$HCD" "$BRCM/BCM4345C0.hcd"
@@ -554,7 +659,7 @@ fi
 # natively-working r03 from the 4C+ (identical bluetoothd binary). Staging is
 # inert — the helper self-stands-down on boards the manifest qualifies native.
 info "Installing BLE advertising selector + helper..."
-BLE_ADV_BASE_URL="https://raw.githubusercontent.com/${REPO}/main/setup/pi"
+BLE_ADV_BASE_URL="https://raw.githubusercontent.com/${REPO}/${SOURCE_REF}/setup/pi"
 LOCAL_PI_DIR="$(dirname "${1:-/dev/null}")/setup/pi"
 fetch_file() {
     # $1 = filename, $2 = destination, $3 = mode (default 644). Local repo first, then URL.
@@ -603,7 +708,7 @@ if [ ! -f /root/sentryusb.conf ]; then
     # returned the Go-era sample OR fell back to the tiny offline stub
     # below — both of which left the "raw config editor" in the web UI
     # showing only a handful of keys instead of the full documented set.
-    SAMPLE_URL="https://raw.githubusercontent.com/${REPO}/main/pi-gen-sources/00-sentryusb-tweaks/files/sentryusb.conf.sample"
+    SAMPLE_URL="https://raw.githubusercontent.com/${REPO}/${SOURCE_REF}/pi-gen-sources/00-sentryusb-tweaks/files/sentryusb.conf.sample"
     if curl -fsSL --max-time 15 "$SAMPLE_URL" -o /root/sentryusb.conf; then
         ok "Sample config downloaded to /root/sentryusb.conf"
     else
@@ -671,7 +776,7 @@ fi
 # Advertise IPv4 only: a AAAA answer for .local sends Windows/Chrome to the
 # Pi's rotating SLAAC address (slow, stale) and triggers Chrome Private
 # Network Access "CORS" blocks on the plain-http UI. Device IPv6 untouched.
-AVAHI_V4_URL="https://raw.githubusercontent.com/${REPO}/main/setup/pi/avahi-ipv4-only.sh"
+AVAHI_V4_URL="https://raw.githubusercontent.com/${REPO}/${SOURCE_REF}/setup/pi/avahi-ipv4-only.sh"
 if curl -fsSL --max-time 15 "$AVAHI_V4_URL" -o /tmp/avahi-ipv4-only.sh 2>/dev/null; then
     bash /tmp/avahi-ipv4-only.sh >/dev/null 2>&1 || warn "could not apply IPv4-only mDNS config"
     rm -f /tmp/avahi-ipv4-only.sh

--- a/pi-gen-sources/00-sentryusb-tweaks/files/sentryusb-pick-binary
+++ b/pi-gen-sources/00-sentryusb-tweaks/files/sentryusb-pick-binary
@@ -22,14 +22,37 @@
 # to the unsuffixed legacy name for very old installs that pre-date
 # this scheme.
 
-set -u
+set -euo pipefail
 
-INSTALL_DIR=/opt/sentryusb
+INSTALL_DIR="${SENTRYUSB_INSTALL_DIR:-/opt/sentryusb}"
+ROOT_BIN="${SENTRYUSB_ROOT_BIN:-/root/bin}"
 CURRENT_LINK="${INSTALL_DIR}/sentryusb-current"
 ACTIVE_FILE="${INSTALL_DIR}/active-variant"
 TAG="sentryusb-pick-binary"
 
-log() { logger -t "$TAG" -- "$1" 2>/dev/null || echo "$TAG: $1" >&2; }
+log() {
+    if [ "${SENTRYUSB_PICK_LOG_STDERR:-0}" = 1 ]; then
+        echo "$TAG: $1" >&2
+    else
+        logger -t "$TAG" -- "$1" 2>/dev/null || echo "$TAG: $1" >&2
+    fi
+}
+
+ensure_symlink() {
+    local target="$1"
+    local link="$2"
+
+    # A read-only production root is the normal boot state. Avoid rewriting an
+    # already-correct link: ln -sfn would fail with EROFS even though no repair
+    # is needed.
+    if [ -L "$link" ] \
+        && [ "$(readlink "$link" 2>/dev/null || true)" = "$target" ] \
+        && [ -x "$link" ]; then
+        return 0
+    fi
+
+    ln -sfn "$target" "$link"
+}
 
 detect_variant() {
     # Userspace arch takes precedence — a 64-bit kernel may host a 32-bit
@@ -125,7 +148,10 @@ fi
 # Atomic symlink swap — ln -sfn keeps the old link reachable until rename
 # completes, so a concurrent systemd ExecStart wouldn't dereference a
 # half-written link.
-ln -sfn "$PICKED_PATH" "$CURRENT_LINK"
+if ! ensure_symlink "$PICKED_PATH" "$CURRENT_LINK"; then
+    log "FATAL: could not link ${CURRENT_LINK} -> ${PICKED_PATH}"
+    exit 1
+fi
 
 # Record what this CPU NEEDS (the detected variant) — NOT what we ended
 # up running. The fallback pick above reflects what happened to be on
@@ -136,8 +162,11 @@ ln -sfn "$PICKED_PATH" "$CURRENT_LINK"
 # it isn't a release suffix and 404s every download built from it.
 # Best-effort write — failure here doesn't block startup, the updater
 # just falls back to re-detection on its own.
-if [ -n "$DETECTED" ]; then
-    printf '%s\n' "$DETECTED" > "$ACTIVE_FILE" 2>/dev/null || true
+if [ -n "$DETECTED" ] \
+    && [ "$(cat "$ACTIVE_FILE" 2>/dev/null || true)" != "$DETECTED" ]; then
+    if ! printf '%s\n' "$DETECTED" > "$ACTIVE_FILE" 2>/dev/null; then
+        log "WARNING: could not update ${ACTIVE_FILE}; keeping existing value"
+    fi
 fi
 
 log "selected variant=${PICKED} (detected=${DETECTED:-unknown}) path=${PICKED_PATH}"
@@ -160,7 +189,9 @@ log "selected variant=${PICKED} (detected=${DETECTED:-unknown}) path=${PICKED_PA
 # Legacy installs: if no per-variant copies exist under /opt/sentryusb
 # (image predates this scheme and the OTA updater hasn't run since), leave
 # /root/bin alone — a regular file there is the only copy we have.
-mkdir -p /root/bin 2>/dev/null || true
+if ! mkdir -p "$ROOT_BIN" 2>/dev/null; then
+    log "WARNING: could not create ${ROOT_BIN}; auxiliary BLE links cannot be repaired"
+fi
 for name in sentryusb-tesla-telemetry sentryusb-ble-action; do
     AUX_PATH="${INSTALL_DIR}/${name}-${PICKED}"
     if [ ! -x "$AUX_PATH" ]; then
@@ -175,8 +206,21 @@ for name in sentryusb-tesla-telemetry sentryusb-ble-action; do
         done
     fi
     if [ -x "$AUX_PATH" ]; then
-        ln -sfn "$AUX_PATH" "/root/bin/${name}"
-        log "${name} -> ${AUX_PATH}"
+        if ensure_symlink "$AUX_PATH" "${ROOT_BIN}/${name}"; then
+            log "${name} -> ${AUX_PATH}"
+        else
+            log "ERROR: could not link ${ROOT_BIN}/${name} -> ${AUX_PATH}"
+        fi
+    elif [ -L "${ROOT_BIN}/${name}" ]; then
+        if [ -x "${ROOT_BIN}/${name}" ]; then
+            if rm -f "${ROOT_BIN}/${name}" 2>/dev/null; then
+                log "ERROR: removed incompatible helper link ${ROOT_BIN}/${name}; no executable fallback is installed"
+            else
+                log "ERROR: ${ROOT_BIN}/${name} points to an incompatible helper and the read-only root prevented removal"
+            fi
+        else
+            log "WARNING: ${ROOT_BIN}/${name} is a dangling symlink and no executable fallback is installed"
+        fi
     fi
 done
 

--- a/server/ble/sentryusb-telemetry.service
+++ b/server/ble/sentryusb-telemetry.service
@@ -20,8 +20,16 @@ After=sentryusb.service
 # no longer a tesla-control dependency. Listing each path separately
 # means `systemctl status` says exactly which one is missing rather than
 # spawning and crashing at ExecStart.
+#
+# The key uses ConditionFileNotEmpty=, NOT ConditionPathExists=: an
+# interrupted keygen leaves a 0-byte key_private.pem, which satisfies
+# "exists". The unit then started, bound its IPC socket, reported
+# `active (running)`, and failed every single pair request with
+# "parsing PEM envelope: malformedframing" — the confusing case where
+# systemctl says healthy but nothing works. Refusing to start on an
+# empty key surfaces the real problem in `systemctl status`.
 ConditionPathExists=/root/bin/sentryusb-tesla-telemetry
-ConditionPathExists=/root/.ble/key_private.pem
+ConditionFileNotEmpty=/root/.ble/key_private.pem
 # Match sentryusb-ble.service's burst limits so a flaky boot doesn't
 # burn through the systemd restart budget.
 StartLimitBurst=20

--- a/setup/pi/configure.sh
+++ b/setup/pi/configure.sh
@@ -299,13 +299,22 @@ function check_and_configure_tesla_ble () {
 
     local pairing_needed=true
     mkdir -p /root/.ble
-    if [ ! -f /root/.ble/key_public.pem ] || [ ! -f /root/.ble/key_private.pem ]
+    # `-s` (exists AND non-empty), not `-f` (merely exists). An interrupted
+    # keygen leaves a 0-byte PEM behind; `-f` accepted it, skipped
+    # regeneration, and every later pair attempt died with an opaque
+    # "parsing PEM envelope: malformedframing". keygen itself now validates
+    # and replaces an unusable key, so re-running it here is safe.
+    if [ ! -s /root/.ble/key_public.pem ] || [ ! -s /root/.ble/key_private.pem ]
     then
       if [ -x "$ble_action" ]; then
         # Generates the keypair + the key_pending_pairing marker with the
         # right perms (0600 / 0644).
-        "$ble_action" keygen
-        log_progress "Generated keys for Tesla BLE interface."
+        if "$ble_action" keygen; then
+          log_progress "Generated keys for Tesla BLE interface."
+        else
+          log_progress "WARNING: keygen failed (exit $?) — BLE pairing will not work. Check that / is writable and re-run: $ble_action keygen"
+          pairing_needed=false
+        fi
       else
         log_progress "WARNING: $ble_action not found — keys will be generated later via the web UI."
         pairing_needed=false

--- a/test/install-pi-safety.test.sh
+++ b/test/install-pi-safety.test.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+# Regression coverage for reinstalling onto an already read-only SentryUSB.
+set -euo pipefail
+
+script=${1:-install-pi.sh}
+script=$(cd "$(dirname "$script")" && pwd)/$(basename "$script")
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+# curl | bash ignores the shebang, so strict mode must be enabled by the body.
+grep -q '^set -Eeuo pipefail$' "$script"
+
+# Install the EXIT warning before the first remount attempt: root may become RW
+# and a later boot remount can still fail inside the same function.
+trap_line=$(grep -n "^trap 'readonly_reinstall_exit_notice" "$script" | cut -d: -f1)
+remount_line=$(grep -n '^ensure_install_filesystems_writable$' "$script" | cut -d: -f1)
+[ -n "$trap_line" ] && [ -n "$remount_line" ] && [ "$trap_line" -lt "$remount_line" ]
+
+# Functions and variables below are consumed by functions loaded via eval.
+# shellcheck disable=SC2034,SC2329
+load_installer_functions() {
+  REPO=Sentry-Six/Sentry-USB-Rusty
+  INSTALL_DIR="${SENTRYUSB_INSTALL_DIR:-/opt/sentryusb}"
+  REMOUNT_HELPER="${SENTRYUSB_REMOUNT_HELPER:-/root/bin/remountfs_rw}"
+  BINARY_NAME=sentryusb
+  RELEASE_TAG=v-test
+  RED='' GREEN='' BLUE='' YELLOW='' NC=''
+  info() { echo "[INFO] $1"; }
+  ok() { echo "[OK] $1"; }
+  warn() { echo "[WARN] $1"; }
+  error_exit() { echo "[ERROR] $1"; exit 1; }
+  eval "$(awk '/^mount_is_writable\(\)/,/^}/' "$script")"
+  eval "$(awk '/^ensure_install_filesystems_writable\(\)/,/^}/' "$script")"
+  eval "$(awk '/^install_release_asset\(\)/,/^}/' "$script")"
+  eval "$(awk '/^install_release_bundle\(\)/,/^}/' "$script")"
+  eval "$(awk '/^readonly_reinstall_exit_notice\(\)/,/^}/' "$script")"
+}
+
+# A failed final move must never print OK or return success.
+set +e
+# shellcheck disable=SC2030
+(
+  export SENTRYUSB_INSTALL_DIR="$tmp/install-fail"
+  load_installer_functions
+  mkdir -p "$INSTALL_DIR"
+  # Invoked indirectly by install_release_asset loaded via eval.
+  # shellcheck disable=SC2329
+  curl() {
+    local output=""
+    while [ "$#" -gt 0 ]; do
+      if [ "$1" = -o ]; then output="$2"; shift 2; else shift; fi
+    done
+    printf 'downloaded payload\n' > "$output"
+  }
+  # shellcheck disable=SC2329
+  mv() { printf 'attempt\n' >> "$tmp/mv-attempts"; return 1; }
+  # shellcheck disable=SC2329
+  sleep() { :; }
+  install_release_asset sentryusb linux-arm64-a72
+) >"$tmp/fail.out" 2>&1
+status=$?
+set -e
+[ "$status" -ne 0 ] || { echo "failed move returned success" >&2; exit 1; }
+[ "$(wc -l < "$tmp/mv-attempts")" -eq 5 ] || { echo "failed move was not retried" >&2; exit 1; }
+! grep -q 'Downloaded sentryusb-linux-arm64-a72' "$tmp/fail.out" \
+  || { echo "failed move printed a false OK" >&2; exit 1; }
+
+# The happy path publishes an executable from a same-filesystem staging file.
+# shellcheck disable=SC2031
+(
+  export SENTRYUSB_INSTALL_DIR="$tmp/install-ok"
+  load_installer_functions
+  mkdir -p "$INSTALL_DIR"
+  # Invoked indirectly by install_release_asset loaded via eval.
+  # shellcheck disable=SC2329
+  curl() {
+    local output=""
+    while [ "$#" -gt 0 ]; do
+      if [ "$1" = -o ]; then output="$2"; shift 2; else shift; fi
+    done
+    printf '#!/bin/sh\nexit 0\n' > "$output"
+  }
+  # shellcheck disable=SC2329
+  sleep() { :; }
+  install_release_asset sentryusb linux-arm64-a72
+  [ -x "$INSTALL_DIR/sentryusb-linux-arm64-a72" ]
+  [ ! -e "$INSTALL_DIR/.sentryusb-linux-arm64-a72.new" ]
+) >"$tmp/success.out" 2>&1
+grep -q 'Downloaded sentryusb-linux-arm64-a72' "$tmp/success.out"
+
+# If remounting fails, stop before claiming that installation can proceed.
+set +e
+(
+  export SENTRYUSB_REMOUNT_HELPER="$tmp/missing-remount-helper"
+  load_installer_functions
+  # Invoked indirectly by ensure_install_filesystems_writable loaded via eval.
+  # shellcheck disable=SC2329
+  findmnt() {
+    if [ "${2:-}" = TARGET ]; then printf '%s\n' "${3:-/}"; else printf 'ro,noatime\n'; fi
+  }
+  # shellcheck disable=SC2329
+  mount() { return 1; }
+  ensure_install_filesystems_writable
+) >"$tmp/remount.out" 2>&1
+status=$?
+set -e
+[ "$status" -ne 0 ] || { echo "read-only remount failure returned success" >&2; exit 1; }
+grep -q 'could not be remounted read-write' "$tmp/remount.out"
+
+# Release installs must not mix latest binaries with scripts from moving main.
+# shellcheck disable=SC2016
+grep -q 'SOURCE_REF="${RELEASE_TAG:-main}"' "$script"
+# shellcheck disable=SC2016
+if grep -q 'raw.githubusercontent.com/${REPO}/main/' "$script"; then
+  echo "release-managed scripts still bypass SOURCE_REF" >&2
+  exit 1
+fi
+
+# A release is a protocol-compatible bundle: every CPU variant gets the main
+# daemon and both native BLE helpers from the same pinned tag.
+(
+  load_installer_functions
+  # Consumed by functions loaded dynamically above.
+  # shellcheck disable=SC2034
+  SUFFIXES='linux-arm64-a53 linux-arm64-a72 linux-arm64-a76'
+  RELEASE_TAG=v9.9.9
+  # Invoked indirectly by install_release_bundle loaded via eval.
+  # shellcheck disable=SC2329
+  install_release_asset() { printf '%s %s %s\n' "$RELEASE_TAG" "$1" "$2"; }
+  install_release_bundle
+) >"$tmp/bundle.out"
+[ "$(wc -l < "$tmp/bundle.out")" -eq 9 ]
+for suffix in linux-arm64-a53 linux-arm64-a72 linux-arm64-a76; do
+  grep -qx "v9.9.9 sentryusb $suffix" "$tmp/bundle.out"
+  grep -qx "v9.9.9 sentryusb-tesla-telemetry $suffix" "$tmp/bundle.out"
+  grep -qx "v9.9.9 sentryusb-ble-action $suffix" "$tmp/bundle.out"
+done
+
+# Failure after remounting a read-only install must leave an explicit warning;
+# otherwise the appliance silently remains writable until reboot.
+(
+  load_installer_functions
+  # Consumed by readonly_reinstall_exit_notice loaded via eval.
+  # shellcheck disable=SC2034
+  ROOT_WAS_READONLY=1
+  # shellcheck disable=SC2034
+  BOOT_WAS_READONLY=0
+  readonly_reinstall_exit_notice 1
+) >"$tmp/exit-notice.out" 2>&1
+grep -q 'installation failed after remounting' "$tmp/exit-notice.out"
+
+echo "install-pi safety tests passed"

--- a/test/sentryusb-pick-binary.test.sh
+++ b/test/sentryusb-pick-binary.test.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Regression coverage for auxiliary helper symlink repair on read-only roots.
+set -euo pipefail
+
+picker=${1:-pi-gen-sources/00-sentryusb-tweaks/files/sentryusb-pick-binary}
+picker=$(cd "$(dirname "$picker")" && pwd)/$(basename "$picker")
+tmp=$(mktemp -d)
+trap 'chmod 755 "$tmp/install" "$tmp/root-bin" 2>/dev/null || true; rm -rf "$tmp"' EXIT
+
+install="$tmp/install"
+root_bin="$tmp/root-bin"
+suffix=linux-arm64-a72
+mkdir -p "$install" "$root_bin"
+
+make_executable() {
+  printf '#!/bin/sh\nexit 0\n' > "$1"
+  chmod +x "$1"
+}
+
+make_executable "$install/sentryusb-$suffix"
+make_executable "$install/sentryusb-tesla-telemetry-$suffix"
+make_executable "$install/sentryusb-ble-action-$suffix"
+
+run_picker() {
+  SENTRYUSB_INSTALL_DIR="$install" \
+  SENTRYUSB_ROOT_BIN="$root_bin" \
+  SENTRYUSB_PICK_LOG_STDERR=1 \
+    bash "$picker"
+}
+
+run_picker >"$tmp/first.out" 2>&1
+[ "$(readlink "$install/sentryusb-current")" = "$install/sentryusb-$suffix" ]
+[ "$(readlink "$root_bin/sentryusb-tesla-telemetry")" = "$install/sentryusb-tesla-telemetry-$suffix" ]
+[ "$(readlink "$root_bin/sentryusb-ble-action")" = "$install/sentryusb-ble-action-$suffix" ]
+[ -x "$root_bin/sentryusb-ble-action" ]
+
+# Correct links must not be rewritten on the normal read-only boot path.
+chmod 555 "$install" "$root_bin"
+run_picker >"$tmp/readonly.out" 2>&1
+if grep -qE 'FATAL|ERROR|dangling' "$tmp/readonly.out"; then
+  echo "correct read-only links were treated as failures" >&2
+  exit 1
+fi
+chmod 755 "$install" "$root_bin"
+
+# A dangling link is not healthy and must be reported, not logged as repaired.
+rm -f "$install/sentryusb-ble-action-$suffix"
+run_picker >"$tmp/dangling.out" 2>&1
+grep -q 'sentryusb-ble-action is a dangling symlink' "$tmp/dangling.out"
+if grep -q "sentryusb-ble-action ->" "$tmp/dangling.out"; then
+  echo "dangling helper was falsely logged as repaired" >&2
+  exit 1
+fi
+
+# Once the expected binary appears, the picker repairs the dangling link.
+make_executable "$install/sentryusb-ble-action-$suffix"
+run_picker >"$tmp/repaired.out" 2>&1
+[ -x "$root_bin/sentryusb-ble-action" ]
+grep -q "sentryusb-ble-action -> $install/sentryusb-ble-action-$suffix" "$tmp/repaired.out"
+
+# A helper for a newer CPU can still satisfy -x on the current host even though
+# executing it would SIGILL. With no compatible fallback, remove that unsafe
+# symlink instead of silently leaving it active.
+rm -f "$install/sentryusb-ble-action-$suffix"
+newer_suffix=linux-arm64-a76
+make_executable "$install/sentryusb-ble-action-$newer_suffix"
+ln -sfn "$install/sentryusb-ble-action-$newer_suffix" "$root_bin/sentryusb-ble-action"
+run_picker >"$tmp/incompatible.out" 2>&1
+[ ! -e "$root_bin/sentryusb-ble-action" ]
+grep -q 'removed incompatible helper link' "$tmp/incompatible.out"
+
+echo "sentryusb picker auxiliary-link tests passed"


### PR DESCRIPTION
## What does this PR do?

Fixes a BLE setup deadlock caused by interrupted key generation.

A zero-byte or malformed `key_private.pem` previously passed existence checks, so setup and systemd treated BLE as installed while every pairing attempt failed with `parsing PEM envelope: malformedframing`. Re-running key generation could not recover automatically. Partial helper downloads could also leave dangling links or mix binaries from different releases.

This PR:

- validates that private/public PEM files are regular, parseable, and belong to the same keypair;
- writes key files under a directory lock using staged files, fsync, and atomic rename;
- preserves a valid private key and repairs only its public half, while explicit key generation can replace an unusable private key and require re-pairing;
- clears stale paired state before rotating a private key, while preserving it for public-key-only repair;
- uses key validity/non-empty checks in setup, API, actions, and systemd, with clearer recovery errors;
- installs the main binary and BLE helpers from one resolved release, verifies staged executables, and repairs dangling helper links on read-only installations;
- adds BLE, installer, and binary-picker regression tests and runs the shell regressions in CI.

`check.sh` and `setup/pi/configure.sh` are TeslaUSB-derived and remain under the MIT license listed in `NOTICE`.

### Validation

- `cargo test -p sentryusb-tesla-ble -p sentryusb-setup`: 101 passed (55 BLE, 46 setup)
- `cargo test --workspace --exclude sentryusb-drives`: passed
- `cargo clippy --all-targets --all-features`: passed with existing warnings
- `cargo fmt --all`: completed in a clean scratch worktree; current stable rustfmt rewrites 161 existing files, so unrelated repository-wide formatting churn was not included in this focused PR
- `bash test/install-pi-safety.test.sh`: passed
- `bash test/sentryusb-pick-binary.test.sh`: passed
- Bash syntax and `git diff --check`: passed

The complete workspace run has one unrelated macOS-only failure: `sentryusb-drives::db::tests::is_mount_point_accepts_root` expects Linux `/proc/mounts`.

## Checklist

- [x] I ran `cargo fmt --all` and `cargo clippy`
- [x] I have read and agree to the [Contributor License Agreement](../CLA.md) (the CLA Assistant bot will prompt me to sign)
- [x] If this PR touches MIT-derived scripts listed in [NOTICE](../NOTICE), I noted it above so the license boundary is preserved